### PR TITLE
Report commit url for artifacts and attestations

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,9 @@ on:
       platforms:
         required: true
         type: string
+      assert:
+        type: boolean
+        default: false
     secrets:
       slack_channel:
         required: true
@@ -124,7 +127,7 @@ jobs:
         # or you can signup for free at https://snyk.io/login
         SNYK_TOKEN: ${{ secrets.snyk_token }}
       run: 
-          snyk test --json-file-output=snyk-code.json --prune-repeated-subdependencies
+          snyk test --policy-path=.snyk  --json-file-output=snyk-code.json --prune-repeated-subdependencies
 
 
     - name: Report Snyk CODE scan results evidence to Kosli
@@ -149,7 +152,8 @@ jobs:
         SNYK_TOKEN: ${{ secrets.snyk_token }}
       run: 
           snyk container test ${{ env.IMAGE }}:${{ inputs.tag }} 
-             --file=Dockerfile 
+             --file=Dockerfile
+             --policy-path=.snyk
              --json-file-output=snyk-docker.json
 
 
@@ -206,3 +210,13 @@ jobs:
       run:
         kosli report evidence artifact pullrequest github
           --github-token ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Assert artifact in Kosli
+      if: ${{ inputs.assert }}
+      env:
+        KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
+        KOSLI_ORG: kosli
+      run: 
+        kosli assert artifact flow cli
+          --fingerprint ${{ env.FINGERPRINT }}
+          --flow cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
     with:
       tag: ${{ needs.pre-build.outputs.tag }}
       platforms: linux/amd64
+      assert: true
     secrets:
       slack_webhook: ${{ secrets.MERKELY_SLACK_CI_FAILURES_WEBHOOK }}
       slack_channel: ${{ secrets.MERKELY_SLACK_CI_FAILURES_CHANNEL }} 

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,10 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-GOLANG-GOLANGORGXNETHTTP2-6173321:
+    - '*':
+        reason: A fix was pushed into the master branch but not yet published.
+        expires: 2024-03-31T11:00:12.080Z
+        created: 2024-01-31T11:00:12.086Z
+patch: {}

--- a/cmd/kosli/attestArtifact.go
+++ b/cmd/kosli/attestArtifact.go
@@ -161,14 +161,14 @@ func (o *attestArtifactOptions) run(args []string) error {
 		return err
 	}
 
-	commitInfo, err := gitView.GetCommitInfoFromCommitSHA(o.gitReference)
+	commitInfo, err := gitView.GetCommitInfoFromCommitSHA(o.gitReference, false)
 	if err != nil {
 		return err
 	}
 	o.payload.GitCommit = commitInfo.Sha1
 	o.payload.GitCommitInfo = &commitInfo.BasicCommitInfo
 
-	o.payload.RepoUrl, err = gitView.RepoUrl()
+	o.payload.RepoUrl, err = gitView.RepoURL()
 	if err != nil {
 		logger.Warning("Repo URL will not be reported, %s", err.Error())
 	}

--- a/cmd/kosli/attestation.go
+++ b/cmd/kosli/attestation.go
@@ -63,7 +63,7 @@ func (o *CommonAttestationOptions) run(args []string, payload *CommonAttestation
 		if err != nil {
 			return err
 		}
-		commitInfo, err := gv.GetCommitInfoFromCommitSHA(o.commitSHA)
+		commitInfo, err := gv.GetCommitInfoFromCommitSHA(o.commitSHA, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/kosli/beginTrail.go
+++ b/cmd/kosli/beginTrail.go
@@ -103,7 +103,7 @@ func (o *beginTrailOptions) run(args []string) error {
 		if err != nil {
 			return err
 		}
-		commitInfo, err := gv.GetCommitInfoFromCommitSHA(o.commitSHA)
+		commitInfo, err := gv.GetCommitInfoFromCommitSHA(o.commitSHA, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/kosli/cli_utils.go
+++ b/cmd/kosli/cli_utils.go
@@ -134,7 +134,7 @@ func DefaultValue(ci, flag string) string {
 			result := os.ExpandEnv(v)
 			// github and gitlab use ../commit/.. , bitbucket uses ../commits/..
 			if ci == circleci && flag == "commit-url" {
-				result = gitview.ExtractRepoURLFromRemote(result)
+				result, _ = gitview.ExtractRepoURLFromRemote(result)
 				if strings.Contains(result, "bitbucket.org") {
 					return strings.Replace(result, "commit", "commits", 1)
 				}

--- a/cmd/kosli/reportArtifact.go
+++ b/cmd/kosli/reportArtifact.go
@@ -129,7 +129,7 @@ func (o *reportArtifactOptions) run(args []string) error {
 		return err
 	}
 
-	commitObject, err := gitView.GetCommitInfoFromCommitSHA(o.gitReference)
+	commitObject, err := gitView.GetCommitInfoFromCommitSHA(o.gitReference, false)
 	if err != nil {
 		return err
 	}
@@ -145,7 +145,7 @@ func (o *reportArtifactOptions) run(args []string) error {
 		return err
 	}
 
-	o.payload.RepoUrl, err = gitView.RepoUrl()
+	o.payload.RepoUrl, err = gitView.RepoURL()
 	if err != nil {
 		logger.Warning("Repo URL will not be reported, %s", err.Error())
 	}


### PR DESCRIPTION
- add snyk policy
- assert cli before releasing it
- attempt to capture commit url in commit_info and send it for artifact reports and attestations.