### PR TITLE
Add `--assert` option for reporting jira evidence

### DIFF
--- a/cmd/kosli/reportEvidenceCommitJira_test.go
+++ b/cmd/kosli/reportEvidenceCommitJira_test.go
@@ -124,6 +124,18 @@ func (suite *CommitEvidenceJiraCommandTestSuite) TestCommitEvidenceJiraCommandCm
 			},
 		},
 		{
+			name: "report Jira commit evidence with reference as branch name works",
+			cmd: fmt.Sprintf(`report evidence commit jira --name jira-validation 
+					--jira-base-url https://kosli-test.atlassian.net/  --jira-username tore@kosli.com
+					--repo-root %s
+					--build-url example.com %s`, suite.tmpDir, suite.defaultKosliArguments),
+			goldenRegex: "Jira evidence is reported to commit: [0-9a-f]{40}\n.*Issues references reported:.*\n.*EX-1: issue found",
+			additionalConfig: jiraTestsAdditionalConfig{
+				branchName:    "EX-1",
+				commitMessage: "test commit has no reference",
+			},
+		},
+		{
 			name: "report Jira commit evidence with a slash at the end of --jira-base-url works",
 			cmd: fmt.Sprintf(`report evidence commit jira --name jira-validation
 				--jira-base-url https://kosli-test.atlassian.net/  --jira-username tore@kosli.com
@@ -137,7 +149,7 @@ func (suite *CommitEvidenceJiraCommandTestSuite) TestCommitEvidenceJiraCommandCm
 		{
 			wantError: true,
 			name:      "report Jira commit evidence with --jira-pat and --jira-api-token fails",
-			cmd: fmt.Sprintf(`report evidence commit jira --name jira-validation 
+			cmd: fmt.Sprintf(`report evidence commit jira --name jira-validation
 					--jira-base-url https://kosli-test.atlassian.net  --jira-api-token xxx
 					--jira-pat xxxx --repo-root %s --commit 61ab3ea22bd4264996b35bfb82869c482d9f4a06
 					--build-url example.com %s`, suite.tmpDir, suite.defaultKosliArguments),
@@ -163,20 +175,26 @@ func (suite *CommitEvidenceJiraCommandTestSuite) TestCommitEvidenceJiraCommandCm
 		},
 	}
 	for _, test := range tests {
-		if test.additionalConfig != nil {
-			branchName := test.additionalConfig.(jiraTestsAdditionalConfig).branchName
-			if branchName != "" {
-				testHelpers.CheckoutNewBranch(suite.workTree, branchName)
-			}
-			msg := test.additionalConfig.(jiraTestsAdditionalConfig).commitMessage
-			commitSha, err := testHelpers.CommitToRepo(suite.workTree, suite.fs, msg)
-			require.NoError(suite.T(), err)
-
-			test.cmd = test.cmd + " --commit " + commitSha
-		}
-
-		runTestCmd(suite.T(), []cmdTestCase{test})
+		funcName(test, suite)
 	}
+}
+
+func funcName(test cmdTestCase, suite *CommitEvidenceJiraCommandTestSuite) {
+	if test.additionalConfig != nil {
+		branchName := test.additionalConfig.(jiraTestsAdditionalConfig).branchName
+		if branchName != "" {
+			err := testHelpers.CheckoutNewBranch(suite.workTree, branchName)
+			require.NoError(suite.T(), err)
+			defer testHelpers.CheckoutMaster(suite.workTree, suite.T())
+		}
+		msg := test.additionalConfig.(jiraTestsAdditionalConfig).commitMessage
+		commitSha, err := testHelpers.CommitToRepo(suite.workTree, suite.fs, msg)
+		require.NoError(suite.T(), err)
+
+		test.cmd = test.cmd + " --commit " + commitSha
+	}
+
+	runTestCmd(suite.T(), []cmdTestCase{test})
 }
 
 // In order for 'go test' to run this suite, we need to create

--- a/cmd/kosli/reportEvidenceCommitJira_test.go
+++ b/cmd/kosli/reportEvidenceCommitJira_test.go
@@ -49,6 +49,7 @@ func (suite *CommitEvidenceJiraCommandTestSuite) TearDownSuite() {
 
 type jiraTestsAdditionalConfig struct {
 	commitMessage string
+	branchName    string
 }
 
 func (suite *CommitEvidenceJiraCommandTestSuite) TestCommitEvidenceJiraCommandCmd() {
@@ -163,6 +164,10 @@ func (suite *CommitEvidenceJiraCommandTestSuite) TestCommitEvidenceJiraCommandCm
 	}
 	for _, test := range tests {
 		if test.additionalConfig != nil {
+			branchName := test.additionalConfig.(jiraTestsAdditionalConfig).branchName
+			if branchName != "" {
+				testHelpers.CheckoutNewBranch(suite.workTree, branchName)
+			}
 			msg := test.additionalConfig.(jiraTestsAdditionalConfig).commitMessage
 			commitSha, err := testHelpers.CommitToRepo(suite.workTree, suite.fs, msg)
 			require.NoError(suite.T(), err)

--- a/cmd/kosli/reportEvidenceCommitJira_test.go
+++ b/cmd/kosli/reportEvidenceCommitJira_test.go
@@ -173,6 +173,32 @@ func (suite *CommitEvidenceJiraCommandTestSuite) TestCommitEvidenceJiraCommandCm
 					--build-url example.com %s`, suite.tmpDir, suite.defaultKosliArguments),
 			golden: "Error: required flag(s) \"commit\" not set\n",
 		},
+		{
+			wantError: true,
+			name:      "assert for non-existing Jira issue gives an error",
+			cmd: fmt.Sprintf(`report evidence commit jira --name jira-validation 
+					--jira-base-url https://kosli-test.atlassian.net  --jira-username tore@kosli.com
+					--repo-root %s
+					--assert
+					--build-url example.com %s`, suite.tmpDir, suite.defaultKosliArguments),
+			goldenRegex: "Error: missing Jira issues from references found in commit message or branch name.*",
+			additionalConfig: jiraTestsAdditionalConfig{
+				commitMessage: "SAMI-1 test commit",
+			},
+		},
+		{
+			wantError: true,
+			name:      "assert for no Jira issue reference gives an error",
+			cmd: fmt.Sprintf(`report evidence commit jira --name jira-validation 
+					--jira-base-url https://kosli-test.atlassian.net  --jira-username tore@kosli.com
+					--repo-root %s
+					--assert
+					--build-url example.com %s`, suite.tmpDir, suite.defaultKosliArguments),
+			goldenRegex: "Error: no Jira references are found in commit message or branch name",
+			additionalConfig: jiraTestsAdditionalConfig{
+				commitMessage: "test commit without reference",
+			},
+		},
 	}
 	for _, test := range tests {
 		funcName(test, suite)

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -110,6 +110,7 @@ The service principal needs to have the following permissions:
 	commitEvidenceFlag         = "Git commit for which to verify and given evidence. (defaulted in some CIs: https://docs.kosli.com/ci-defaults )."
 	repositoryFlag             = "Git repository. (defaulted in some CIs: https://docs.kosli.com/ci-defaults )."
 	assertPREvidenceFlag       = "[optional] Exit with non-zero code if no pull requests found for the given commit."
+	assertJiraEvidenceFlag     = "[optional] Exit with non-zero code if no jira issue reference found, or jira issue does not exist, for the given commit or branch."
 	assertStatusFlag           = "[optional] Exit with non-zero code if Kosli server is not responding."
 	azureTokenFlag             = "Azure Personal Access token."
 	azureProjectFlag           = "Azure project.(defaulted if you are running in Azure Devops pipelines: https://docs.kosli.com/ci-defaults )."

--- a/internal/gitview/gitView.go
+++ b/internal/gitview/gitView.go
@@ -193,23 +193,23 @@ func asCommitInfo(commit *object.Commit, branchName string) *CommitInfo {
 // MatchPatternInCommitMessageORBranchName returns a slice of strings matching a pattern in a commit message or branch name
 // matches lookup happens in the commit message first, and if none is found, matching against the branch name is done
 // if no matches are found in both the commit message and the branch name, an empty slice is returned
-func (gv *GitView) MatchPatternInCommitMessageORBranchName(pattern, commitSHA string) ([]string, error) {
+func (gv *GitView) MatchPatternInCommitMessageORBranchName(pattern, commitSHA string) ([]string, *CommitInfo, error) {
 	commitInfo, err := gv.GetCommitInfoFromCommitSHA(commitSHA)
 	if err != nil {
-		return []string{}, err
+		return []string{}, nil, err
 	}
 
 	re := regexp.MustCompile(pattern)
 	matches := re.FindAllString(commitInfo.Message, -1)
 	if matches != nil {
-		return matches, nil
+		return matches, commitInfo, nil
 	} else {
 		matches := re.FindAllString(commitInfo.Branch, -1)
 		if matches != nil {
-			return matches, nil
+			return matches, commitInfo, nil
 		}
 	}
-	return []string{}, nil
+	return []string{}, commitInfo, nil
 }
 
 // ResolveRevision returns an explicit commit SHA1 from commit SHA or ref (e.g. HEAD~2)

--- a/internal/gitview/gitView_test.go
+++ b/internal/gitview/gitView_test.go
@@ -327,7 +327,7 @@ func (suite *GitViewTestSuite) TestMatchPatternInCommitMessageORBranchName() {
 			gitView, err := New(suite.tmpDir)
 			require.NoError(suite.T(), err)
 
-			actual, err := gitView.MatchPatternInCommitMessageORBranchName(t.pattern, t.commitSha)
+			actual, _, err := gitView.MatchPatternInCommitMessageORBranchName(t.pattern, t.commitSha)
 			require.True(suite.T(), (err != nil) == t.wantError)
 			require.ElementsMatch(suite.T(), t.want, actual)
 

--- a/internal/testHelpers/testHelpers.go
+++ b/internal/testHelpers/testHelpers.go
@@ -2,6 +2,7 @@ package testHelpers
 
 import (
 	"fmt"
+	"github.com/go-git/go-git/v5/plumbing"
 	"os"
 	"path/filepath"
 	"testing"
@@ -76,4 +77,11 @@ func CommitToRepo(w *git.Worktree, fs billy.Filesystem, commitMessage string) (s
 	}
 
 	return hash.String(), nil
+}
+
+func CheckoutNewBranch(w *git.Worktree, branchName string) error {
+	return w.Checkout(&git.CheckoutOptions{
+		Create: true,
+		Branch: plumbing.ReferenceName(branchName),
+	})
 }

--- a/internal/testHelpers/testHelpers.go
+++ b/internal/testHelpers/testHelpers.go
@@ -3,6 +3,7 @@ package testHelpers
 import (
 	"fmt"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"testing"
@@ -50,6 +51,11 @@ func InitializeGitRepo(repoPath string) (*git.Repository, *git.Worktree, billy.F
 		return repo, nil, fs, err
 	}
 
+	_, err = CommitToRepo(w, fs, "Initial Commit")
+	if err != nil {
+		return repo, w, fs, err
+	}
+
 	return repo, w, fs, nil
 }
 
@@ -82,6 +88,13 @@ func CommitToRepo(w *git.Worktree, fs billy.Filesystem, commitMessage string) (s
 func CheckoutNewBranch(w *git.Worktree, branchName string) error {
 	return w.Checkout(&git.CheckoutOptions{
 		Create: true,
-		Branch: plumbing.ReferenceName(branchName),
+		Branch: plumbing.NewBranchReferenceName(branchName),
 	})
+}
+
+func CheckoutMaster(workTree *git.Worktree, t *testing.T) {
+	err := workTree.Checkout(&git.CheckoutOptions{
+		Branch: plumbing.Master,
+	})
+	require.NoError(t, err)
 }


### PR DESCRIPTION
- Add a failing test for pulling jira reference from branch
- Add a test for checking branch name with Jira
- Added `--assert` option to `report evidence commit jira`

related to kosli-dev/server#1018
