### PR TITLE
support making requests via an http proxy

### DIFF
--- a/cmd/kosli/config.go
+++ b/cmd/kosli/config.go
@@ -42,7 +42,8 @@ kosli config --org=yourOrg \
 	--api-token=yourAPIToken \
 	--host=https://app.kosli.com \
 	--debug=false \
-	--max-api-retries=3
+	--max-api-retries=3 \
+	--http-proxy=http://192.0.0.1:8080
 
 # configure non-global flags in your default config file
 kosli config --set FLOW=yourFlowName
@@ -112,6 +113,16 @@ func (o *configOptions) run() error {
 	if global.Host != defaultHost {
 		viper.Set("host", global.Host)
 	}
+	if global.MaxAPIRetries != defaultMaxAPIRetries {
+		viper.Set("max-api-retries", global.MaxAPIRetries)
+	}
+	if global.HttpProxy != "" {
+		viper.Set("http-proxy", global.HttpProxy)
+	}
+
+	viper.Set("debug", global.Debug)
+	viper.Set("dry-run", global.DryRun)
+
 	if global.ApiToken != "" {
 		// get encryption key
 		key, err := security.GetSecretFromCredentialsStore(credentialsStoreKeySecretName)
@@ -137,12 +148,6 @@ func (o *configOptions) run() error {
 		}
 		viper.Set("api-token", string(encryptedTokenBytes))
 	}
-	if global.MaxAPIRetries != defaultMaxAPIRetries {
-		viper.Set("max-api-retries", global.MaxAPIRetries)
-	}
-
-	viper.Set("debug", global.Debug)
-	viper.Set("dry-run", global.DryRun)
 
 	for key, value := range o.setKeys {
 		viper.Set(key, value)

--- a/cmd/kosli/main.go
+++ b/cmd/kosli/main.go
@@ -18,7 +18,6 @@ var (
 
 func init() {
 	logger = log.NewStandardLogger()
-	kosliClient = requests.NewStandardKosliClient()
 }
 
 func main() {

--- a/cmd/kosli/main.go
+++ b/cmd/kosli/main.go
@@ -18,6 +18,8 @@ var (
 
 func init() {
 	logger = log.NewStandardLogger()
+	// needed for some tests, actual CLI client is initialized in root.go
+	kosliClient, _ = requests.NewStandardKosliClient("")
 }
 
 func main() {

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -200,10 +200,13 @@ func requestManifestFromRegistry(registryEndPoint, imageName, imageTag, registry
 		Token:             registryToken,
 		AdditionalHeaders: dockerHeaders,
 	}
-	kosliClient := requests.NewKosliClient(1, logger.DebugEnabled, logger)
+	kosliClient, err := requests.NewKosliClient("", 1, logger.DebugEnabled, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get docker digest from registry: %v", err)
+	}
 	res, err := kosliClient.Do(reqParams)
 	if err != nil {
-		return res, fmt.Errorf("failed to get docker digest from registry %v", err)
+		return res, fmt.Errorf("failed to get docker digest from registry: %v", err)
 	}
 	return res, nil
 

--- a/internal/requests/requests.go
+++ b/internal/requests/requests.go
@@ -40,16 +40,16 @@ type Client struct {
 func NewKosliClient(httpProxyURL string, maxAPIRetries int, debug bool, logger *logger.Logger) (*Client, error) {
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = maxAPIRetries
-	retryClient.Logger = nil         // this silences logging each individual attempt
-	client := retryClient.HTTPClient // return a standard *http.Client from the retryable client
+	retryClient.Logger = nil               // this silences logging each individual attempt
+	client := retryClient.StandardClient() // return a standard *http.Client from the retryable client
 	if httpProxyURL != "" {
 		proxyURL, err := url.Parse(httpProxyURL)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse proxy URL when creating a Kosli http client: %s", err)
 		}
-		client.Transport = &http.Transport{
-			Proxy: http.ProxyURL(proxyURL),
-		}
+		// client.Transport is already set by retryClient.StandardClient() and we add
+		// the proxy to it
+		client.Transport.(*retryablehttp.RoundTripper).Client.HTTPClient.Transport.(*http.Transport).Proxy = http.ProxyURL(proxyURL)
 	}
 
 	return &Client{

--- a/internal/requests/requests_test.go
+++ b/internal/requests/requests_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"github.com/kosli-dev/cli/internal/logger"
 	"github.com/kosli-dev/cli/internal/version"
 	"github.com/maxcnunes/httpfake"
@@ -127,7 +128,7 @@ func (suite *RequestsTestSuite) TestNewStandardKosliClient() {
 	client2, err := NewStandardKosliClient("http://192.0.0.1:8001")
 	require.NoError(suite.T(), err)
 	require.NotNil(suite.T(), client2.HttpClient.Transport)
-	require.NotNil(suite.T(), client2.HttpClient.Transport.(*http.Transport).Proxy)
+	require.NotNil(suite.T(), client2.HttpClient.Transport.(*retryablehttp.RoundTripper).Client.HTTPClient.Transport.(*http.Transport).Proxy)
 }
 
 func (suite *RequestsTestSuite) TestNewHttpRequest() {


### PR DESCRIPTION
fixes kosli-dev/server#1749 

- Kosli client can be created with an http proxy
- http proxy can be set via global flag, env var or in the kosli config file