### PR TITLE
ensure git commits made in helm docs updating PRs are signed

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -65,11 +65,19 @@ jobs:
         run: |
           rm -rf package 
 
+      - uses: crazy-max/ghaction-import-gpg@v5
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+  
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ secrets.COMMITTER_TOKEN }}
+          committer: Sami Alajrami <sami@kosli.com>
           commit-message: 'Update helm docs'
-          committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           signoff: false
           delete-branch: true


### PR DESCRIPTION
GPG signature is pulled in CI and used to sign commits made for the PR that CI creates to update the helm docs on the live docs.