### PR TITLE
1021 auto merge ci

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -18,11 +18,23 @@ jobs:
       - name: check requester
         run: |
           # fail job if the requester is not a member of the organization
-          curl -s -H "Authorization: token ${{ secrets.READ_KOSLI_GH_ORG_MEMBERS }}" \
-            https://api.github.com/orgs/kosli-dev/members \
-            | jq -r ".[].login" \
-            | grep -w "${{ github.event.pull_request.user.login }}"
+
+          # curl -s -H "Authorization: token ${{ secrets.READ_KOSLI_GH_ORG_MEMBERS }}" \
+          #   https://api.github.com/orgs/kosli-dev/members \
+          #   | jq -r ".[].login" \
+          #   | grep -w "${{ github.event.pull_request.user.login }}"
+          # result=$?
+
+          members=$(curl -s -H "Authorization: token ${{ secrets.READ_KOSLI_GH_ORG_MEMBERS }}" \
+            https://api.github.com/orgs/kosli-dev/members)
+          echo $?
+          echo $members
+          logins=$(echo $members | jq -r ".[].login")
+          echo $?
+          echo $logins
+          echo $logins | grep -w "${{ github.event.pull_request.user.login }}"
           result=$?
+          echo $result
 
           if [[ $result -eq 0 ]]; then
             echo "User ${{ github.event.pull_request.user.login }} is a member of kosli-dev"

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -18,7 +18,7 @@ jobs:
       - name: check requester
         run: |
           # fail job if the requester is not a member of the organization
-          curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          curl -s -H "Authorization: token ${{ secrets.READ_KOSLI_GH_ORG_MEMBERS }}" \
             https://api.github.com/orgs/kosli-dev/members \
             | jq -r ".[].login" \
             | grep -w "${{ github.event.pull_request.user.login }}"


### PR DESCRIPTION
- CI: use fine-grained API token instead of default GH token in auto-approve ci
- Add more logging to auto-approve ci for debugging