### PR TITLE
Fixed bug with Windows absolute path in evidence-paths. Do not include colon in the destination tar ball kosli-dev/server#1521

### DIFF
--- a/cmd/kosli/cli_utils.go
+++ b/cmd/kosli/cli_utils.go
@@ -616,6 +616,13 @@ func getPathOfEvidenceFileToUpload(evidencePaths []string) (string, bool, error)
 		logger.Debug("[%d] paths are provided as evidence. They will be tarred from %s", len(evidencePaths), tmpDir)
 
 		for _, path := range evidencePaths {
+			volume := filepath.VolumeName(path)
+			pathWithoutVolume := path[len(volume):]
+
+			logger.Debug("\npath  =%s\npathWV=%s\njoin_new=%s\njoin_old=%s",
+				path, pathWithoutVolume,
+				filepath.Join(tmpDir, path),
+				filepath.Join(tmpDir, filepath.Base(path)))
 			err := cp.Copy(path, filepath.Join(tmpDir, path), cp.Options{
 				PreserveTimes: true,
 				PreserveOwner: true,

--- a/cmd/kosli/cli_utils.go
+++ b/cmd/kosli/cli_utils.go
@@ -617,13 +617,14 @@ func getPathOfEvidenceFileToUpload(evidencePaths []string) (string, bool, error)
 
 		for _, path := range evidencePaths {
 			volume := filepath.VolumeName(path)
+			volumeWithoutColon := strings.Replace(volume, ":", "", 1)
 			pathWithoutVolume := path[len(volume):]
+			pathWithoutColon := volumeWithoutColon + pathWithoutVolume
 
-			logger.Debug("\npath  =%s\npathWV=%s\njoin_new=%s\njoin_old=%s",
-				path, pathWithoutVolume,
-				filepath.Join(tmpDir, path),
-				filepath.Join(tmpDir, filepath.Base(path)))
-			err := cp.Copy(path, filepath.Join(tmpDir, path), cp.Options{
+			logger.Debug("\npath  =%s\npathWC=%s",
+				path, pathWithoutColon)
+
+			err := cp.Copy(path, filepath.Join(tmpDir, pathWithoutColon), cp.Options{
 				PreserveTimes: true,
 				PreserveOwner: true,
 			})

--- a/cmd/kosli/cli_utils.go
+++ b/cmd/kosli/cli_utils.go
@@ -621,9 +621,6 @@ func getPathOfEvidenceFileToUpload(evidencePaths []string) (string, bool, error)
 			pathWithoutVolume := path[len(volume):]
 			pathWithoutColon := volumeWithoutColon + pathWithoutVolume
 
-			logger.Debug("\npath  =%s\npathWC=%s",
-				path, pathWithoutColon)
-
 			err := cp.Copy(path, filepath.Join(tmpDir, pathWithoutColon), cp.Options{
 				PreserveTimes: true,
 				PreserveOwner: true,


### PR DESCRIPTION
- Added debug info to test out on windows
- Changed to path without colon
- Removed some debug info
