### PR TITLE
add hidden tag command

### DIFF
--- a/cmd/kosli/attestArtifact.go
+++ b/cmd/kosli/attestArtifact.go
@@ -46,7 +46,7 @@ kosli attest artifact FILE.tgz \
 	--artifact-type file \
 	--build-url https://exampleci.com \
 	--commit-url https://github.com/YourOrg/YourProject/commit/yourCommitShaThatThisArtifactWasBuiltFrom \
-	--git-commit yourCommitShaThatThisArtifactWasBuiltFrom \
+	--commit yourCommitShaThatThisArtifactWasBuiltFrom \
 	--flow yourFlowName \
 	--trail yourTrailName \
 	--name yourTemplateArtifactName \
@@ -58,7 +58,7 @@ kosli attest artifact FILE.tgz \
 kosli attest artifact ANOTHER_FILE.txt \
 	--build-url https://exampleci.com \
 	--commit-url https://github.com/YourOrg/YourProject/commit/yourCommitShaThatThisArtifactWasBuiltFrom \
-	--git-commit yourCommitShaThatThisArtifactWasBuiltFrom \
+	--commit yourCommitShaThatThisArtifactWasBuiltFrom \
 	--flow yourFlowName \
 	--trail yourTrailName \
 	--fingerprint yourArtifactFingerprint \
@@ -70,7 +70,7 @@ kosli attest artifact ANOTHER_FILE.txt \
 kosli attest artifact ANOTHER_FILE.txt \
 	--build-url https://exampleci.com \
 	--commit-url https://github.com/YourOrg/YourProject/commit/yourCommitShaThatThisArtifactWasBuiltFrom \
-	--git-commit yourCommitShaThatThisArtifactWasBuiltFrom \
+	--commit yourCommitShaThatThisArtifactWasBuiltFrom \
 	--flow yourFlowName \
 	--trail yourTrailName \
 	--fingerprint yourArtifactFingerprint \

--- a/cmd/kosli/getEnvironment.go
+++ b/cmd/kosli/getEnvironment.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/kosli-dev/cli/internal/output"
 	"github.com/kosli-dev/cli/internal/requests"
@@ -81,6 +82,13 @@ func printEnvironmentAsTable(raw string, out io.Writer, page int) error {
 		state = "INCOMPLIANT"
 	}
 
+	tags := env["tags"].(map[string]interface{})
+	tagsOutput := ""
+	for key, value := range tags {
+		tagsOutput += fmt.Sprintf("[%s=%s], ", key, value)
+	}
+	tagsOutput = strings.TrimSuffix(tagsOutput, ", ")
+
 	header := []string{}
 	rows := []string{}
 	rows = append(rows, fmt.Sprintf("Name:\t%s", env["name"]))
@@ -88,6 +96,7 @@ func printEnvironmentAsTable(raw string, out io.Writer, page int) error {
 	rows = append(rows, fmt.Sprintf("Description:\t%s", env["description"]))
 	rows = append(rows, fmt.Sprintf("State:\t%s", state))
 	rows = append(rows, fmt.Sprintf("Last Reported At:\t%s", lastReportedAt))
+	rows = append(rows, fmt.Sprintf("Tags:\t%s", tagsOutput))
 
 	tabFormattedPrint(out, header, rows)
 

--- a/cmd/kosli/getFlow.go
+++ b/cmd/kosli/getFlow.go
@@ -79,11 +79,19 @@ func printFlowAsTable(raw string, out io.Writer, page int) error {
 	template := fmt.Sprintf("%s", flow["template"])
 	template = strings.Replace(template, " ", ", ", -1)
 
+	tags := flow["tags"].(map[string]interface{})
+	tagsOutput := ""
+	for key, value := range tags {
+		tagsOutput += fmt.Sprintf("[%s=%s], ", key, value)
+	}
+	tagsOutput = strings.TrimSuffix(tagsOutput, ", ")
+
 	rows = append(rows, fmt.Sprintf("Name:\t%s", flow["name"]))
 	rows = append(rows, fmt.Sprintf("Description:\t%s", flow["description"]))
 	rows = append(rows, fmt.Sprintf("Visibility:\t%s", flow["visibility"]))
 	rows = append(rows, fmt.Sprintf("Template:\t%s", template))
 	rows = append(rows, fmt.Sprintf("Last Deployment At:\t%s", lastDeployedAt))
+	rows = append(rows, fmt.Sprintf("Tags:\t%s", tagsOutput))
 
 	tabFormattedPrint(out, header, rows)
 	return nil

--- a/cmd/kosli/getSnapshot.go
+++ b/cmd/kosli/getSnapshot.go
@@ -179,7 +179,7 @@ func printSnapshotAsTable(raw string, out io.Writer, page int) error {
 		return nil
 	}
 
-	header := []string{"COMMIT", "ARTIFACT", "FLOW", "RUNNING_SINCE", "REPLICAS"}
+	header := []string{"COMMIT", "ARTIFACT", "FLOW", "COMPLIANCE", "RUNNING_SINCE", "REPLICAS"}
 	rows := []string{}
 	for _, artifact := range snapshot.Artifacts {
 		if artifact.Annotation.Now == 0 {
@@ -199,7 +199,12 @@ func printSnapshotAsTable(raw string, out io.Writer, page int) error {
 			flowName = artifact.FlowName
 		}
 
-		row := fmt.Sprintf("%s\tName: %s\t%s\t%s\t%d", gitCommit, artifact.Name, flowName, since, len(artifact.CreationTimestamp))
+		compliance := "COMPLIANT"
+		if !artifact.Compliant {
+			compliance = "NON-COMPLIANT"
+		}
+
+		row := fmt.Sprintf("%s\tName: %s\t%s\t%s\t%s\t%d", gitCommit, artifact.Name, flowName, compliance, since, len(artifact.CreationTimestamp))
 		rows = append(rows, row)
 		row = fmt.Sprintf("\tFingerprint: %s\t\t\t", artifact.Fingerprint)
 		rows = append(rows, row)

--- a/cmd/kosli/listEnvironments.go
+++ b/cmd/kosli/listEnvironments.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/kosli-dev/cli/internal/output"
@@ -75,7 +76,7 @@ func printEnvListAsTable(raw string, out io.Writer, page int) error {
 		return nil
 	}
 
-	header := []string{"NAME", "TYPE", "LAST REPORT", "LAST MODIFIED"}
+	header := []string{"NAME", "TYPE", "LAST REPORT", "LAST MODIFIED", "TAGS"}
 	rows := []string{}
 	for _, env := range envs {
 		last_reported_str := ""
@@ -88,7 +89,15 @@ func printEnvListAsTable(raw string, out io.Writer, page int) error {
 		if last_modified_at != nil {
 			last_modified_str = time.Unix(int64(last_modified_at.(float64)), 0).Format(time.RFC3339)
 		}
-		row := fmt.Sprintf("%s\t%s\t%s\t%s", env["name"], env["type"], last_reported_str, last_modified_str)
+
+		tags := env["tags"].(map[string]interface{})
+		tagsOutput := ""
+		for key, value := range tags {
+			tagsOutput += fmt.Sprintf("[%s=%s], ", key, value)
+		}
+		tagsOutput = strings.TrimSuffix(tagsOutput, ", ")
+
+		row := fmt.Sprintf("%s\t%s\t%s\t%s\t%s", env["name"], env["type"], last_reported_str, last_modified_str, tagsOutput)
 		rows = append(rows, row)
 	}
 	tabFormattedPrint(out, header, rows)

--- a/cmd/kosli/listFlows.go
+++ b/cmd/kosli/listFlows.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/kosli-dev/cli/internal/output"
 	"github.com/kosli-dev/cli/internal/requests"
@@ -73,10 +74,16 @@ func printFlowsListAsTable(raw string, out io.Writer, page int) error {
 		return nil
 	}
 
-	header := []string{"NAME", "DESCRIPTION", "VISIBILITY"}
+	header := []string{"NAME", "DESCRIPTION", "VISIBILITY", "TAGS"}
 	rows := []string{}
 	for _, flow := range flows {
-		row := fmt.Sprintf("%s\t%s\t%s", flow["name"], flow["description"], flow["visibility"])
+		tags := flow["tags"].(map[string]interface{})
+		tagsOutput := ""
+		for key, value := range tags {
+			tagsOutput += fmt.Sprintf("[%s=%s], ", key, value)
+		}
+		tagsOutput = strings.TrimSuffix(tagsOutput, ", ")
+		row := fmt.Sprintf("%s\t%s\t%s\t%s", flow["name"], flow["description"], flow["visibility"], tagsOutput)
 		rows = append(rows, row)
 	}
 	tabFormattedPrint(out, header, rows)

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -184,6 +184,8 @@ The service principal needs to have the following permissions:
 	attestationDescription      = "[optional] attestation description"
 	excludeScalingFlag          = "[optional] Exclude scaling events for snapshots. Snapshots with scaling changes will not result in new environment records."
 	includeScalingFlag          = "[optional] Include scaling events for snapshots. Snapshots with scaling changes will result in new environment records."
+	setTagsFlag                 = "[optional] The key-value pairs to tag the resource with. The format is: key=value"
+	unsetTagsFlag               = "[optional] The list of tag keys to remove from the resource."
 )
 
 var global *GlobalOpts
@@ -274,6 +276,7 @@ func newRootCmd(out io.Writer, args []string) (*cobra.Command, error) {
 		newLogCmd(out),
 		newDisableCmd(out),
 		newEnableCmd(out),
+		newTagCmd(out),
 	)
 
 	cobra.AddTemplateFunc("isBeta", isBeta)

--- a/cmd/kosli/status_test.go
+++ b/cmd/kosli/status_test.go
@@ -19,7 +19,8 @@ func (suite *StatusTestSuite) TestStatusCmd() {
 			name:   "default",
 			cmd:    "status",
 			golden: "OK\n",
-		}, {
+		},
+		{
 			name:      "assert fail",
 			cmd:       "status --assert --host 123",
 			wantError: true,

--- a/cmd/kosli/tag.go
+++ b/cmd/kosli/tag.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/kosli-dev/cli/internal/requests"
+	"github.com/spf13/cobra"
+)
+
+type tagOptions struct {
+	resourceType string
+	resourceID   string
+	payload      TagResourcePayload
+}
+
+type TagResourcePayload struct {
+	SetTags    map[string]string `json:"set_tags"`
+	RemoveTags []string          `json:"remove_tags"`
+}
+
+const tagShortDesc = `Tag a resource in Kosli with key-value pairs.  `
+
+const tagLongDesc = tagShortDesc + `
+use --set to add or update tags, and --unset to remove tags.
+`
+
+const tagExample = `
+# add/update tags to a flow
+kosli tag flow yourFlowName \
+	--set key1=value1 \
+	--set key2=value2 \
+	--api-token yourApiToken \
+	--org yourOrgName
+
+# tag an environment
+kosli tag env yourEnvironmentName \
+	--set key1=value1 \
+	--set key2=value2 \
+	--api-token yourApiToken \
+	--org yourOrgName
+
+# add/update tags to an environment
+kosli tag env yourEnvironmentName \
+	--set key1=value1 \
+	--set key2=value2 \
+	--api-token yourApiToken \
+	--org yourOrgName
+
+# remove tags from an environment
+kosli tag env yourEnvironmentName \
+	--unset key1=value1 \
+	--api-token yourApiToken \
+	--org yourOrgName
+`
+
+func newTagCmd(out io.Writer) *cobra.Command {
+	o := new(tagOptions)
+	cmd := &cobra.Command{
+		Use:     "tag {IMAGE-NAME | FILE-PATH | DIR-PATH}",
+		Short:   tagShortDesc,
+		Long:    tagLongDesc,
+		Example: tagExample,
+		Hidden:  true,
+		Args:    cobra.ExactArgs(2),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			err := RequireGlobalFlags(global, []string{"Org", "ApiToken"})
+			if err != nil {
+				return ErrorBeforePrintingUsage(cmd, err.Error())
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return o.run(args)
+		},
+	}
+
+	cmd.Flags().StringToStringVar(&o.payload.SetTags, "set", map[string]string{}, setTagsFlag)
+	cmd.Flags().StringSliceVar(&o.payload.RemoveTags, "unset", []string{}, unsetTagsFlag)
+
+	addDryRunFlag(cmd)
+
+	return cmd
+}
+
+func (o *tagOptions) run(args []string) error {
+	o.resourceType = args[0]
+	o.resourceID = args[1]
+
+	err := validateResourceType(o.resourceType)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s/api/v2/tags/%s/%s/%s", global.Host, global.Org, o.resourceType, o.resourceID)
+
+	reqParams := &requests.RequestParams{
+		Method:   http.MethodPatch,
+		URL:      url,
+		Payload:  o.payload,
+		DryRun:   global.DryRun,
+		Password: global.ApiToken,
+	}
+	_, err = kosliClient.Do(reqParams)
+	if err == nil && !global.DryRun {
+		var addMsg, removedMsg, msg string
+		if len(o.payload.SetTags) > 0 {
+			keys := make([]string, 0, len(o.payload.SetTags))
+			for key := range o.payload.SetTags {
+				keys = append(keys, key)
+			}
+			keysStr := strings.Join(keys, ", ")
+			addMsg = fmt.Sprintf("Tag(s) [%s] added", keysStr)
+		}
+		if len(o.payload.RemoveTags) > 0 {
+			keysStr := strings.Join(o.payload.RemoveTags, ", ")
+			removedMsg = fmt.Sprintf("Tag(s) [%s] removed", keysStr)
+		}
+		if addMsg != "" {
+			msg = addMsg
+			if removedMsg != "" {
+				msg += fmt.Sprintf(", and %s", removedMsg)
+			}
+
+		} else {
+			msg = removedMsg
+		}
+		if msg != "" {
+			msg += fmt.Sprintf(" for %s '%s'", o.resourceType, o.resourceID)
+		} else {
+			msg = fmt.Sprintf("No tags were applied for %s '%s'", o.resourceType, o.resourceID)
+		}
+		logger.Info(msg)
+	}
+	return err
+}
+
+func validateResourceType(resourceType string) error {
+	options := []string{"flow", "flows", "env", "environment", "environments"}
+	match := false
+	for _, opt := range options {
+		if resourceType == opt {
+			match = true
+			break
+		}
+	}
+
+	if !match {
+		return fmt.Errorf("%s is not a valid resource type. Valid resource types are: %s", resourceType, options)
+	}
+	return nil
+}

--- a/cmd/kosli/tag_test.go
+++ b/cmd/kosli/tag_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// Define the suite, and absorb the built-in basic suite
+// functionality from testify - including a T() method which
+// returns the current testing context
+type TagTestSuite struct {
+	suite.Suite
+	defaultKosliArguments string
+	flowName              string
+	envName               string
+	envType               string
+}
+
+func (suite *TagTestSuite) SetupTest() {
+	suite.flowName = "tag-flow"
+	suite.envName = "tag-env"
+	suite.envType = "K8S"
+	global = &GlobalOpts{
+		ApiToken: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6ImNkNzg4OTg5In0.e8i_lA_QrEhFncb05Xw6E_tkCHU9QfcY4OLTVUCHffY",
+		Org:      "docs-cmd-test-user",
+		Host:     "http://localhost:8001",
+	}
+	suite.defaultKosliArguments = fmt.Sprintf(" --host %s --org %s --api-token %s", global.Host, global.Org, global.ApiToken)
+
+	CreateFlow(suite.flowName, suite.T())
+	CreateEnv(global.Org, suite.envName, suite.envType, suite.T())
+}
+
+func (suite *TagTestSuite) TestTagCmd() {
+	tests := []cmdTestCase{
+		{
+			name:   "can tag an environment with one tag",
+			cmd:    fmt.Sprintf("tag environment %s --set foo=bar %s", suite.envName, suite.defaultKosliArguments),
+			golden: "Tag(s) [foo] added for environment 'tag-env'\n",
+		},
+		{
+			name:   "can tag an environment with multiple tags",
+			cmd:    fmt.Sprintf("tag environment %s --set foo=bar --set key=value %s", suite.envName, suite.defaultKosliArguments),
+			golden: "Tag(s) [foo, key] added for environment 'tag-env'\n",
+		},
+		{
+			name:   "can remove tags from an environment",
+			cmd:    fmt.Sprintf("tag environment %s --unset foo %s", suite.envName, suite.defaultKosliArguments),
+			golden: "Tag(s) [foo] removed for environment 'tag-env'\n",
+		},
+		{
+			name:   "can add and remove tags from an environment at the same time",
+			cmd:    fmt.Sprintf("tag environment %s --set key=value --unset foo %s", suite.envName, suite.defaultKosliArguments),
+			golden: "Tag(s) [key] added, and Tag(s) [foo] removed for environment 'tag-env'\n",
+		},
+		{
+			name:   "removing a non-existing tag is okay",
+			cmd:    fmt.Sprintf("tag environment %s --unset non-existing %s", suite.envName, suite.defaultKosliArguments),
+			golden: "Tag(s) [non-existing] removed for environment 'tag-env'\n",
+		},
+		{
+			name:   "can tag a flow",
+			cmd:    fmt.Sprintf("tag flow %s --set foo=bar %s", suite.flowName, suite.defaultKosliArguments),
+			golden: "Tag(s) [foo] added for flow 'tag-flow'\n",
+		},
+	}
+	runTestCmd(suite.T(), tests)
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestTagTestSuite(t *testing.T) {
+	suite.Run(t, new(TagTestSuite))
+}


### PR DESCRIPTION
related to kosli-dev/server#1587

- add hidden command to tag flows and environments
- include tags in the tabular output of list flows, get flow, list envs, get env commands
-  include compliance in get snapshot tabular output