### PR TITLE
Update golint action version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
     
     - name: Run golangci-lint
       id: lint
-      uses: golangci/golangci-lint-action@v4
+      uses: golangci/golangci-lint-action@v6
       with:
         version: latest
         args: --timeout=5m -v


### PR DESCRIPTION
We are getting errors during linting. This newer version handles package cache differently, fixing these:

![image](https://github.com/kosli-dev/cli/assets/349/36c37136-a3d6-47be-8301-6d4d17f2c1e2)
