### PR TITLE
fix pushing helm docs back to main

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Check non critical
         id: non-critical
         run: |
-          ACCEPTED_PATHS="^bin/|^design-docs/"
+          ACCEPTED_PATHS="^bin/|^design-docs/|^charts/k8s-reporter/README.md|^docs.kosli.com/content/helm/_index.md"
           CRITICAL=false
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             echo "$file"

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -64,10 +65,14 @@ jobs:
         run: |
           rm -rf package 
 
-      - uses: EndBug/add-and-commit@v7
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
         with:
-          add: '["docs.kosli.com/.", "charts/."]'
-          branch: main
-          default_author: github_actor
-          message: 'Update helm docs'
-          pull: 'NO-PULL'
+          commit-message: 'Update helm docs'
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          signoff: false
+          delete-branch: true
+          title: 'Update helm docs'
+          body: |
+            Update helms docs


### PR DESCRIPTION
when helm chart is updated, CI attempts to push the updated docs back to main to release them later in the release workflow.

Currently, this [fails due to branch protection](https://github.com/kosli-dev/cli/actions/runs/7530331081/job/20496459283). This PR switches to creating a PR and auto-merge it instead of a direct push.