### PR TITLE
copy with full path instead of just base name of file or dir

### DIFF
--- a/cmd/kosli/cli_utils.go
+++ b/cmd/kosli/cli_utils.go
@@ -604,7 +604,10 @@ func getPathOfEvidenceFileToUpload(evidencePaths []string) (string, bool, error)
 		logger.Debug("[%d] paths are provided as evidence. They will be tarred from %s", len(evidencePaths), tmpDir)
 
 		for _, path := range evidencePaths {
-			err := cp.Copy(path, filepath.Join(tmpDir, filepath.Base(path)))
+			err := cp.Copy(path, filepath.Join(tmpDir, path), cp.Options{
+				PreserveTimes: true,
+				PreserveOwner: true,
+			})
 			if err != nil {
 				return "", cleanupNeeded, err
 			}


### PR DESCRIPTION
fixes kosli-dev/server#1168 