### PR TITLE
Updated docker image for release to be multi arch with amd64 and arm64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,7 @@ on:
 
 env:
   IMAGE: ghcr.io/kosli-dev/cli
-  KOSLI_CLI_VERSION: "2.7.8"
+  KOSLI_CLI_VERSION: "2.8.5"
   # KOSLI_DRY_RUN: "True"
   # Ordinarily we declare KOSLI_ORG and KOSLI_FLOW here but
   # this interferes with the CLI integration tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
     uses: kosli-dev/cli/.github/workflows/docker.yml@main
     with:
       tag: ${{ needs.pre-build.outputs.tag }}
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm64
     secrets:
       slack_webhook: ${{ secrets.MERKELY_SLACK_CI_FAILURES_WEBHOOK }}
       slack_channel: ${{ secrets.MERKELY_SLACK_CI_FAILURES_CHANNEL }} 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
     uses: kosli-dev/cli/.github/workflows/docker.yml@main
     with:
       tag: ${{ needs.pre-build.outputs.tag }}
-      platforms: linux/amd64,linux/arm64
+      platforms: linux/amd64
     secrets:
       slack_webhook: ${{ secrets.MERKELY_SLACK_CI_FAILURES_WEBHOOK }}
       slack_channel: ${{ secrets.MERKELY_SLACK_CI_FAILURES_CHANNEL }} 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
     uses: kosli-dev/cli/.github/workflows/docker.yml@main
     with:
       tag: ${{ needs.pre-build.outputs.tag }}
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm64
       assert: true
     secrets:
       slack_webhook: ${{ secrets.MERKELY_SLACK_CI_FAILURES_WEBHOOK }}

--- a/charts/k8s-reporter/Chart.yaml
+++ b/charts/k8s-reporter/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.0
+version: 1.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.7.2"
+appVersion: "2.8.5"

--- a/docs.kosli.com/content/helm/_index.md
+++ b/docs.kosli.com/content/helm/_index.md
@@ -23,7 +23,7 @@ You can install the Kosli reporter Helm chart from source code:
 
 ```shell
 git clone https://github.com/kosli-dev/cli.git
-cd reporter/charts/k8s-reporter
+cd cli/charts/k8s-reporter
 helm install [RELEASE-NAME] . -f [VALUES-FILE-PATH]
 ```
 


### PR DESCRIPTION
- Helm: Updated platforms to include both amd64 and arm64
- Build for helm chart arm64 only on release
- Updated typo in docs
- Helm: Updated kosli version to 2.8.5
