### PR TITLE
Use trails for the CLI artifact

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,6 @@ on:
 
 env:
   IMAGE: ghcr.io/kosli-dev/cli
-  KOSLI_CLI_VERSION: "2.8.5"
   # KOSLI_DRY_RUN: "True"
   # Ordinarily we declare KOSLI_ORG and KOSLI_FLOW here but
   # this interferes with the CLI integration tests
@@ -91,7 +90,7 @@ jobs:
       uses: kosli-dev/setup-cli-action@v2
       with:
         version:
-          ${{ env.KOSLI_CLI_VERSION }}
+          ${{ vars.KOSLI_CLI_VERSION }}
 
     
     - name: setup Snyk

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -147,7 +147,7 @@ jobs:
         kosli attest generic
           --flow cli
           --trail ${{ inputs.trail_name }} 
-          --name cli-docker
+          --name sbom
           --fingerprint ${{ env.FINGERPRINT }}
           --attachments  sbom.spdx.json
           --org ${{ inputs.kosli_org }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,8 +47,9 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    steps:
+      attestations: write
 
+    steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 3
@@ -63,7 +64,13 @@ jobs:
 
     # This is the a separate action that sets up buildx (buildkit) runner
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3 
+      uses: docker/setup-buildx-action@v3
+
+    - name: setup-kosli-cli
+      uses: kosli-dev/setup-cli-action@v2
+      with:
+        version:
+          ${{ vars.KOSLI_CLI_VERSION }}
     
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
@@ -82,14 +89,30 @@ jobs:
         tags: ${{ env.IMAGE }}:${{ inputs.tag }}
         platforms: ${{ inputs.platforms }}
         cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache
-        cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max    
+        cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max
 
-
-    - name: setup-kosli-cli
-      uses: kosli-dev/setup-cli-action@v2
+    - name: Attest Build Provenance
+      uses: actions/attest-build-provenance@v1
       with:
-        version:
-          ${{ vars.KOSLI_CLI_VERSION }}
+        subject-name: ${{ env.IMAGE }}:${{ inputs.tag }}
+        subject-digest: ${{ steps.docker_build.outputs.digest }}
+        push-to-registry: true
+
+    - name: Generate SBOM for the docker image
+      uses: anchore/sbom-action@v0
+      with:
+        image: ${{ env.IMAGE }}:${{ inputs.tag }}
+        format: 'spdx-json'
+        output-file: 'sbom.spdx.json'
+
+
+    - name: Attest SBOM to Github
+      uses: actions/attest-sbom@v1
+      with:
+        sbom-path: 'sbom.spdx.json'
+        subject-name: ${{ env.IMAGE }}:${{ inputs.tag }}
+        subject-digest: ${{ steps.docker_build.outputs.digest }}
+        push-to-registry: true
 
     
     - name: setup Snyk
@@ -107,6 +130,19 @@ jobs:
            --name cli-docker
            --fingerprint ${{ steps.docker_build.outputs.digest }} 
            --org ${{ inputs.kosli_org }}
+
+           
+    - name: Report SBOM to Kosli
+      env:
+        KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
+      run: 
+        kosli attest generic
+          --flow cli
+          --trail ${{ inputs.trail_name }} 
+          --name cli-docker
+          --fingerprint ${{ steps.docker_build.outputs.digest }}
+          --attachments  sbom.spdx.json
+          --org ${{ inputs.kosli_org }}
 
     
     - name: Run Snyk to scan the Docker image for vulnerabilities

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,12 @@ on:
       assert:
         type: boolean
         default: false
+      trail_name:
+        required: true
+        type: string
+      kosli_org:
+        required: true
+        type: string
     secrets:
       slack_channel:
         required: true
@@ -41,7 +47,6 @@ jobs:
     permissions:
       id-token: write
       contents: write
-      pull-requests: read
     steps:
 
     - uses: actions/checkout@v4
@@ -80,12 +85,6 @@ jobs:
         cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max    
 
 
-    - name: Make the image fingerprint available for following steps
-      run: |
-        ARTIFACT_SHA=$( echo ${{ steps.docker_build.outputs.digest }} | sed 's/.*://')
-        echo "FINGERPRINT=$ARTIFACT_SHA" >> ${GITHUB_ENV}
-
-
     - name: setup-kosli-cli
       uses: kosli-dev/setup-cli-action@v2
       with:
@@ -97,80 +96,46 @@ jobs:
       uses: snyk/actions/setup@master
 
 
-    - name: Create Kosli flow
-      env:
-        KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
-        KOSLI_ORG: kosli
-      run: 
-        kosli create flow cli
-          --description "Kosli CLI" 
-          --template "artifact,snyk-code-scan,snyk-docker-scan,smoke-test,pull-request"
-
-
     - name: Report Docker image to Kosli
       env:
         KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
-        KOSLI_ORG: kosli
       run: 
-        kosli report artifact
+        kosli attest artifact
            ${{ env.IMAGE }}:${{ inputs.tag }}
-           --fingerprint=${{ env.FINGERPRINT }}
            --flow cli
-
-
-    - name: Run Snyk to check source code for vulnerabilities
-      continue-on-error: true
-      env:
-        # In order to use the Snyk Action you will need to have a Snyk API token.
-        # More details in https://github.com/snyk/actions#getting-your-snyk-token
-        # or you can signup for free at https://snyk.io/login
-        SNYK_TOKEN: ${{ secrets.snyk_token }}
-      run: 
-          snyk test --policy-path=.snyk  --json-file-output=snyk-code.json --prune-repeated-subdependencies
-
-
-    - name: Report Snyk CODE scan results evidence to Kosli
-      env:
-        KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN }}
-        KOSLI_ORG: kosli
-      run: 
-        kosli report evidence artifact snyk 
-          ${{ env.IMAGE }}:${{ inputs.tag }}
-            --fingerprint ${{ env.FINGERPRINT }}
-            --name snyk-code-scan
-            --scan-results snyk-code.json
-            --flow cli
+           --trail ${{ inputs.trail_name }} 
+           --name cli-docker
+           --fingerprint ${{ steps.docker_build.outputs.digest }} 
+           --org ${{ inputs.kosli_org }}
 
     
     - name: Run Snyk to scan the Docker image for vulnerabilities
-      continue-on-error: true
       env:
-        # In order to use the Snyk Action you will need to have a Snyk API token.
-        # More details in https://github.com/snyk/actions#getting-your-snyk-token
-        # or you can signup for free at https://snyk.io/login
         SNYK_TOKEN: ${{ secrets.snyk_token }}
       run: 
           snyk container test ${{ env.IMAGE }}:${{ inputs.tag }} 
              --file=Dockerfile
+             --sarif
              --policy-path=.snyk
-             --json-file-output=snyk-docker.json
+             --sarif-file-output=snyk-docker.json
 
 
     - name: Report Snyk Docker scan results evidence to Kosli
+      if:  ${{ (success() || failure()) }}
       env:
         KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN }}
-        KOSLI_ORG: kosli
       run: 
-        kosli report evidence artifact snyk 
-          ${{ env.IMAGE }}:${{ inputs.tag }}
-            --fingerprint ${{ env.FINGERPRINT }}
-            --name snyk-docker-scan
-            --scan-results snyk-docker.json
+        kosli attest snyk 
             --flow cli
+            --trail ${{ inputs.trail_name }} 
+            --fingerprint ${{ steps.docker_build.outputs.digest }} 
+            --name snyk-container
+            --scan-results snyk-docker.json
+            --org ${{ inputs.kosli_org }}
+
 
     - name: Smoke test the docker image to be sure it can connect to Kosli
       id: smoke-test
-      continue-on-error: true
       env:
         KOSLI_ORG: cyber-dojo
         KOSLI_API_TOKEN: any-token-will-do
@@ -179,43 +144,17 @@ jobs:
           -e KOSLI_ORG --rm ${{ env.IMAGE }}:${{ inputs.tag }}
           list environments
 
-    - name: Report Docker smoke test evidence to Kosli
+    - name: Report Docker smoke test attestation to Kosli
+      if:  ${{ (success() || failure()) }}
       env:
         KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN }}
-        KOSLI_ORG: kosli
         SMOKE_TEST_OUTCOME: ${{ steps.smoke-test.outcome}}
-      run: |
-        if [ $SMOKE_TEST_OUTCOME = success ]
-        then
-          export SMOKE_TEST_PASSED=true
-        else
-          export SMOKE_TEST_PASSED=false
-        fi
-
-        kosli report evidence artifact generic \
-          ${{ env.IMAGE }}:${{ inputs.tag }} \
-            --fingerprint ${{ env.FINGERPRINT }} \
-            --name smoke-test \
-            --compliant=$SMOKE_TEST_PASSED \
-            --flow cli
-
-    - name: Report pull-request evidence to Kosli (production)
-      env:
-        KOSLI_NAME: "pull-request"
-        KOSLI_FINGERPRINT: ${{ env.FINGERPRINT }} 
-        KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN }}
-        KOSLI_ORG: kosli
-        KOSLI_FLOW: cli
-      run:
-        kosli report evidence artifact pullrequest github
-          --github-token ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Assert artifact in Kosli
-      if: ${{ inputs.assert }}
-      env:
-        KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
-        KOSLI_ORG: kosli
       run: 
-        kosli assert artifact
-          --fingerprint ${{ env.FINGERPRINT }}
-          --flow cli
+        kosli attest generic 
+            --flow cli
+            --trail ${{ inputs.trail_name }} 
+            --fingerprint ${{ steps.docker_build.outputs.digest }} 
+            --name smoke-test
+            --compliant=${{ steps.smoke-test.outcome == 'success' }} 
+            --org ${{ inputs.kosli_org }}
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -91,10 +91,17 @@ jobs:
         cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache
         cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max
 
+
+    - name: Make the image fingerprint available for following steps
+      run: |
+        ARTIFACT_SHA=$( echo ${{ steps.docker_build.outputs.digest }} | sed 's/.*://')
+        echo "FINGERPRINT=$ARTIFACT_SHA" >> ${GITHUB_ENV}
+
+
     - name: Attest Build Provenance
       uses: actions/attest-build-provenance@v1
       with:
-        subject-name: ${{ env.IMAGE }}:${{ inputs.tag }}
+        subject-name: ${{ env.IMAGE }}
         subject-digest: ${{ steps.docker_build.outputs.digest }}
         push-to-registry: true
 
@@ -110,7 +117,7 @@ jobs:
       uses: actions/attest-sbom@v1
       with:
         sbom-path: 'sbom.spdx.json'
-        subject-name: ${{ env.IMAGE }}:${{ inputs.tag }}
+        subject-name: ${{ env.IMAGE }}
         subject-digest: ${{ steps.docker_build.outputs.digest }}
         push-to-registry: true
 
@@ -128,7 +135,8 @@ jobs:
            --flow cli
            --trail ${{ inputs.trail_name }} 
            --name cli-docker
-           --fingerprint ${{ steps.docker_build.outputs.digest }} 
+           --fingerprint ${{ env.FINGERPRINT }}
+           --external-url sigstore=https://search.sigstore.dev/?hash=${{ env.FINGERPRINT }}
            --org ${{ inputs.kosli_org }}
 
            
@@ -140,7 +148,7 @@ jobs:
           --flow cli
           --trail ${{ inputs.trail_name }} 
           --name cli-docker
-          --fingerprint ${{ steps.docker_build.outputs.digest }}
+          --fingerprint ${{ env.FINGERPRINT }}
           --attachments  sbom.spdx.json
           --org ${{ inputs.kosli_org }}
 
@@ -156,15 +164,15 @@ jobs:
              --sarif-file-output=snyk-docker.json
 
 
-    - name: Report Snyk Docker scan results evidence to Kosli
+    - name: Report Snyk Docker scan results attestation to Kosli
       if:  ${{ (success() || failure()) }}
       env:
-        KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN }}
+        KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
       run: 
         kosli attest snyk 
             --flow cli
             --trail ${{ inputs.trail_name }} 
-            --fingerprint ${{ steps.docker_build.outputs.digest }} 
+            --fingerprint ${{ env.FINGERPRINT }} 
             --name snyk-container
             --scan-results snyk-docker.json
             --org ${{ inputs.kosli_org }}
@@ -183,13 +191,13 @@ jobs:
     - name: Report Docker smoke test attestation to Kosli
       if:  ${{ (success() || failure()) }}
       env:
-        KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN }}
+        KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
         SMOKE_TEST_OUTCOME: ${{ steps.smoke-test.outcome}}
       run: 
         kosli attest generic 
             --flow cli
             --trail ${{ inputs.trail_name }} 
-            --fingerprint ${{ steps.docker_build.outputs.digest }} 
+            --fingerprint ${{ env.FINGERPRINT }} 
             --name smoke-test
             --compliant=${{ steps.smoke-test.outcome == 'success' }} 
             --org ${{ inputs.kosli_org }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -127,6 +127,7 @@ jobs:
 
 
     - name: Report Docker image to Kosli
+      if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
       env:
         KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
       run: 
@@ -141,6 +142,7 @@ jobs:
 
            
     - name: Report SBOM to Kosli
+      if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
       env:
         KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
       run: 
@@ -165,7 +167,7 @@ jobs:
 
 
     - name: Report Snyk Docker scan results attestation to Kosli
-      if:  ${{ (success() || failure()) }}
+      if:  ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') && (success() || failure()) }}
       env:
         KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
       run: 
@@ -189,7 +191,7 @@ jobs:
           list environments
 
     - name: Report Docker smoke test attestation to Kosli
-      if:  ${{ (success() || failure()) }}
+      if:  ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') && (success() || failure()) }}
       env:
         KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
         SMOKE_TEST_OUTCOME: ${{ steps.smoke-test.outcome}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,10 @@ jobs:
 
   init-kosli:
     runs-on: ubuntu-20.04
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: read
     needs: [pre-build]
     steps:
 
@@ -69,6 +73,17 @@ jobs:
            --template-file ${{needs.pre-build.outputs.trail_template_file}}
            --org kosli-public
 
+    - name: Report pull-request attestation to Kosli
+      env:
+        KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN }}
+      run:
+        kosli attest pullrequest github
+          --flow cli
+          --trail ${{needs.pre-build.outputs.trail_name}} 
+          --name pr
+          --github-token ${{ secrets.GITHUB_TOKEN }}
+          --org kosli-public
+
   test:
     needs: [pre-build]
     if: ${{ github.ref != 'refs/heads/prod' }}
@@ -93,14 +108,16 @@ jobs:
   docker:
     needs: [pre-build, test]
     if: ${{ github.ref != 'refs/heads/prod' }}
-    uses: kosli-dev/cli/.github/workflows/docker.yml@main
+    uses: kosli-dev/cli/.github/workflows/docker.yml@use-trails
     with:
       tag: ${{ needs.pre-build.outputs.tag }}
       platforms: linux/amd64
+      trail_name: ${{ needs.pre-build.outputs.trail_name }}
+      kosli_org: kosli-public
     secrets:
       slack_webhook: ${{ secrets.MERKELY_SLACK_CI_FAILURES_WEBHOOK }}
       slack_channel: ${{ secrets.MERKELY_SLACK_CI_FAILURES_CHANNEL }} 
       ghcr_user: ${{ secrets.GHCR_USER }}
       ghcr_token: ${{ secrets.GHCR_TOKEN }}
-      kosli_api_token: ${{ secrets.KOSLI_API_TOKEN_PROD }}
+      kosli_api_token: ${{ secrets.KOSLI_API_TOKEN_2 }}
       snyk_token: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,7 @@ jobs:
           ${{ vars.KOSLI_CLI_VERSION }}
 
     - name: Update Kosli Flow
+      if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
       env:
         KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN }}
       run: kosli create flow cli 
@@ -66,6 +67,7 @@ jobs:
            --org kosli-public
 
     - name: Init Kosli Trail
+      if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
       env:
         KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN }}
       run: kosli begin trail ${{needs.pre-build.outputs.trail_name}} 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,8 +74,9 @@ jobs:
            --org kosli-public
 
     - name: Report pull-request attestation to Kosli
+      if: ${{ github.ref == 'refs/heads/main' }}
       env:
-        KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN }}
+        KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN_2 }}
       run:
         kosli attest pullrequest github
           --flow cli

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,12 +56,18 @@ jobs:
     - name: Update Kosli Flow
       env:
         KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN_2 }}
-      run: kosli create flow cli --description "CLI change and release process" --template-file main-flow-template.yml
+      run: kosli create flow cli 
+           --description "CLI change and release process" 
+           --template-file main-flow-template.yml
+           --org kosli-public
 
     - name: Init Kosli Trail
       env:
         KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN_2 }}
-      run: kosli begin trail ${{needs.pre-build.outputs.trail_name}} --flow cli --template-file ${{needs.pre-build.outputs.trail_template_file}}
+      run: kosli begin trail ${{needs.pre-build.outputs.trail_name}} 
+           --flow cli 
+           --template-file ${{needs.pre-build.outputs.trail_template_file}}
+           --org kosli-public
 
   test:
     needs: [pre-build]
@@ -82,6 +88,7 @@ jobs:
       slack_webhook: ${{ secrets.MERKELY_SLACK_CI_FAILURES_WEBHOOK }}
       slack_channel: ${{ secrets.MERKELY_SLACK_CI_FAILURES_CHANNEL }}
       snyk_token: ${{ secrets.SNYK_TOKEN }}
+      kosli_api_token: ${{ secrets.KOSLI_API_TOKEN_2 }}
 
   docker:
     needs: [pre-build, test]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,12 @@ jobs:
 
     - uses: actions/checkout@v4
 
+    - name: setup-kosli-cli
+      uses: kosli-dev/setup-cli-action@v2
+      with:
+        version:
+          ${{ vars.KOSLI_CLI_VERSION }}
+
     - name: Update Kosli Flow
       env:
         KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN_2 }}
@@ -74,7 +80,8 @@ jobs:
       bitbucket_password: ${{ secrets.KOSLI_BITBUCKET_PASSWORD }}
       jira_api_token: ${{ secrets.KOSLI_JIRA_API_TOKEN }}
       slack_webhook: ${{ secrets.MERKELY_SLACK_CI_FAILURES_WEBHOOK }}
-      slack_channel: ${{ secrets.MERKELY_SLACK_CI_FAILURES_CHANNEL }} 
+      slack_channel: ${{ secrets.MERKELY_SLACK_CI_FAILURES_CHANNEL }}
+      snyk_token: ${{ secrets.SNYK_TOKEN }}
 
   docker:
     needs: [pre-build, test]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         echo "TAG=${TAG}" >> ${GITHUB_ENV}
         echo "tag=$TAG" >> $GITHUB_OUTPUT
 
-        if [ -n "${GITHUB_REF##refs/tags/}" ]; then
+        if [ "${GITHUB_REF}" == refs/tags/* ]; then
           TRAIL_NAME=${GITHUB_REF##refs/tags/}
           TRAIL_TEMPLATE_FILE=release-flow-template.yml
         else

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       tag: ${{ steps.prep.outputs.tag }}
+      trail_name: ${{ steps.prep.outputs.trail_name }}
+      trail_template_file: ${{ steps.prep.outputs.trail_template_file }}
     steps:
 
     - uses: actions/checkout@v4
@@ -24,13 +26,46 @@ jobs:
         echo "TAG=${TAG}" >> ${GITHUB_ENV}
         echo "tag=$TAG" >> $GITHUB_OUTPUT
 
+        if [ -n "${GITHUB_REF##refs/tags/}" ]; then
+          TRAIL_NAME=${GITHUB_REF##refs/tags/}
+          TRAIL_TEMPLATE_FILE=release-flow-template.yml
+        else
+          TRAIL_NAME=$(echo $GITHUB_SHA | head -c 7)
+          TRAIL_TEMPLATE_FILE=main-flow-template.yml
+        fi
+        echo "TRAIL_NAME=${TRAIL_NAME}" >> $GITHUB_ENV
+        echo "trail_name=$TRAIL_NAME" >> $GITHUB_OUTPUT
+
+        echo "TRAIL_TEMPLATE_FILE=${TRAIL_TEMPLATE_FILE}" >> $GITHUB_ENV
+        echo "trail_template_file=$TRAIL_TEMPLATE_FILE" >> $GITHUB_OUTPUT
+
+
+  init-kosli:
+    runs-on: ubuntu-20.04
+    needs: [pre-build]
+    steps:
+
+    - uses: actions/checkout@v4
+
+    - name: Update Kosli Flow
+      env:
+        KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN_2 }}
+      run: kosli create flow cli --description "CLI change and release process" --template-file main-flow-template.yml
+
+    - name: Init Kosli Trail
+      env:
+        KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN_2 }}
+      run: kosli begin trail ${{needs.pre-build.outputs.trail_name}} --flow cli --template-file ${{needs.pre-build.outputs.trail_template_file}}
+
   test:
     needs: [pre-build]
     if: ${{ github.ref != 'refs/heads/prod' }}
-    uses: kosli-dev/cli/.github/workflows/test.yml@main
+    uses: kosli-dev/cli/.github/workflows/test.yml@use-trails
     with:
       AWS_ACCOUNT_ID: 772819027869
       AWS_REGION: eu-central-1
+      TRAIL_NAME: ${{ needs.pre-build.outputs.trail_name }}
+      KOSLI_ORG: kosli-public
     secrets:
       github_access_token: ${{ secrets.KOSLI_GITHUB_TOKEN }}
       gitlab_access_token: ${{ secrets.KOSLI_GITLAB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
 
     - name: Update Kosli Flow
       env:
-        KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN_2 }}
+        KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN }}
       run: kosli create flow cli 
            --description "CLI change and release process" 
            --template-file main-flow-template.yml
@@ -67,7 +67,7 @@ jobs:
 
     - name: Init Kosli Trail
       env:
-        KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN_2 }}
+        KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN }}
       run: kosli begin trail ${{needs.pre-build.outputs.trail_name}} 
            --flow cli 
            --template-file ${{needs.pre-build.outputs.trail_template_file}}
@@ -76,7 +76,7 @@ jobs:
     - name: Report pull-request attestation to Kosli
       if: ${{ github.ref == 'refs/heads/main' }}
       env:
-        KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN_2 }}
+        KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN }}
       run:
         kosli attest pullrequest github
           --flow cli
@@ -88,7 +88,7 @@ jobs:
   test:
     needs: [pre-build]
     if: ${{ github.ref != 'refs/heads/prod' }}
-    uses: kosli-dev/cli/.github/workflows/test.yml@use-trails
+    uses: kosli-dev/cli/.github/workflows/test.yml@main
     with:
       AWS_ACCOUNT_ID: 772819027869
       AWS_REGION: eu-central-1
@@ -104,12 +104,12 @@ jobs:
       slack_webhook: ${{ secrets.MERKELY_SLACK_CI_FAILURES_WEBHOOK }}
       slack_channel: ${{ secrets.MERKELY_SLACK_CI_FAILURES_CHANNEL }}
       snyk_token: ${{ secrets.SNYK_TOKEN }}
-      kosli_api_token: ${{ secrets.KOSLI_API_TOKEN_2 }}
+      kosli_api_token: ${{ secrets.KOSLI_API_TOKEN }}
 
   docker:
     needs: [pre-build, test]
     if: ${{ github.ref != 'refs/heads/prod' }}
-    uses: kosli-dev/cli/.github/workflows/docker.yml@use-trails
+    uses: kosli-dev/cli/.github/workflows/docker.yml@main
     with:
       tag: ${{ needs.pre-build.outputs.tag }}
       platforms: linux/amd64
@@ -120,5 +120,5 @@ jobs:
       slack_channel: ${{ secrets.MERKELY_SLACK_CI_FAILURES_CHANNEL }} 
       ghcr_user: ${{ secrets.GHCR_USER }}
       ghcr_token: ${{ secrets.GHCR_TOKEN }}
-      kosli_api_token: ${{ secrets.KOSLI_API_TOKEN_2 }}
+      kosli_api_token: ${{ secrets.KOSLI_API_TOKEN }}
       snyk_token: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
         go-version: '1.22.0'
     
     - name: Run golangci-lint
+      id: lint
       uses: golangci/golangci-lint-action@v4
       with:
         version: latest
@@ -64,9 +65,9 @@ jobs:
       run: kosli attest generic 
            --name lint 
            --flow cli 
-           --trail ${{ inputs.TRAIL_NAME }} 
-           --compliant=${{ success() }} 
+           --trail ${{ inputs.TRAIL_NAME }}  
            --org ${{ inputs.KOSLI_ORG }}
+           --compliance ${{ steps.lint.outcome == 'success' }} 
 
     - name: Slack Notification on Failure
       if: ${{ failure() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,8 @@ on:
         required: true 
       snyk_token:
         required: true
+      kosli_api_toke:
+        required: true
 
 
 jobs:
@@ -46,8 +48,6 @@ jobs:
     steps:
 
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
     
     - uses: actions/setup-go@v5
       with:
@@ -69,13 +69,13 @@ jobs:
     - name: Report lint to Kosli
       if:  ${{ (success() || failure()) }}
       env:
-        KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN_2 }}
+        KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
       run: kosli attest generic 
            --name lint 
            --flow cli 
            --trail ${{ inputs.TRAIL_NAME }}  
            --org ${{ inputs.KOSLI_ORG }}
-           --compliance ${{ steps.lint.outcome == 'success' }} 
+           --compliant=${{ steps.lint.outcome == 'success' }} 
 
     - name: Slack Notification on Failure
       if: ${{ failure() }}
@@ -96,8 +96,6 @@ jobs:
     steps:
       
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
     
     - uses: actions/setup-go@v5
       with:
@@ -138,7 +136,7 @@ jobs:
     - name: Report test to Kosli
       if:  ${{ (success() || failure()) }}
       env:
-        KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN_2 }}
+        KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
       run: kosli attest junit 
            --name test 
            --flow cli 
@@ -167,8 +165,6 @@ jobs:
     steps:
 
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 1
 
     - name: setup Snyk
       uses: snyk/actions/setup@master
@@ -188,7 +184,7 @@ jobs:
     - name: Report Snyk Code to Kosli
       if:  ${{ (success() || failure()) }}
       env:
-        KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN_2 }}
+        KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
       run: kosli attest snyk 
            --name snyk-code 
            --flow cli 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,8 @@ jobs:
     steps:
       
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # needed for some tests referencing older commits
     
     - uses: actions/setup-go@v5
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ on:
         required: true 
       snyk_token:
         required: true
-      kosli_api_toke:
+      kosli_api_token:
         required: true
 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,9 @@ on:
       bitbucket_password:
         required: true
       jira_api_token:
-        required: true      
+        required: true 
+      snyk_token:
+        required: true
 
 
 jobs:
@@ -50,6 +52,12 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version: '1.22.0'
+
+    - name: setup-kosli-cli
+      uses: kosli-dev/setup-cli-action@v2
+      with:
+        version:
+          ${{ vars.KOSLI_CLI_VERSION }}
     
     - name: Run golangci-lint
       id: lint
@@ -94,6 +102,12 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version: '1.22.0'
+
+    - name: setup-kosli-cli
+      uses: kosli-dev/setup-cli-action@v2
+      with:
+        version:
+          ${{ vars.KOSLI_CLI_VERSION }}
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
         args: --timeout=5m -v
 
     - name: Report lint to Kosli
-      if:  ${{ (success() || failure()) }}
+      if:  ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) &&  (success() || failure()) }}
       env:
         KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
       run: kosli attest generic 
@@ -136,7 +136,7 @@ jobs:
         make test_integration_full
 
     - name: Report test to Kosli
-      if:  ${{ (success() || failure()) }}
+      if:  ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) &&  (success() || failure()) }}
       env:
         KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
       run: kosli attest junit 
@@ -184,7 +184,7 @@ jobs:
           snyk test --sarif --policy-path=.snyk  --sarif-file-output=snyk-code.json --prune-repeated-subdependencies
     
     - name: Report Snyk Code to Kosli
-      if:  ${{ (success() || failure()) }}
+      if:  ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) &&  (success() || failure()) }}
       env:
         KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
       run: kosli attest snyk 
@@ -203,5 +203,3 @@ jobs:
         SLACK_TITLE: Snyk Code Failed in CLI repository
         SLACK_USERNAME: GithubActions
         SLACK_WEBHOOK: ${{ secrets.slack_webhook }}
-
-# (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,12 @@ on:
       AWS_REGION:
         required: true
         type: string
+      TRAIL_NAME:
+        required: true
+        type: string
+      KOSLI_ORG:
+        required: true
+        type: string
     secrets:
       slack_channel:
         required: true
@@ -29,8 +35,8 @@ on:
 
 
 jobs:
-  test:
-    name: Lint & Test
+  lint:
+    name: Lint
     runs-on: ubuntu-20.04
     permissions:
       id-token: write
@@ -50,6 +56,43 @@ jobs:
       with:
         version: latest
         args: --timeout=5m -v
+
+    - name: Report lint to Kosli
+      if:  ${{ (success() || failure()) }}
+      env:
+        KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN_2 }}
+      run: kosli attest generic 
+           --name lint 
+           --flow cli 
+           --trail ${{ inputs.TRAIL_NAME }} 
+           --compliant=${{ success() }} 
+           --org ${{ inputs.KOSLI_ORG }}
+
+    - name: Slack Notification on Failure
+      if: ${{ failure() }}
+      uses: rtCamp/action-slack-notify@v2
+      env:
+        SLACK_CHANNEL: ${{ secrets.slack_channel }}
+        SLACK_COLOR: ${{ job.status }}
+        SLACK_TITLE: Lint Failed in CLI repository
+        SLACK_USERNAME: GithubActions
+        SLACK_WEBHOOK: ${{ secrets.slack_webhook }} 
+
+  test:
+    name: Test
+    runs-on: ubuntu-20.04
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '1.22.0'
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
@@ -77,6 +120,16 @@ jobs:
         git config --global user.email johndoe@example.com
         make test_integration_full
 
+    - name: Report test to Kosli
+      if:  ${{ (success() || failure()) }}
+      env:
+        KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN_2 }}
+      run: kosli attest junit 
+           --name test 
+           --flow cli 
+           --trail ${{ inputs.TRAIL_NAME }} 
+           --org ${{ inputs.KOSLI_ORG }}
+
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4
 
@@ -86,6 +139,56 @@ jobs:
       env:
         SLACK_CHANNEL: ${{ secrets.slack_channel }}
         SLACK_COLOR: ${{ job.status }}
-        SLACK_TITLE: Test & Lint Failed in CLI repository
+        SLACK_TITLE: Test Failed in CLI repository
         SLACK_USERNAME: GithubActions
-        SLACK_WEBHOOK: ${{ secrets.slack_webhook }} 
+        SLACK_WEBHOOK: ${{ secrets.slack_webhook }}
+
+  snyk-code:
+    name: Snyk Code
+    runs-on: ubuntu-20.04
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+
+    - name: setup Snyk
+      uses: snyk/actions/setup@master
+
+    - name: setup-kosli-cli
+      uses: kosli-dev/setup-cli-action@v2
+      with:
+        version:
+          ${{ vars.KOSLI_CLI_VERSION }}
+
+    - name: Run Snyk to check source code for vulnerabilities
+      env:
+        SNYK_TOKEN: ${{ secrets.snyk_token }}
+      run: 
+          snyk test --sarif --policy-path=.snyk  --sarif-file-output=snyk-code.json --prune-repeated-subdependencies
+    
+    - name: Report Snyk Code to Kosli
+      if:  ${{ (success() || failure()) }}
+      env:
+        KOSLI_API_TOKEN: ${{ secrets.KOSLI_API_TOKEN_2 }}
+      run: kosli attest snyk 
+           --name snyk-code 
+           --flow cli 
+           --trail ${{ inputs.TRAIL_NAME }} 
+           --scan-results  snyk-code.json
+           --org ${{ inputs.KOSLI_ORG }}
+    
+    - name: Slack Notification on Failure
+      if: ${{ failure() }}
+      uses: rtCamp/action-slack-notify@v2
+      env:
+        SLACK_CHANNEL: ${{ secrets.slack_channel }}
+        SLACK_COLOR: ${{ job.status }}
+        SLACK_TITLE: Snyk Code Failed in CLI repository
+        SLACK_USERNAME: GithubActions
+        SLACK_WEBHOOK: ${{ secrets.slack_webhook }}
+
+# (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && 

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ docs.kosli.com/.netlify
 # keep it uncommented on main
 docs.kosli.com/assets/metadata.json
 tmp/
+junit.xml

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ test_integration: deps vet ensure_network test_setup ## Run tests except the too
 
 test_integration_full: deps vet ensure_network test_setup ## Run all tests
 	@mv ~/.kosli.yml ~/.kosli-renamed.yml || true
-	@export KOSLI_TESTS=true && $(GOTESTSUM) -- -p=8 -coverprofile=cover.out ./...
+	@export KOSLI_TESTS=true && $(GOTESTSUM) --junitfile junit.xml -- -p=8 -coverprofile=cover.out ./...
 	@go tool cover -func=cover.out
 	@mv ~/.kosli-renamed.yml ~/.kosli.yml || true
 

--- a/main-flow-template.yml
+++ b/main-flow-template.yml
@@ -14,3 +14,5 @@ trail:
     attestations:
     - name: snyk-container
       type: snyk
+    - name: smoke-test
+      type: generic

--- a/main-flow-template.yml
+++ b/main-flow-template.yml
@@ -16,3 +16,5 @@ trail:
       type: snyk
     - name: smoke-test
       type: generic
+    - name: sbom
+      type: generic

--- a/main-flow-template.yml
+++ b/main-flow-template.yml
@@ -1,0 +1,16 @@
+version: 1
+trail:
+  attestations:
+  - name: pr
+    type: pull-request
+  - name: lint
+    type: generic
+  - name: test
+    type: junit
+  - name: snyk-code
+    type: snyk
+  artifacts:
+  - name: cli-docker
+    attestations:
+    - name: snyk-container
+      type: snyk

--- a/main-flow-template.yml
+++ b/main-flow-template.yml
@@ -2,7 +2,7 @@ version: 1
 trail:
   attestations:
   - name: pr
-    type: pull-request
+    type: pull_request
   - name: lint
     type: generic
   - name: test

--- a/release-flow-template.yml
+++ b/release-flow-template.yml
@@ -14,6 +14,8 @@ trail:
       type: snyk
     - name: smoke-test
       type: generic
+    - name: sbom
+      type: generic
 
   - name: cli-docker
   - name: cli-darwin

--- a/release-flow-template.yml
+++ b/release-flow-template.yml
@@ -1,0 +1,20 @@
+version: 1
+trail:
+  attestations:
+  - name: lint
+    type: generic
+  - name: test
+    type: junit
+  - name: snyk-code
+    type: snyk
+  artifacts:
+  - name: cli-docker
+    attestations:
+    - name: snyk-container
+      type: snyk
+
+  - name: cli-docker
+  - name: cli-darwin
+  - name: cli-windows
+  - name: cli-linux
+

--- a/release-flow-template.yml
+++ b/release-flow-template.yml
@@ -12,6 +12,8 @@ trail:
     attestations:
     - name: snyk-container
       type: snyk
+    - name: smoke-test
+      type: generic
 
   - name: cli-docker
   - name: cli-darwin


### PR DESCRIPTION
related to kosli-dev/server#1867

- parallelize CI tasks where possible
- use Github attestations for the docker image artifact
- generate SBOM for the docker image artifact
- start tracking CLI in a new Flow with trails
- record builds on main

results look like: https://app.kosli.com/kosli-public/flows/cli/trails/feb74ee