### PR TITLE
add a netlify redirect for old what is kosli page

### DIFF
--- a/cmd/kosli/snapshotECS_test.go
+++ b/cmd/kosli/snapshotECS_test.go
@@ -59,7 +59,7 @@ func (suite *SnapshotECSTestSuite) TestSnapshotECSCmd() {
 			additionalConfig: snapshotECSTestConfig{
 				requireAuthToBeSet: true,
 			},
-			golden: "[3] containers were reported to environment snapshot-ecs-env\n",
+			goldenRegex: "\\[\\d+\\] containers were reported to environment snapshot-ecs-env\n",
 		},
 		{
 			name: "snapshot ECS works with --service-name",
@@ -67,7 +67,7 @@ func (suite *SnapshotECSTestSuite) TestSnapshotECSCmd() {
 			additionalConfig: snapshotECSTestConfig{
 				requireAuthToBeSet: true,
 			},
-			golden: "[2] containers were reported to environment snapshot-ecs-env\n",
+			golden: "\\[\\d+\\] containers were reported to environment snapshot-ecs-env\n",
 		},
 	}
 

--- a/docs.kosli.com/static/_redirects
+++ b/docs.kosli.com/static/_redirects
@@ -1,3 +1,4 @@
 /getting_started/part_9_querying/               /tutorials/querying_kosli/
 /getting_started/part_5_artifacts/              /getting_started/artifacts/
 /getting_started/part_1_overview/               /getting_started/overview/
+/kosli_overview/what_is_kosli/                  /understand_kosli/what_is_kosli/


### PR DESCRIPTION
fixing a link from kosli.com