### PR TITLE
All urls for live command examples

### DIFF
--- a/cmd/kosli/archiveEnvironment.go
+++ b/cmd/kosli/archiveEnvironment.go
@@ -12,7 +12,7 @@ import (
 const archiveEnvironmentShortDesc = `Archive a Kosli environment.`
 
 const archiveEnvironmentLongDesc = archiveEnvironmentShortDesc + `
-The environment will no longer be visible in list of environments, data is still stored in database.
+The environment will no longer be visible in list of environments, data is still stored in the database.
 `
 
 const archiveEnvironmentExample = `

--- a/cmd/kosli/archiveFlow.go
+++ b/cmd/kosli/archiveFlow.go
@@ -12,7 +12,7 @@ import (
 const archiveFlowShortDesc = `Archive a Kosli flow.`
 
 const archiveFlowLongDesc = archiveFlowShortDesc + `
-The flow will no longer be visible in list of flows, data is still stored in database.
+The flow will no longer be visible in list of flows, data is still stored in the database.
 `
 
 const archiveFlowExample = `

--- a/cmd/kosli/attestSnyk.go
+++ b/cmd/kosli/attestSnyk.go
@@ -29,10 +29,10 @@ const attestSnykLongDesc = attestSnykShortDesc + `
 Only SARIF snyk output is accepted. 
 Snyk output can be for "snyk code test", "snyk container test", or "snyk iac test".
 
-The --scan-results .json file is analyzed and a summary of the scan results are reported to Kosli.
+The ^--scan-results^ .json file is analyzed and a summary of the scan results are reported to Kosli.
 
-By default, the --scan-results .json file is also uploaded to Kosli's evidence vault. 
-You can disable that by setting --upload-results=false
+By default, the ^--scan-results^ .json file is also uploaded to Kosli's evidence vault.
+You can disable that by setting ^--upload-results=false^
 
 ` + fingerprintDesc
 

--- a/cmd/kosli/diffSnapshots.go
+++ b/cmd/kosli/diffSnapshots.go
@@ -15,12 +15,23 @@ import (
 const diffSnapshotsDescShort = `Diff environment snapshots.  `
 
 const diffSnapshotsDesc = diffSnapshotsDescShort + `
-Specify SNAPPISH_1 and SNAPPISH_2 by:  
-- environmentName~<N>  N'th behind the latest snapshot  
-- environmentName#<N>  snapshot number N  
-- environmentName@{YYYY-MM-DDTHH:MM:SS} snapshot at specific moment in time in UTC
-- environmentName@{<N>.<hours|days|weeks|months>.ago} snapshot at a relative time
-- environmentName      the latest snapshot`
+Specify SNAPPISH_1 and SNAPPISH_2 by:
+- environmentName
+    - the latest snapshot for environmentName, at the time of the request
+    - e.g., **prod**
+- environmentName#N
+    - the Nth snapshot, counting from 1
+    - e.g., **prod#42**
+- environmentName~N
+    - the Nth snapshot behind the latest, at the time of the request
+    - e.g., **prod~5**
+- environmentName@{YYYY-MM-DDTHH:MM:SS}
+    - the snapshot at specific moment in time in UTC
+    - e.g., **prod@{2023-10-02T12:00:00}**
+- environmentName@{N.<hours|days|weeks|months>.ago}
+    - the snapshot at a time relative to the time of the request
+    - e.g., **prod@{2.hours.ago}**
+`
 
 const diffSnapshotsExample = `
 # compare the third latest snapshot in an environment to the latest

--- a/cmd/kosli/docs.go
+++ b/cmd/kosli/docs.go
@@ -143,11 +143,13 @@ func KosliGenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(st
 		buf.WriteString("#### Live Examples\n\n")
 		if liveYaml {
 			buf.WriteString(fmt.Sprintf("[Github YAML](%v)\n", yamlURL("github", urlSafeName)))
-			buf.WriteString(fmt.Sprintf("[-> Kosli Event](%v)\n\n", eventURL("github", urlSafeName)))
-		}
-		if liveEvent {
+			if liveEvent {
+			    buf.WriteString(fmt.Sprintf("[-> Kosli Event](%v)\n\n", eventURL("github", urlSafeName)))
+			}
 			buf.WriteString(fmt.Sprintf("[GitLab YAML](%v)\n", yamlURL("gitlab", urlSafeName)))
-			buf.WriteString(fmt.Sprintf("[-> Kosli Event](%v)\n\n", eventURL("gitlab", urlSafeName)))
+			if liveEvent {
+			    buf.WriteString(fmt.Sprintf("[-> Kosli Event](%v)\n\n", eventURL("gitlab", urlSafeName)))
+			}
 		}
 	}
 

--- a/cmd/kosli/docs.go
+++ b/cmd/kosli/docs.go
@@ -200,7 +200,7 @@ func printOptions(buf *bytes.Buffer, cmd *cobra.Command, name string) error {
 	return nil
 }
 
-const baseURL = "https://staging.app.kosli.com/api/v2/livedocs/cyber-dojo"
+const baseURL = "https://app.kosli.com/api/v2/livedocs/cyber-dojo"
 
 func liveYamlDocExists(ci string, command string) bool {
 	url := fmt.Sprintf("%v/yaml_exists?ci=%v&command=%v", baseURL, ci, command)

--- a/cmd/kosli/docs.go
+++ b/cmd/kosli/docs.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -135,13 +136,13 @@ func KosliGenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(st
 		buf.WriteString(fmt.Sprintf("```shell\n%s\n```\n\n", cmd.UseLine()))
 	}
 
-	uname := strings.Replace(name, " ", "_", -1)
-	if liveDocsExist(uname) {
+	urlSafeName := url.QueryEscape(name)
+	if liveDocsExist(urlSafeName) {
 		buf.WriteString("#### Live Examples\n\n")
-		buf.WriteString(fmt.Sprintf("[Github YAML](%v)\n", yamlURL("github", uname)))
-		buf.WriteString(fmt.Sprintf("[-> Kosli Event](%v)\n\n", eventURL("github", uname)))
-		buf.WriteString(fmt.Sprintf("[GitLab YAML](%v)\n", yamlURL("gitlab", uname)))
-		buf.WriteString(fmt.Sprintf("[-> Kosli Event](%v)\n\n", eventURL("gitlab", uname)))
+		buf.WriteString(fmt.Sprintf("[Github YAML](%v)\n", yamlURL("github", urlSafeName)))
+		buf.WriteString(fmt.Sprintf("[-> Kosli Event](%v)\n\n", eventURL("github", urlSafeName)))
+		buf.WriteString(fmt.Sprintf("[GitLab YAML](%v)\n", yamlURL("gitlab", urlSafeName)))
+		buf.WriteString(fmt.Sprintf("[-> Kosli Event](%v)\n\n", eventURL("gitlab", urlSafeName)))
 	}
 
 	if err := printOptions(buf, cmd, name); err != nil {

--- a/cmd/kosli/docs.go
+++ b/cmd/kosli/docs.go
@@ -133,6 +133,16 @@ func KosliGenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(st
 		buf.WriteString(fmt.Sprintf("```shell\n%s\n```\n\n", cmd.UseLine()))
 	}
 
+	if entry, ok := liveExamples[name]; ok {
+		buf.WriteString("## Live Examples\n\n")
+		if githubURL, okGH := entry["Github"]; okGH {
+			buf.WriteString(fmt.Sprintf("[Github](%v)\n", githubURL))
+		}
+		if gitlabURL, okGL := entry["Gitlab"]; okGL {
+			buf.WriteString(fmt.Sprintf("[Gitlab](%v)\n", gitlabURL))
+		}
+	}
+
 	if err := printOptions(buf, cmd, name); err != nil {
 		return err
 	}
@@ -168,4 +178,41 @@ func printOptions(buf *bytes.Buffer, cmd *cobra.Command, name string) error {
 		buf.WriteString("\n\n")
 	}
 	return nil
+}
+
+var liveExamples = map[string]map[string]string{
+	"kosli create flow": {
+		"Github": "https://github.com/cyber-dojo/runner/blob/main/.github/workflows/main.yml#L32",
+		"Gitlab": "https://gitlab.com/cyber-dojo/creator/-/blob/main/.gitlab/workflows/main.yml#L44",
+	},
+	"kosli begin trail": {
+		"Github": "https://github.com/cyber-dojo/runner/blob/main/.github/workflows/main.yml#L38",
+		"Gitlab": "https://gitlab.com/cyber-dojo/creator/-/blob/main/.gitlab/workflows/main.yml#L44",
+	},
+	"kosli attest junit": {
+		"Github": "https://github.com/cyber-dojo/runner/blob/main/.github/workflows/main.yml#L167",
+		"Gitlab": "https://gitlab.com/cyber-dojo/creator/-/blob/main/.gitlab/workflows/main.yml#L103",
+	},
+	"kosli attest pullrequest github": {
+		"Github": "https://github.com/cyber-dojo/runner/blob/main/.github/workflows/main.yml#L66",
+	},
+	"kosli attest pullrequest gitlab": {
+		"Gitlab": "ttps://gitlab.com/cyber-dojo/creator/-/blob/main/.gitlab/workflows/main.yml#L56",
+	},
+	"kosli attest snyk": {
+		"Github": "https://github.com/cyber-dojo/runner/blob/main/.github/workflows/main.yml#L227",
+		"Gitlab": "https://gitlab.com/cyber-dojo/creator/-/blob/main/.gitlab/workflows/main.yml#L130",
+	},
+	"kosli attest generic": {
+		"Github": "https://github.com/cyber-dojo/runner/blob/main/.github/workflows/main.yml#L98",
+		"Gitlab": "https://gitlab.com/cyber-dojo/creator/-/blob/main/.gitlab/workflows/main.yml#L66",
+	},
+	"kosli attest artifact": {
+		"Github": "https://github.com/cyber-dojo/runner/blob/main/.github/workflows/main.yml#L135",
+		"Gitlab": "https://gitlab.com/cyber-dojo/creator/-/blob/main/.gitlab/workflows/main.yml#L85",
+	},
+	"kosli assert artifact": {
+		"Github": "https://github.com/cyber-dojo/runner/blob/main/.github/workflows/main.yml#L298",
+		"Gitlab": "https://gitlab.com/cyber-dojo/creator/-/blob/main/.gitlab/workflows/main.yml#L203",
+	},
 }

--- a/cmd/kosli/docs.go
+++ b/cmd/kosli/docs.go
@@ -145,9 +145,9 @@ func KosliGenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(st
 	for _, ci := range []string{"github", "gitlab"} {
 		if liveYamlDocExists(ci, urlSafeName) {
 			liveExamplesBuf.WriteString(fmt.Sprintf("### %v\n\n", ci))
-			liveExamplesBuf.WriteString(fmt.Sprintf("In [this YAML file](%v)", yamlURL("github", urlSafeName)))
+			liveExamplesBuf.WriteString(fmt.Sprintf("In [this YAML file](%v)", yamlURL(ci, urlSafeName)))
 			if liveEventDocExists(ci, urlSafeName) {
-				liveExamplesBuf.WriteString(fmt.Sprintf(", which created [this Kosli Event](%v).", eventURL("github", urlSafeName)))
+				liveExamplesBuf.WriteString(fmt.Sprintf(", which created [this Kosli Event](%v).", eventURL(ci, urlSafeName)))
 			}
 			liveExamplesBuf.WriteString("\n\n")
 		}

--- a/cmd/kosli/docs.go
+++ b/cmd/kosli/docs.go
@@ -142,7 +142,7 @@ func KosliGenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(st
 
 	urlSafeName := url.QueryEscape(name)
 	liveYaml := liveYamlDocExists(urlSafeName)
-	//liveEvent := liveEventDocExists(urlSafeName)
+	liveEvent := liveEventDocExists(urlSafeName)
 
 	if len(cmd.Example) > 0 || liveYaml {
 		buf.WriteString("## Examples\n\n")
@@ -152,22 +152,26 @@ func KosliGenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(st
 
 			buf.WriteString(fmt.Sprintf("#### Github\n\n"))
 			buf.WriteString(fmt.Sprintf("[Pipeline YAML](%v)\n", yamlURL("github", urlSafeName)))
-			// 			if liveEvent {
-			// 				buf.WriteString(fmt.Sprintf("[View Event in Kosli](%v)\n\n", eventURL("github", urlSafeName)))
-			// 			}
+			if liveEvent {
+				buf.WriteString(fmt.Sprintf("[View Event in Kosli](%v)\n\n", eventURL("github", urlSafeName)))
+			}
 
 			buf.WriteString(fmt.Sprintf("#### Gitlab\n\n"))
 			buf.WriteString(fmt.Sprintf("[Pipeline YAML](%v)\n", yamlURL("gitlab", urlSafeName)))
-			// 			if liveEvent {
-			// 				buf.WriteString(fmt.Sprintf("[View Event in Kosli](%v)\n\n", eventURL("gitlab", urlSafeName)))
-			// 			}
+			if liveEvent {
+				buf.WriteString(fmt.Sprintf("[View Event in Kosli](%v)\n\n", eventURL("gitlab", urlSafeName)))
+			}
 		}
 		if len(cmd.Example) > 0 {
 			buf.WriteString("### Examples Use Cases\n\n")
-			if cmd.Example[0] == '\n' {
-				cmd.Example = cmd.Example[1:]
+			all := strings.Split(cmd.Example, "#")
+			for _, one := range all {
+				lines := strings.Split(one, "\n")
+				if len(lines[0]) > 0 {
+					buf.WriteString(fmt.Sprintf("#### %s\n\n", lines[0]))
+					buf.WriteString(fmt.Sprintf("```shell\n%s\n```\n\n", strings.Join(lines[1:], "\n")))
+				}
 			}
-			buf.WriteString(fmt.Sprintf("```shell\n%s\n```\n\n", cmd.Example))
 		}
 	}
 
@@ -200,7 +204,7 @@ func printOptions(buf *bytes.Buffer, cmd *cobra.Command, name string) error {
 	return nil
 }
 
-const baseURL = "http://localhost/api/v2/livedocs/cyber-dojo"
+const baseURL = "https://staging.app.kosli.com/api/v2/livedocs/cyber-dojo"
 
 func liveYamlDocExists(command string) bool {
 	url := fmt.Sprintf("%v/yaml_exists?command=%v&ci=github", baseURL, command)

--- a/cmd/kosli/docs.go
+++ b/cmd/kosli/docs.go
@@ -137,12 +137,18 @@ func KosliGenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(st
 	}
 
 	urlSafeName := url.QueryEscape(name)
-	if liveDocsExist(urlSafeName) {
+	liveYaml := liveYamlDocExists(urlSafeName)
+	liveEvent := liveEventDocExists(urlSafeName)
+	if liveYaml || liveEvent {
 		buf.WriteString("#### Live Examples\n\n")
-		buf.WriteString(fmt.Sprintf("[Github YAML](%v)\n", yamlURL("github", urlSafeName)))
-		buf.WriteString(fmt.Sprintf("[-> Kosli Event](%v)\n\n", eventURL("github", urlSafeName)))
-		buf.WriteString(fmt.Sprintf("[GitLab YAML](%v)\n", yamlURL("gitlab", urlSafeName)))
-		buf.WriteString(fmt.Sprintf("[-> Kosli Event](%v)\n\n", eventURL("gitlab", urlSafeName)))
+		if liveYaml {
+			buf.WriteString(fmt.Sprintf("[Github YAML](%v)\n", yamlURL("github", urlSafeName)))
+			buf.WriteString(fmt.Sprintf("[-> Kosli Event](%v)\n\n", eventURL("github", urlSafeName)))
+		}
+		if liveEvent {
+			buf.WriteString(fmt.Sprintf("[GitLab YAML](%v)\n", yamlURL("gitlab", urlSafeName)))
+			buf.WriteString(fmt.Sprintf("[-> Kosli Event](%v)\n\n", eventURL("gitlab", urlSafeName)))
+		}
 	}
 
 	if err := printOptions(buf, cmd, name); err != nil {
@@ -184,16 +190,17 @@ func printOptions(buf *bytes.Buffer, cmd *cobra.Command, name string) error {
 
 const baseURL = "http://localhost/api/v2/livedocs/cyber-dojo"
 
-func yamlURL(ci string, command string) string {
-	return fmt.Sprintf("%v/yaml?ci=%v&command=%v", baseURL, ci, command)
-}
-
-func eventURL(ci string, command string) string {
-	return fmt.Sprintf("%v/event?ci=%v&command=%v", baseURL, ci, command)
-}
-
-func liveDocsExist(command string) bool {
+func liveYamlDocExists(command string) bool {
 	url := fmt.Sprintf("%v/yaml_exists?command=%v&ci=github", baseURL, command)
+	return liveDocExists(url)
+}
+
+func liveEventDocExists(command string) bool {
+	url := fmt.Sprintf("%v/event_exists?command=%v&ci=github", baseURL, command)
+	return liveDocExists(url)
+}
+
+func liveDocExists(url string) bool {
 	response, err := http.Get(url)
 	if err != nil {
 		return false
@@ -206,4 +213,12 @@ func liveDocsExist(command string) bool {
 		return false
 	}
 	return exists
+}
+
+func yamlURL(ci string, command string) string {
+	return fmt.Sprintf("%v/yaml?ci=%v&command=%v", baseURL, ci, command)
+}
+
+func eventURL(ci string, command string) string {
+	return fmt.Sprintf("%v/event?ci=%v&command=%v", baseURL, ci, command)
 }

--- a/cmd/kosli/docs.go
+++ b/cmd/kosli/docs.go
@@ -136,31 +136,36 @@ func KosliGenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(st
 		buf.WriteString(fmt.Sprintf("```shell\n%s\n```\n\n", cmd.UseLine()))
 	}
 
-	urlSafeName := url.QueryEscape(name)
-	liveYaml := liveYamlDocExists(urlSafeName)
-	liveEvent := liveEventDocExists(urlSafeName)
-	if liveYaml || liveEvent {
-		buf.WriteString("#### Live Examples\n\n")
-		if liveYaml {
-			buf.WriteString(fmt.Sprintf("[Github YAML](%v)\n", yamlURL("github", urlSafeName)))
-			if liveEvent {
-			    buf.WriteString(fmt.Sprintf("[-> Kosli Event](%v)\n\n", eventURL("github", urlSafeName)))
-			}
-			buf.WriteString(fmt.Sprintf("[GitLab YAML](%v)\n", yamlURL("gitlab", urlSafeName)))
-			if liveEvent {
-			    buf.WriteString(fmt.Sprintf("[-> Kosli Event](%v)\n\n", eventURL("gitlab", urlSafeName)))
-			}
-		}
-	}
-
 	if err := printOptions(buf, cmd, name); err != nil {
 		return err
 	}
 
-	if len(cmd.Example) > 0 {
+	urlSafeName := url.QueryEscape(name)
+	liveYaml := liveYamlDocExists(urlSafeName)
+	liveEvent := liveEventDocExists(urlSafeName)
+
+	if len(cmd.Example) > 0 || liveYaml || liveEvent {
 		buf.WriteString("## Examples\n\n")
-		buf.WriteString(fmt.Sprintf("```shell\n%s\n```\n\n", cmd.Example))
+		if liveYaml {
+			buf.WriteString("### Live Examples\n\n")
+			buf.WriteString(fmt.Sprintf("[Github YAML](%v)\n", yamlURL("github", urlSafeName)))
+			if liveEvent {
+				buf.WriteString(fmt.Sprintf("[-> Kosli Event](%v)\n\n", eventURL("github", urlSafeName)))
+			}
+			buf.WriteString(fmt.Sprintf("[GitLab YAML](%v)\n", yamlURL("gitlab", urlSafeName)))
+			if liveEvent {
+				buf.WriteString(fmt.Sprintf("[-> Kosli Event](%v)\n\n", eventURL("gitlab", urlSafeName)))
+			}
+		}
+		if len(cmd.Example) > 0 {
+			buf.WriteString("### Examples Use Cases\n\n")
+			if cmd.Example[0] == '\n' {
+				cmd.Example = cmd.Example[1:]
+			}
+			buf.WriteString(fmt.Sprintf("```shell\n%s\n```\n\n", cmd.Example))
+		}
 	}
+
 	_, err := buf.WriteTo(w)
 	return err
 }

--- a/cmd/kosli/docs.go
+++ b/cmd/kosli/docs.go
@@ -142,20 +142,25 @@ func KosliGenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(st
 
 	urlSafeName := url.QueryEscape(name)
 	liveYaml := liveYamlDocExists(urlSafeName)
-	liveEvent := liveEventDocExists(urlSafeName)
+	//liveEvent := liveEventDocExists(urlSafeName)
 
-	if len(cmd.Example) > 0 || liveYaml || liveEvent {
+	if len(cmd.Example) > 0 || liveYaml {
 		buf.WriteString("## Examples\n\n")
 		if liveYaml {
 			buf.WriteString("### Live Examples\n\n")
-			buf.WriteString(fmt.Sprintf("[Github YAML](%v)\n", yamlURL("github", urlSafeName)))
-			if liveEvent {
-				buf.WriteString(fmt.Sprintf("[-> Kosli Event](%v)\n\n", eventURL("github", urlSafeName)))
-			}
-			buf.WriteString(fmt.Sprintf("[GitLab YAML](%v)\n", yamlURL("gitlab", urlSafeName)))
-			if liveEvent {
-				buf.WriteString(fmt.Sprintf("[-> Kosli Event](%v)\n\n", eventURL("gitlab", urlSafeName)))
-			}
+			buf.WriteString(fmt.Sprintf("View examples of the `%s` command in different CI systems.\n\n", name))
+
+			buf.WriteString(fmt.Sprintf("#### Github\n\n"))
+			buf.WriteString(fmt.Sprintf("[Pipeline YAML](%v)\n", yamlURL("github", urlSafeName)))
+			// 			if liveEvent {
+			// 				buf.WriteString(fmt.Sprintf("[View Event in Kosli](%v)\n\n", eventURL("github", urlSafeName)))
+			// 			}
+
+			buf.WriteString(fmt.Sprintf("#### Gitlab\n\n"))
+			buf.WriteString(fmt.Sprintf("[Pipeline YAML](%v)\n", yamlURL("gitlab", urlSafeName)))
+			// 			if liveEvent {
+			// 				buf.WriteString(fmt.Sprintf("[View Event in Kosli](%v)\n\n", eventURL("gitlab", urlSafeName)))
+			// 			}
 		}
 		if len(cmd.Example) > 0 {
 			buf.WriteString("### Examples Use Cases\n\n")

--- a/cmd/kosli/docs_test.go
+++ b/cmd/kosli/docs_test.go
@@ -24,15 +24,15 @@ func (suite *DocsCommandTestSuite) TestDocsCmd() {
 
 	o := &docsOptions{
 		dest:            tempDirName,
-		topCmd:          newReportArtifactCmd(os.Stdout),
+		topCmd:          newAttestSnykCmd(os.Stdout),
 		generateHeaders: true,
 	}
 	err = o.run()
 	require.NoError(suite.T(), err)
 
-	actualFile := filepath.Join(tempDirName, "artifact.md")
+	actualFile := filepath.Join(tempDirName, "snyk.md")
 	require.FileExists(suite.T(), actualFile)
-	err = compareTwoFiles(actualFile, goldenPath("output/docs/artifact.md"))
+	err = compareTwoFiles(actualFile, goldenPath("output/docs/snyk.md"))
 	require.NoError(suite.T(), err)
 }
 

--- a/cmd/kosli/getSnapshot.go
+++ b/cmd/kosli/getSnapshot.go
@@ -70,7 +70,7 @@ type environmentGetOptions struct {
 	output string
 }
 
-const getSnapshotDescShort = `Get a specified environment snapshot.`
+const getSnapshotDescShort = `Get a specified environment snapshot.  `
 
 const getSnapshotDesc = getSnapshotDescShort + `
 ENVIRONMENT-NAME-OR-EXPRESSION can be specified as follows:

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -31,7 +31,7 @@ const (
 	envPrefix = "KOSLI"
 
 	// the following constants are used in the docs/help
-	fingerprintDesc = "The artifact SHA256 fingerprint is calculated (based on --artifact-type flag) or alternatively it can be provided directly (with --fingerprint flag)."
+	fingerprintDesc = "The artifact SHA256 fingerprint is calculated (based on the ^--artifact-type^ flag) or can be provided directly (with the ^--fingerprint^ flag)."
 	awsAuthDesc     = `
 
 To authenticate to AWS, you can either:  

--- a/cmd/kosli/testdata/output/docs/snyk.md
+++ b/cmd/kosli/testdata/output/docs/snyk.md
@@ -1,0 +1,140 @@
+---
+title: "snyk"
+beta: false
+deprecated: false
+---
+
+# snyk
+
+## Synopsis
+
+Report a snyk attestation to an artifact or a trail in a Kosli flow.  
+Only SARIF snyk output is accepted. 
+Snyk output can be for "snyk code test", "snyk container test", or "snyk iac test".
+
+The `--scan-results` .json file is analyzed and a summary of the scan results are reported to Kosli.
+
+By default, the `--scan-results` .json file is also uploaded to Kosli's evidence vault.
+You can disable that by setting `--upload-results=false`
+
+The artifact SHA256 fingerprint is calculated (based on the `--artifact-type` flag) or can be provided directly (with the `--fingerprint` flag).
+
+```shell
+snyk [IMAGE-NAME | FILE-PATH | DIR-PATH] [flags]
+```
+
+## Flags
+| Flag | Description |
+| :--- | :--- |
+|    -t, --artifact-type string  |  [conditional] The type of the artifact to calculate its SHA256 fingerprint. One of: [docker, file, dir]. Only required if you don't specify '--fingerprint'.  |
+|        --attachments strings  |  [optional] The comma-separated list of paths of attachments for the reported attestation. Attachments can be files or directories. All attachments are compressed and uploaded to Kosli's evidence vault.  |
+|    -g, --commit string  |  [optional] The git commit associated to the attestation. (defaulted in some CIs: https://docs.kosli.com/ci-defaults ).  |
+|        --description string  |  [optional] attestation description  |
+|    -D, --dry-run  |  [optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors.  |
+|    -x, --exclude strings  |  [optional] The comma separated list of directories and files to exclude from fingerprinting. Can take glob patterns. Only applicable for --artifact-type dir.  |
+|        --external-fingerprint stringToString  |  [optional] A SHA256 fingerprint of an external attachment represented by --external-url. The format is label=fingerprint (labels cannot contain '.' or '='). This flag can be set multiple times. There must be an external url with a matching label for each external fingerprint.  |
+|        --external-url stringToString  |  [optional] Add labeled reference URL for an external resource. The format is label=url (labels cannot contain '.' or '='). This flag can be set multiple times. If the resource is a file or dir, you can optionally add its fingerprint via --external-fingerprint  |
+|    -F, --fingerprint string  |  [optional] The SHA256 fingerprint of the artifact to attach the attestation to.  |
+|    -f, --flow string  |  The Kosli flow name.  |
+|    -h, --help  |  help for snyk  |
+|    -n, --name string  |  The name of the attestation as declared in the flow or trail yaml template.  |
+|    -o, --origin-url string  |  [optional] The url pointing to where the attestation came from or is related. (defaulted to the CI url in some CIs: https://docs.kosli.com/ci-defaults ).  |
+|        --registry-password string  |  [conditional] The docker registry password or access token. Only required if you want to read docker image SHA256 digest from a remote docker registry.  |
+|        --registry-provider string  |  [conditional] The docker registry provider or url. Only required if you want to read docker image SHA256 digest from a remote docker registry.  |
+|        --registry-username string  |  [conditional] The docker registry username. Only required if you want to read docker image SHA256 digest from a remote docker registry.  |
+|        --repo-root string  |  [defaulted] The directory where the source git repository is available. Only used if --commit is used. (default ".")  |
+|    -R, --scan-results string  |  The path to Snyk scan SARIF results file from 'snyk test' and 'snyk container test'. By default, the Snyk results will be uploaded to Kosli's evidence vault.  |
+|    -T, --trail string  |  The Kosli trail name.  |
+|        --upload-results  |  [defaulted] Whether to upload the provided Snyk results file as an attachment to Kosli or not. (default true)  |
+|    -u, --user-data string  |  [optional] The path to a JSON file containing additional data you would like to attach to the attestation.  |
+
+
+## Examples Use Cases
+
+###  report a snyk attestation about a pre-built docker artifact (kosli calculates the fingerprint):
+
+```shell
+kosli attest snyk yourDockerImageName \
+	--artifact-type docker \
+	--name yourAttestationName \
+	--flow yourFlowName \
+	--trail yourTrailName \
+	--scan-results yourSnykSARIFScanResults \
+	--api-token yourAPIToken \
+	--org yourOrgName
+
+
+```
+
+###  report a snyk attestation about a pre-built docker artifact (you provide the fingerprint):
+
+```shell
+kosli attest snyk \
+	--fingerprint yourDockerImageFingerprint \
+	--name yourAttestationName \
+	--flow yourFlowName \
+	--trail yourTrailName \
+	--scan-results yourSnykSARIFScanResults \
+	--api-token yourAPIToken \
+	--org yourOrgName
+
+
+```
+
+###  report a snyk attestation about a trail:
+
+```shell
+kosli attest snyk \
+	--name yourAttestationName \
+	--flow yourFlowName \
+	--trail yourTrailName \
+	--scan-results yourSnykSARIFScanResults \
+	--api-token yourAPIToken \
+	--org yourOrgName
+
+
+```
+
+###  report a snyk attestation about an artifact which has not been reported yet in a trail:
+
+```shell
+kosli attest snyk \
+	--name yourTemplateArtifactName.yourAttestationName \
+	--flow yourFlowName \
+	--trail yourTrailName \
+	--scan-results yourSnykSARIFScanResults \
+	--api-token yourAPIToken \
+	--org yourOrgName
+
+
+```
+
+###  report a snyk attestation about a trail with an attachment:
+
+```shell
+kosli attest snyk \
+	--name yourAttestationName \
+	--flow yourFlowName \
+	--trail yourTrailName \
+	--scan-results yourSnykSARIFScanResults \
+	--attachments=yourEvidencePathName \
+	--api-token yourAPIToken \
+	--org yourOrgName
+
+
+```
+
+###  report a snyk attestation about a trail without uploading the snyk results file:
+
+```shell
+kosli attest snyk \
+	--name yourAttestationName \
+	--flow yourFlowName \
+	--trail yourTrailName \
+	--scan-results yourSnykSARIFScanResults \
+	--upload-results=false \
+	--api-token yourAPIToken \
+	--org yourOrgName
+
+```
+


### PR DESCRIPTION
This creates live md documentation examples for some commands.
It relies on the server live-docs API running on production to determine which commands have live examples.
An update to the CLI documentation relies on a new CLI version being released (( think)