### PR TITLE
Split snapshot paths

### DIFF
--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -198,9 +198,9 @@ The service principal needs to have the following permissions:
 	setTagsFlag                          = "[optional] The key-value pairs to tag the resource with. The format is: key=value"
 	unsetTagsFlag                        = "[optional] The list of tag keys to remove from the resource."
 	pathsSpecFileFlag                    = "[conditional] The path to a paths file in YAML/JSON/TOML format. Cannot be used together with --path ."
-	snapshotPathsPathFlag                = "[conditional] The base path for the artifact to snapshot. Cannot be used together with --paths-file ."
-	snapshotPathsExcludeFlag             = "[optional] The comma-separated list of literal paths or glob patterns to exclude when fingerprinting the artifact. Can only be used together with --path ."
-	snapshotPathsArtifactNameFlag        = "[conditional] The reported name of the artifact. Only required when --path is used."
+	snapshotPathPathFlag                 = "The base path for the artifact to snapshot."
+	snapshotPathExcludeFlag              = "[optional] The comma-separated list of literal paths or glob patterns to exclude when fingerprinting the artifact."
+	snapshotPathArtifactNameFlag         = "The reported name of the artifact."
 )
 
 var global *GlobalOpts

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -197,7 +197,7 @@ The service principal needs to have the following permissions:
 	deprecatedKosliReportEvidenceMessage = "See **kosli attest** commands."
 	setTagsFlag                          = "[optional] The key-value pairs to tag the resource with. The format is: key=value"
 	unsetTagsFlag                        = "[optional] The list of tag keys to remove from the resource."
-	pathsSpecFileFlag                    = "[conditional] The path to a paths file in YAML/JSON/TOML format. Cannot be used together with --path ."
+	pathsSpecFileFlag                    = "The path to a paths file in YAML/JSON/TOML format. Cannot be used together with --path ."
 	snapshotPathPathFlag                 = "The base path for the artifact to snapshot."
 	snapshotPathExcludeFlag              = "[optional] The comma-separated list of literal paths or glob patterns to exclude when fingerprinting the artifact."
 	snapshotPathArtifactNameFlag         = "The reported name of the artifact."

--- a/cmd/kosli/snapshot.go
+++ b/cmd/kosli/snapshot.go
@@ -25,6 +25,7 @@ func newSnapshotCmd(out io.Writer) *cobra.Command {
 		newSnapshotS3Cmd(out),
 		newSnapshotAzureAppsCmd(out),
 		newSnapshotPathsCmd(out),
+		newSnapshotPathCmd(out),
 	)
 
 	return cmd

--- a/cmd/kosli/snapshotPath.go
+++ b/cmd/kosli/snapshotPath.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/kosli-dev/cli/internal/requests"
+	"github.com/kosli-dev/cli/internal/server"
+	"github.com/spf13/cobra"
+)
+
+const snapshotPathShortDesc = `Report a snapshot of a single artifact running in a specific filesystem path to Kosli.  `
+
+const snapshotPathLongDesc = snapshotPathsShortDesc + `
+You can report a directory or file artifact. For reporting multiple artifacts in one go, use "kosli snapshot paths".
+You can exclude certain paths or patterns from the artifact fingerprint using ^--exclude^
+
+`
+
+const snapshotPathExample = `
+# report one artifact running in a specific path in a filesystem:
+kosli snapshot path yourEnvironmentName \
+	--path path/to/your/artifact/dir/or/file \
+	--name yourArtifactDisplayName \
+	--api-token yourAPIToken \
+	--org yourOrgName
+
+# report one artifact running in a specific path in a filesystem AND exclude certain path patterns:
+kosli snapshot path yourEnvironmentName \
+	--path path/to/your/artifact/dir \
+	--name yourArtifactDisplayName \
+	--exclude **/log,unwanted.txt,path/**/output.txt
+	--api-token yourAPIToken \
+	--org yourOrgName
+`
+
+type snapshotPathOptions struct {
+	path         string
+	artifactName string
+	exclude      []string
+}
+
+func newSnapshotPathCmd(out io.Writer) *cobra.Command {
+	o := new(snapshotPathOptions)
+	cmd := &cobra.Command{
+		Use:     "path ENVIRONMENT-NAME",
+		Short:   snapshotPathShortDesc,
+		Long:    snapshotPathLongDesc,
+		Args:    cobra.ExactArgs(1),
+		Example: snapshotPathExample,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			err := RequireGlobalFlags(global, []string{"Org", "ApiToken"})
+			if err != nil {
+				return ErrorBeforePrintingUsage(cmd, err.Error())
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return o.run(args)
+		},
+	}
+
+	cmd.Flags().StringVar(&o.path, "path", "", snapshotPathPathFlag)
+	cmd.Flags().StringVar(&o.artifactName, "name", "", snapshotPathArtifactNameFlag)
+	cmd.Flags().StringSliceVarP(&o.exclude, "exclude", "x", []string{}, snapshotPathExcludeFlag)
+	addDryRunFlag(cmd)
+
+	if err := RequireFlags(cmd, []string{"path", "name"}); err != nil {
+		logger.Error("failed to configure required flags: %v", err)
+	}
+
+	return cmd
+}
+
+func (o *snapshotPathOptions) run(args []string) error {
+	envName := args[0]
+
+	url := fmt.Sprintf("%s/api/v2/environments/%s/%s/report/server", global.Host, global.Org, envName)
+
+	// load path spec from flags
+	ps := &server.PathsSpec{
+		Version: 1,
+		Artifacts: map[string]server.ArtifactPathSpec{
+			o.artifactName: {
+				Path:    o.path,
+				Exclude: o.exclude,
+			},
+		},
+	}
+
+	artifacts, err := server.CreatePathsArtifactsData(ps, logger)
+	if err != nil {
+		return err
+	}
+	payload := &server.ServerEnvRequest{
+		Artifacts: artifacts,
+	}
+
+	reqParams := &requests.RequestParams{
+		Method:   http.MethodPut,
+		URL:      url,
+		Payload:  payload,
+		DryRun:   global.DryRun,
+		Password: global.ApiToken,
+	}
+	_, err = kosliClient.Do(reqParams)
+	if err == nil && !global.DryRun {
+		logger.Info("[%d] artifacts were reported to environment %s", len(payload.Artifacts), envName)
+	}
+	return err
+}

--- a/cmd/kosli/snapshotPath.go
+++ b/cmd/kosli/snapshotPath.go
@@ -14,7 +14,9 @@ const snapshotPathShortDesc = `Report a snapshot of a single artifact running in
 
 const snapshotPathLongDesc = snapshotPathsShortDesc + `
 You can report a directory or file artifact. For reporting multiple artifacts in one go, use "kosli snapshot paths".
-You can exclude certain paths or patterns from the artifact fingerprint using ^--exclude^
+You can exclude certain paths or patterns from the artifact fingerprint using ^--exclude^.
+The supported glob pattern syntax is what is documented here: https://pkg.go.dev/path/filepath#Match , 
+plus the ability to use recursive globs "**"
 
 `
 

--- a/cmd/kosli/snapshotPath_test.go
+++ b/cmd/kosli/snapshotPath_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// Define the suite, and absorb the built-in basic suite
+// functionality from testify - including a T() method which
+// returns the current testing context
+type SnapshotPathTestSuite struct {
+	suite.Suite
+	defaultKosliArguments string
+	envName               string
+}
+
+func (suite *SnapshotPathTestSuite) SetupSuite() {
+	suite.envName = "snapshot-path-env"
+	global = &GlobalOpts{
+		ApiToken: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6ImNkNzg4OTg5In0.e8i_lA_QrEhFncb05Xw6E_tkCHU9QfcY4OLTVUCHffY",
+		Org:      "docs-cmd-test-user",
+		Host:     "http://localhost:8001",
+	}
+	suite.defaultKosliArguments = fmt.Sprintf(" --host %s --org %s --api-token %s", global.Host, global.Org, global.ApiToken)
+
+	CreateEnv(global.Org, suite.envName, "server", suite.T())
+}
+
+func (suite *SnapshotPathTestSuite) TestSnapshotPathCmd() {
+	tests := []cmdTestCase{
+		{
+			wantError: true,
+			name:      "fails when --path is missing",
+			cmd:       fmt.Sprintf(`snapshot path --name foo %s %s`, suite.envName, suite.defaultKosliArguments),
+			golden:    "Error: required flag(s) \"path\" not set\n",
+		},
+		{
+			wantError: true,
+			name:      "fails when --name is missing",
+			cmd:       fmt.Sprintf(`snapshot path --path testdata/paths-files %s %s`, suite.envName, suite.defaultKosliArguments),
+			golden:    "Error: required flag(s) \"name\" not set\n",
+		},
+		{
+			wantError: true,
+			name:      "fails when --path does not exist",
+			cmd:       fmt.Sprintf(`snapshot path --path testdata/paths-files/does-not-exist --name foo %s %s`, suite.envName, suite.defaultKosliArguments),
+			golden:    "Error: failed to calculate fingerprint for artifact [foo]: failed to open path testdata/paths-files/does-not-exist with error: stat testdata/paths-files/does-not-exist: no such file or directory\n",
+		},
+		{
+			name:   "can report artifact data with --path and --name",
+			cmd:    fmt.Sprintf(`snapshot path --path testdata/file1 --name foo %s %s`, suite.envName, suite.defaultKosliArguments),
+			golden: fmt.Sprintf("[1] artifacts were reported to environment %s\n", suite.envName),
+		},
+		{
+			name:   "can report artifact data with --path and --exclude",
+			cmd:    fmt.Sprintf(`snapshot path --path testdata/server --name foo --exclude app.app,"**/logs.txt" %s %s`, suite.envName, suite.defaultKosliArguments),
+			golden: fmt.Sprintf("[1] artifacts were reported to environment %s\n", suite.envName),
+		},
+	}
+
+	runTestCmd(suite.T(), tests)
+
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestSnapshotPathTestSuite(t *testing.T) {
+	suite.Run(t, new(SnapshotPathTestSuite))
+}

--- a/cmd/kosli/snapshotPaths.go
+++ b/cmd/kosli/snapshotPaths.go
@@ -24,12 +24,15 @@ The supported glob pattern syntax is what is documented here: https://pkg.go.dev
 plus the ability to use recursive globs "**"
 
 This is an example YAML paths spec file:
+` +
 
-version: 1
+	"```yaml\n" +
+	`version: 1
 artifacts:
   artifact_name_a:
     path: dir1
-    exclude: [subdir1, **/log]`
+    exclude: [subdir1, **/log]` +
+	"\n```"
 
 const snapshotPathsLongDesc = snapshotPathsShortDesc + `
 You can report directory or file artifacts in one or more filesystem paths. 

--- a/cmd/kosli/snapshotPaths.go
+++ b/cmd/kosli/snapshotPaths.go
@@ -52,9 +52,6 @@ kosli snapshot paths yourEnvironmentName \
 
 type snapshotPathsOptions struct {
 	pathSpecFile string
-	path         string
-	artifactName string
-	exclude      []string
 }
 
 func newSnapshotPathsCmd(out io.Writer) *cobra.Command {

--- a/cmd/kosli/snapshotPaths_test.go
+++ b/cmd/kosli/snapshotPaths_test.go
@@ -49,30 +49,6 @@ func (suite *SnapshotPathsTestSuite) TestSnapshotPathsCmd() {
 			golden:    "Error: path spec file [testdata/paths-files/invalid-values-pathsfile.yml] is invalid: Key: 'PathsSpec.Version' Error:Field validation for 'Version' failed on the 'oneof' tag\n",
 		},
 		{
-			wantError: true,
-			name:      "fails when --paths-file and --path are provided",
-			cmd:       fmt.Sprintf(`snapshot paths --paths-file testdata/paths-files/valid-pathsfile.yml --path foo %s %s`, suite.envName, suite.defaultKosliArguments),
-			golden:    "Error: only one of --paths-file, --path is allowed\n",
-		},
-		{
-			wantError: true,
-			name:      "fails when --paths-file and --exclude are provided",
-			cmd:       fmt.Sprintf(`snapshot paths --paths-file testdata/paths-files/valid-pathsfile.yml --exclude foo %s %s`, suite.envName, suite.defaultKosliArguments),
-			golden:    "Error: only one of --paths-file, --exclude is allowed\n",
-		},
-		{
-			wantError: true,
-			name:      "fails when --paths-file and --name are provided",
-			cmd:       fmt.Sprintf(`snapshot paths --paths-file testdata/paths-files/valid-pathsfile.yml --name foo %s %s`, suite.envName, suite.defaultKosliArguments),
-			golden:    "Error: only one of --paths-file, --name is allowed\n",
-		},
-		{
-			wantError: true,
-			name:      "fails when neither --paths-file nor --path are provided",
-			cmd:       fmt.Sprintf(`snapshot paths %s %s`, suite.envName, suite.defaultKosliArguments),
-			golden:    "Error: at least one of --paths-file, --path is required\n",
-		},
-		{
 			name:   "can report artifact data with YAML path spec file",
 			cmd:    fmt.Sprintf(`snapshot paths --paths-file testdata/paths-files/valid-pathsfile.yml %s %s`, suite.envName, suite.defaultKosliArguments),
 			golden: fmt.Sprintf("[1] artifacts were reported to environment %s\n", suite.envName),
@@ -85,22 +61,6 @@ func (suite *SnapshotPathsTestSuite) TestSnapshotPathsCmd() {
 		{
 			name:   "can report artifact data with TOML path spec file",
 			cmd:    fmt.Sprintf(`snapshot paths --paths-file testdata/paths-files/valid-pathsfile.toml %s %s`, suite.envName, suite.defaultKosliArguments),
-			golden: fmt.Sprintf("[1] artifacts were reported to environment %s\n", suite.envName),
-		},
-		{
-			wantError: true,
-			name:      "--name is required when --path is used",
-			cmd:       fmt.Sprintf(`snapshot paths --path testdata/file1 %s %s`, suite.envName, suite.defaultKosliArguments),
-			golden:    "Error: flag --name is required when flag --path is set\n",
-		},
-		{
-			name:   "can report artifact data with --path and --name",
-			cmd:    fmt.Sprintf(`snapshot paths --path testdata/file1 --name foo %s %s`, suite.envName, suite.defaultKosliArguments),
-			golden: fmt.Sprintf("[1] artifacts were reported to environment %s\n", suite.envName),
-		},
-		{
-			name:   "can report artifact data with --path and --exclude",
-			cmd:    fmt.Sprintf(`snapshot paths --path testdata/server --name foo --exclude app.app,"**/logs.txt" %s %s`, suite.envName, suite.defaultKosliArguments),
 			golden: fmt.Sprintf("[1] artifacts were reported to environment %s\n", suite.envName),
 		},
 	}


### PR DESCRIPTION
split `kosli snapshot paths` to 2 commands as suggested in [this comment](https://github.com/kosli-dev/server/issues/1714#issuecomment-2082144893):
- `kosli snapshot paths  <env-name> --paths-file ...` for one or multiple artifacts reporting using a paths file
- `kosli snapshot path  <env-name> --path ./path --name foo --exclude *.logs` for single artifact reporting without paths file

