### PR TITLE
Update helm chart to v2.8.6

### DIFF
--- a/charts/k8s-reporter/Chart.yaml
+++ b/charts/k8s-reporter/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.1
+version: 1.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.8.5"
+appVersion: "2.8.6"

--- a/charts/k8s-reporter/values.yaml
+++ b/charts/k8s-reporter/values.yaml
@@ -8,7 +8,7 @@ image:
   # -- the kosli reporter image pull policy
   pullPolicy: IfNotPresent
   # -- the kosli reporter image tag, overrides the image tag whose default is the chart appVersion.
-  tag: "v2.7.2"
+  tag: "v2.8.6"
 
 # -- overrides the name used for the created k8s resources. If `fullnameOverride` is provided, it has higher precedence than this one
 nameOverride: ""


### PR DESCRIPTION
This will use the multi-architecture build to enable kosli reporter on AWS Graviton 🤞 