### PR TITLE
1705 allow no provenance envs

### DIFF
--- a/cmd/kosli/createEnvironment.go
+++ b/cmd/kosli/createEnvironment.go
@@ -13,7 +13,7 @@ const createEnvironmentShortDesc = `Create or update a Kosli environment.`
 
 const createEnvironmentLongDesc = createEnvironmentShortDesc + `
 
-The **--type** must match the type of environment you wish to record snapshots from.
+^^--type^^ must match the type of environment you wish to record snapshots from.
 The following types are supported:
   - k8s        - Kubernetes
   - ecs        - Amazon Elastic Container Service
@@ -23,7 +23,11 @@ The following types are supported:
   - azure-apps - Azure app services
   - server     - Generic type
 
-By default kosli will not make new snapshots for scaling events (change in number of instances running).
+By default, the environment allows artifacts with no provenance (i.e. environment snapshots will not 
+become non-compliant because of artifacts that do not have provenance). You can require provenance for all artifacts
+by setting --allow-no-provenance=false.
+
+Also, by default, kosli will not make new snapshots for scaling events (change in number of instances running).
 For large clusters the scaling events will often outnumber the actual change of SW.
 
 It is possible to enable new snapshots for scaling events with the --include-scaling flag, or turn
@@ -40,16 +44,18 @@ kosli create environment yourEnvironmentName
 `
 
 type createEnvOptions struct {
-	payload        CreateEnvironmentPayload
-	excludeScaling bool
-	includeScaling bool
+	payload           CreateEnvironmentPayload
+	excludeScaling    bool
+	includeScaling    bool
+	allowNoProvenance bool
 }
 
 type CreateEnvironmentPayload struct {
-	Name           string `json:"name"`
-	Type           string `json:"type"`
-	Description    string `json:"description"`
-	IncludeScaling *bool  `json:"include_scaling,omitempty"`
+	Name              string `json:"name"`
+	Type              string `json:"type"`
+	Description       string `json:"description"`
+	IncludeScaling    *bool  `json:"include_scaling,omitempty"`
+	AllowNoProvenance *bool  `json:"allow_no_provenance,omitempty"`
 }
 
 func newCreateEnvironmentCmd(out io.Writer) *cobra.Command {
@@ -81,6 +87,7 @@ func newCreateEnvironmentCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().StringVarP(&o.payload.Description, "description", "d", "", envDescriptionFlag)
 	cmd.Flags().BoolVar(&o.excludeScaling, "exclude-scaling", false, excludeScalingFlag)
 	cmd.Flags().BoolVar(&o.includeScaling, "include-scaling", false, includeScalingFlag)
+	cmd.Flags().BoolVar(&o.allowNoProvenance, "allow-no-provenance", true, allowNoProvenanceFlag)
 	addDryRunFlag(cmd)
 
 	err := RequireFlags(cmd, []string{"type"})

--- a/cmd/kosli/createEnvironment.go
+++ b/cmd/kosli/createEnvironment.go
@@ -23,9 +23,9 @@ The following types are supported:
   - azure-apps - Azure app services
   - server     - Generic type
 
-By default, the environment allows artifacts with no provenance (i.e. environment snapshots will not 
+By default, the environment does not require artifacts provenance (i.e. environment snapshots will not 
 become non-compliant because of artifacts that do not have provenance). You can require provenance for all artifacts
-by setting --allow-no-provenance=false.
+by setting --require-provenance=true
 
 Also, by default, kosli will not make new snapshots for scaling events (change in number of instances running).
 For large clusters the scaling events will often outnumber the actual change of SW.
@@ -54,7 +54,7 @@ type CreateEnvironmentPayload struct {
 	Type              string `json:"type"`
 	Description       string `json:"description"`
 	IncludeScaling    *bool  `json:"include_scaling,omitempty"`
-	AllowNoProvenance bool   `json:"allow_no_provenance"`
+	RequireProvenance bool   `json:"require_provenance"`
 }
 
 func newCreateEnvironmentCmd(out io.Writer) *cobra.Command {
@@ -86,7 +86,7 @@ func newCreateEnvironmentCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().StringVarP(&o.payload.Description, "description", "d", "", envDescriptionFlag)
 	cmd.Flags().BoolVar(&o.excludeScaling, "exclude-scaling", false, excludeScalingFlag)
 	cmd.Flags().BoolVar(&o.includeScaling, "include-scaling", false, includeScalingFlag)
-	cmd.Flags().BoolVar(&o.payload.AllowNoProvenance, "allow-no-provenance", true, allowNoProvenanceFlag)
+	cmd.Flags().BoolVar(&o.payload.RequireProvenance, "require-provenance", false, requireProvenanceFlag)
 	addDryRunFlag(cmd)
 
 	err := RequireFlags(cmd, []string{"type"})

--- a/cmd/kosli/createEnvironment.go
+++ b/cmd/kosli/createEnvironment.go
@@ -44,10 +44,9 @@ kosli create environment yourEnvironmentName
 `
 
 type createEnvOptions struct {
-	payload           CreateEnvironmentPayload
-	excludeScaling    bool
-	includeScaling    bool
-	allowNoProvenance bool
+	payload        CreateEnvironmentPayload
+	excludeScaling bool
+	includeScaling bool
 }
 
 type CreateEnvironmentPayload struct {
@@ -55,7 +54,7 @@ type CreateEnvironmentPayload struct {
 	Type              string `json:"type"`
 	Description       string `json:"description"`
 	IncludeScaling    *bool  `json:"include_scaling,omitempty"`
-	AllowNoProvenance *bool  `json:"allow_no_provenance,omitempty"`
+	AllowNoProvenance bool   `json:"allow_no_provenance"`
 }
 
 func newCreateEnvironmentCmd(out io.Writer) *cobra.Command {
@@ -87,7 +86,7 @@ func newCreateEnvironmentCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().StringVarP(&o.payload.Description, "description", "d", "", envDescriptionFlag)
 	cmd.Flags().BoolVar(&o.excludeScaling, "exclude-scaling", false, excludeScalingFlag)
 	cmd.Flags().BoolVar(&o.includeScaling, "include-scaling", false, includeScalingFlag)
-	cmd.Flags().BoolVar(&o.allowNoProvenance, "allow-no-provenance", true, allowNoProvenanceFlag)
+	cmd.Flags().BoolVar(&o.payload.AllowNoProvenance, "allow-no-provenance", true, allowNoProvenanceFlag)
 	addDryRunFlag(cmd)
 
 	err := RequireFlags(cmd, []string{"type"})

--- a/cmd/kosli/createEnvironment_test.go
+++ b/cmd/kosli/createEnvironment_test.go
@@ -51,6 +51,16 @@ func (suite *CreateEnvironmentCommandTestSuite) TestCreateEnvironmentCmd() {
 			golden:    "environment newEnv1 was created\n",
 		},
 		{
+			name:   "can create K8S env with --allow-no-provenance",
+			cmd:    "create env relaxedEnv --type K8S --allow-no-provenance" + suite.defaultKosliArguments,
+			golden: "environment relaxedEnv was created\n",
+		},
+		{
+			name:   "can create K8S env with --allow-no-provenance=false",
+			cmd:    "create env relaxedEnv --type K8S --allow-no-provenance=false" + suite.defaultKosliArguments,
+			golden: "environment relaxedEnv was created\n",
+		},
+		{
 			wantError: true,
 			name:      "fail if both exclude-scaling an include-scaling is provided",
 			cmd:       "create env newEnv1 --type K8S --exclude-scaling --include-scaling" + suite.defaultKosliArguments,

--- a/cmd/kosli/createEnvironment_test.go
+++ b/cmd/kosli/createEnvironment_test.go
@@ -51,13 +51,13 @@ func (suite *CreateEnvironmentCommandTestSuite) TestCreateEnvironmentCmd() {
 			golden:    "environment newEnv1 was created\n",
 		},
 		{
-			name:   "can create K8S env with --allow-no-provenance",
-			cmd:    "create env relaxedEnv --type K8S --allow-no-provenance" + suite.defaultKosliArguments,
-			golden: "environment relaxedEnv was created\n",
+			name:   "can create K8S env with --require-provenance",
+			cmd:    "create env strictEnv --type K8S --require-provenance" + suite.defaultKosliArguments,
+			golden: "environment strictEnv was created\n",
 		},
 		{
-			name:   "can create K8S env with --allow-no-provenance=false",
-			cmd:    "create env relaxedEnv --type K8S --allow-no-provenance=false" + suite.defaultKosliArguments,
+			name:   "can create K8S env with --require-provenance=false",
+			cmd:    "create env relaxedEnv --type K8S --require-provenance=false" + suite.defaultKosliArguments,
 			golden: "environment relaxedEnv was created\n",
 		},
 		{

--- a/cmd/kosli/getEnvironment.go
+++ b/cmd/kosli/getEnvironment.go
@@ -88,12 +88,16 @@ func printEnvironmentAsTable(raw string, out io.Writer, page int) error {
 		tagsOutput += fmt.Sprintf("[%s=%s], ", key, value)
 	}
 	tagsOutput = strings.TrimSuffix(tagsOutput, ", ")
+	if tagsOutput == "" {
+		tagsOutput = "None"
+	}
 
 	header := []string{}
 	rows := []string{}
 	rows = append(rows, fmt.Sprintf("Name:\t%s", env["name"]))
 	rows = append(rows, fmt.Sprintf("Type:\t%s", env["type"]))
 	rows = append(rows, fmt.Sprintf("Description:\t%s", env["description"]))
+	rows = append(rows, fmt.Sprintf("Allow No Provenance Artifacts:\t%t", env["allow_no_provenance"]))
 	rows = append(rows, fmt.Sprintf("State:\t%s", state))
 	rows = append(rows, fmt.Sprintf("Last Reported At:\t%s", lastReportedAt))
 	rows = append(rows, fmt.Sprintf("Tags:\t%s", tagsOutput))

--- a/cmd/kosli/getEnvironment.go
+++ b/cmd/kosli/getEnvironment.go
@@ -97,7 +97,7 @@ func printEnvironmentAsTable(raw string, out io.Writer, page int) error {
 	rows = append(rows, fmt.Sprintf("Name:\t%s", env["name"]))
 	rows = append(rows, fmt.Sprintf("Type:\t%s", env["type"]))
 	rows = append(rows, fmt.Sprintf("Description:\t%s", env["description"]))
-	rows = append(rows, fmt.Sprintf("Allow No Provenance Artifacts:\t%t", env["allow_no_provenance"]))
+	rows = append(rows, fmt.Sprintf("Require Provenance for Artifacts:\t%t", env["require_provenance"]))
 	rows = append(rows, fmt.Sprintf("State:\t%s", state))
 	rows = append(rows, fmt.Sprintf("Last Reported At:\t%s", lastReportedAt))
 	rows = append(rows, fmt.Sprintf("Tags:\t%s", tagsOutput))

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -194,7 +194,7 @@ The service principal needs to have the following permissions:
 	attestationDescription               = "[optional] attestation description"
 	excludeScalingFlag                   = "[optional] Exclude scaling events for snapshots. Snapshots with scaling changes will not result in new environment records."
 	includeScalingFlag                   = "[optional] Include scaling events for snapshots. Snapshots with scaling changes will result in new environment records."
-	allowNoProvenanceFlag                = "[defaulted] Allow artifacts with no provenance in environment snapshots. Snapshots with such artifacts will not become non-compliant when this flag is set to true,"
+	requireProvenanceFlag                = "[defaulted] Require provenance for all artifacts running in environment snapshots."
 	deprecatedKosliReportEvidenceMessage = "See **kosli attest** commands."
 	setTagsFlag                          = "[optional] The key-value pairs to tag the resource with. The format is: key=value"
 	unsetTagsFlag                        = "[optional] The list of tag keys to remove from the resource."

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -194,6 +194,7 @@ The service principal needs to have the following permissions:
 	attestationDescription               = "[optional] attestation description"
 	excludeScalingFlag                   = "[optional] Exclude scaling events for snapshots. Snapshots with scaling changes will not result in new environment records."
 	includeScalingFlag                   = "[optional] Include scaling events for snapshots. Snapshots with scaling changes will result in new environment records."
+	allowNoProvenanceFlag                = "[defaulted] Allow artifacts with no provenance in environment snapshots. Snapshots with such artifacts will not become non-compliant when this flag is set to true,"
 	deprecatedKosliReportEvidenceMessage = "See **kosli attest** commands."
 	setTagsFlag                          = "[optional] The key-value pairs to tag the resource with. The format is: key=value"
 	unsetTagsFlag                        = "[optional] The list of tag keys to remove from the resource."


### PR DESCRIPTION
partially fulfils kosli-dev/server#1705.

- adds `--require-provenance` flag on `kosli create env`
- shows `require provenace` settings value in `kosli get env`