### PR TITLE
Fix helm chart cronjob command

### DIFF
--- a/charts/k8s-reporter/templates/cronjob.yaml
+++ b/charts/k8s-reporter/templates/cronjob.yaml
@@ -30,9 +30,8 @@ spec:
                 value: {{ $value }}
               {{ end }}    
             command:
-            - /bin/sh
-            - -c
-            - kosli snapshot k8s {{ required ".Values.reporterConfig.kosliEnvironmentName is required" .Values.reporterConfig.kosliEnvironmentName }} {{ if .Values.reporterConfig.namespaces }} --namespaces {{ .Values.reporterConfig.namespaces | quote }} {{ end }} --org {{ required ".Values.reporterConfig.kosliOrg is required" .Values.reporterConfig.kosliOrg }} {{ if .Values.reporterConfig.dryRun }}--dry-run{{ end }}
+            - /bin/kosli
+            - snapshot k8s {{ required ".Values.reporterConfig.kosliEnvironmentName is required" .Values.reporterConfig.kosliEnvironmentName }} {{ if .Values.reporterConfig.namespaces }} --namespaces {{ .Values.reporterConfig.namespaces | quote }} {{ end }} --org {{ required ".Values.reporterConfig.kosliOrg is required" .Values.reporterConfig.kosliOrg }} {{ if .Values.reporterConfig.dryRun }}--dry-run{{ end }}
             resources:
 {{ toYaml .Values.resources | indent 14 }}
           restartPolicy: Never


### PR DESCRIPTION
The base image for the kosli cli image is now a scratch image and does not have `/bin/sh`.

This changes the cronjob in the helm chart to use the correct syntax for our image and use `/bin/kosli` directly.