### PR TITLE
improve docs/help and error messages

### DIFF
--- a/cmd/kosli/attestGeneric.go
+++ b/cmd/kosli/attestGeneric.go
@@ -22,8 +22,7 @@ type attestGenericOptions struct {
 
 const attestGenericShortDesc = `Report a generic attestation to an artifact or a trail in a Kosli flow.  `
 
-const attestGenericLongDesc = attestGenericShortDesc + `
-` + fingerprintDesc
+const attestGenericLongDesc = attestGenericShortDesc + attestationBindingDesc
 
 const attestGenericExample = `
 # report a generic attestation about a pre-built docker artifact (kosli calculates the fingerprint):

--- a/cmd/kosli/attestGeneric.go
+++ b/cmd/kosli/attestGeneric.go
@@ -158,5 +158,5 @@ func (o *attestGenericOptions) run(args []string) error {
 	if err == nil && !global.DryRun {
 		logger.Info("generic attestation '%s' is reported to trail: %s", o.payload.AttestationName, o.trailName)
 	}
-	return err
+	return wrapAttestationError(err)
 }

--- a/cmd/kosli/attestJira.go
+++ b/cmd/kosli/attestJira.go
@@ -253,5 +253,5 @@ func (o *attestJiraOptions) run(args []string) error {
 	if issueFoundCount != len(issueIDs) && o.assert {
 		return fmt.Errorf("missing Jira issues from references found in commit message or branch name%s", issueLog)
 	}
-	return err
+	return wrapAttestationError(err)
 }

--- a/cmd/kosli/attestJira.go
+++ b/cmd/kosli/attestJira.go
@@ -41,7 +41,7 @@ The attestation is reported in all cases, and its compliance status depends on r
 existing Jira issues.  
 If you have wrong Jira credentials or wrong Jira-base-url it will be reported as non existing Jira issue.
 This is because Jira returns same 404 error code in all cases.
-` + fingerprintDesc
+` + attestationBindingDesc
 
 const attestJiraExample = `
 # report a jira attestation about a pre-built docker artifact (kosli calculates the fingerprint):

--- a/cmd/kosli/attestJunit.go
+++ b/cmd/kosli/attestJunit.go
@@ -24,8 +24,7 @@ type attestJunitOptions struct {
 
 const attestJunitShortDesc = `Report a junit attestation to an artifact or a trail in a Kosli flow.  `
 
-const attestJunitLongDesc = attestJunitShortDesc + `
-` + fingerprintDesc
+const attestJunitLongDesc = attestJunitShortDesc + attestationBindingDesc
 
 const attestJunitExample = `
 # report a junit attestation about a pre-built docker artifact (kosli calculates the fingerprint):

--- a/cmd/kosli/attestJunit.go
+++ b/cmd/kosli/attestJunit.go
@@ -171,5 +171,5 @@ func (o *attestJunitOptions) run(args []string) error {
 	if err == nil && !global.DryRun {
 		logger.Info("junit attestation '%s' is reported to trail: %s", o.payload.AttestationName, o.trailName)
 	}
-	return err
+	return wrapAttestationError(err)
 }

--- a/cmd/kosli/attestPRAzure.go
+++ b/cmd/kosli/attestPRAzure.go
@@ -11,7 +11,7 @@ const attestPRAzureShortDesc = `Report an Azure Devops pull request attestation 
 
 const attestPRAzureLongDesc = attestPRAzureShortDesc + `
 It checks if a pull request exists for the artifact (based on its git commit) and reports the pull-request attestation to the artifact in Kosli.
-` + fingerprintDesc
+` + attestationBindingDesc
 
 const attestPRAzureExample = `
 # report an Azure Devops pull request attestation about a pre-built docker artifact (kosli calculates the fingerprint):

--- a/cmd/kosli/attestPRBitbucket.go
+++ b/cmd/kosli/attestPRBitbucket.go
@@ -11,7 +11,7 @@ const attestPRBitbucketShortDesc = `Report a Bitbucket pull request attestation 
 
 const attestPRBitbucketLongDesc = attestPRBitbucketShortDesc + `
 It checks if a pull request exists for a given merge commit and reports the pull-request attestation to Kosli.
-If the attestation is attached to an artifact, ` + fingerprintDesc
+` + attestationBindingDesc
 
 const attestPRBitbucketExample = `
 # report a Bitbucket pull request attestation about a pre-built docker artifact (kosli calculates the fingerprint):

--- a/cmd/kosli/attestPRGithub.go
+++ b/cmd/kosli/attestPRGithub.go
@@ -11,7 +11,7 @@ const attestPRGithubShortDesc = `Report a Github pull request attestation to an 
 
 const attestPRGithubLongDesc = attestPRGithubShortDesc + `
 It checks if a pull request exists for a given merge commit and reports the pull-request attestation to Kosli.
-If the attestation is attached to an artifact, ` + fingerprintDesc
+` + attestationBindingDesc
 
 const attestPRGithubExample = `
 # report a Github pull request attestation about a pre-built docker artifact (kosli calculates the fingerprint):

--- a/cmd/kosli/attestPRGitlab.go
+++ b/cmd/kosli/attestPRGitlab.go
@@ -11,7 +11,7 @@ const attestPRGitlabShortDesc = `Report a Gitlab merge request attestation to an
 
 const attestPRGitlabLongDesc = attestPRGitlabShortDesc + `
 It checks if a merge request exists for a given merge commit and reports the merge request attestation to Kosli.
-If the attestation is attached to an artifact, ` + fingerprintDesc
+` + attestationBindingDesc
 
 const attestPRGitlabExample = `
 # report a Gitlab merge request attestation about a pre-built docker artifact (kosli calculates the fingerprint):

--- a/cmd/kosli/attestSnyk.go
+++ b/cmd/kosli/attestSnyk.go
@@ -185,5 +185,5 @@ func (o *attestSnykOptions) run(args []string) error {
 	if err == nil && !global.DryRun {
 		logger.Info("snyk attestation '%s' is reported to trail: %s", o.payload.AttestationName, o.trailName)
 	}
-	return err
+	return wrapAttestationError(err)
 }

--- a/cmd/kosli/attestSnyk.go
+++ b/cmd/kosli/attestSnyk.go
@@ -33,8 +33,7 @@ The ^--scan-results^ .json file is analyzed and a summary of the scan results ar
 
 By default, the ^--scan-results^ .json file is also uploaded to Kosli's evidence vault.
 You can disable that by setting ^--upload-results=false^
-
-` + fingerprintDesc
+` + attestationBindingDesc
 
 const attestSnykExample = `
 # report a snyk attestation about a pre-built docker artifact (kosli calculates the fingerprint):

--- a/cmd/kosli/attestation.go
+++ b/cmd/kosli/attestation.go
@@ -160,3 +160,11 @@ func newAttestationForm(payload interface{}, attachments []string) (
 
 	return form, cleanupNeeded, evidencePath, nil
 }
+
+func wrapAttestationError(err error) error {
+	if err != nil {
+		return fmt.Errorf(strings.Replace(err.Error(), "requires at least one of: artifact_fingerprint or git_commit_info.",
+			"requires at least one of: specifying the fingerprint (either by calculating it using the artifact name/path and --artifact-type, or by providing it using --fingerprint) or providing --commit (requires an available git repo to access commit details)", 1))
+	}
+	return err
+}

--- a/cmd/kosli/begin.go
+++ b/cmd/kosli/begin.go
@@ -10,9 +10,10 @@ const beginDesc = `All Kosli begin commands.`
 
 func newBeginCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "begin",
-		Short: beginDesc,
-		Long:  beginDesc,
+		Use:     "begin",
+		Aliases: []string{"start", "init"},
+		Short:   beginDesc,
+		Long:    beginDesc,
 	}
 
 	// Add subcommands

--- a/cmd/kosli/pullrequest.go
+++ b/cmd/kosli/pullrequest.go
@@ -155,7 +155,7 @@ func (o *attestPROptions) run(args []string) error {
 	if len(pullRequestsEvidence) == 0 && o.assert && !global.DryRun {
 		return fmt.Errorf("assert failed: no %s found for the given commit: %s", label, o.payload.Commit.Sha1)
 	}
-	return err
+	return wrapAttestationError(err)
 }
 
 type pullRequestCommitOptions struct {

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -40,8 +40,15 @@ const (
 	credentialsStoreKeySecretName = "kosli-encryption-key"
 
 	// the following constants are used in the docs/help
-	fingerprintDesc = "The artifact SHA256 fingerprint is calculated (based on the ^--artifact-type^ flag) or can be provided directly (with the ^--fingerprint^ flag)."
-	awsAuthDesc     = `
+	fingerprintDesc        = "The artifact SHA256 fingerprint is calculated (based on the ^--artifact-type^ flag and the artifact name/path argument) or can be provided directly (with the ^--fingerprint^ flag)."
+	attestationBindingDesc = `
+
+The attestation can be bound to a trail using the trail name.
+
+If the attestation is for an artifact, the attestation can be bound to the artifact using one of two ways:
+- using the artifact's SHA256 fingerprint which is calculated (based on the ^--artifact-type^ flag and the artifact name/path argument) or can be provided directly (with the ^--fingerprint^ flag).
+- using the artifact's name in the flow yaml template and the git commit from which the artifact is/will be created. Useful when reporting an attestation before creating/reporting the artifact.`
+	awsAuthDesc = `
 
 To authenticate to AWS, you can either:  
   1) provide the AWS static credentials via flags or by exporting the equivalent KOSLI env vars (e.g. KOSLI_AWS_KEY_ID)  
@@ -178,8 +185,8 @@ The service principal needs to have the following permissions:
 	intervalFlag                         = "[optional] Expression to define specified snapshots range."
 	showUnchangedArtifactsFlag           = "[defaulted] Show the unchanged artifacts present in both snapshots within the diff output."
 	approverFlag                         = "[optional] The user approving an approval."
-	attestationFingerprintFlag           = "[optional] The SHA256 fingerprint of the artifact to attach the attestation to."
-	attestationCommitFlag                = "[optional] The git commit associated to the attestation. (defaulted in some CIs: https://docs.kosli.com/ci-defaults )."
+	attestationFingerprintFlag           = "[conditional] The SHA256 fingerprint of the artifact to attach the attestation to. Only required if the attestation is for an artifact and --artifact-type and artifact name/path are not used."
+	attestationCommitFlag                = "[conditional] The git commit for which the attestation is associated to. Becomes required when reporting an attestation for an artifact before reporting it to Kosli. (defaulted in some CIs: https://docs.kosli.com/ci-defaults )."
 	attestationOriginUrlFlag             = "[optional] The url pointing to where the attestation came from or is related. (defaulted to the CI url in some CIs: https://docs.kosli.com/ci-defaults )."
 	attestationNameFlag                  = "The name of the attestation as declared in the flow or trail yaml template."
 	attestationCompliantFlag             = "[defaulted] Whether the attestation is compliant or not. A boolean flag https://docs.kosli.com/faq/#boolean-flags"

--- a/cmd/kosli/testdata/output/docs/snyk.md
+++ b/cmd/kosli/testdata/output/docs/snyk.md
@@ -17,7 +17,12 @@ The `--scan-results` .json file is analyzed and a summary of the scan results ar
 By default, the `--scan-results` .json file is also uploaded to Kosli's evidence vault.
 You can disable that by setting `--upload-results=false`
 
-The artifact SHA256 fingerprint is calculated (based on the `--artifact-type` flag) or can be provided directly (with the `--fingerprint` flag).
+
+The attestation can be bound to a trail using the trail name.
+
+If the attestation is for an artifact, the attestation can be bound to the artifact using one of two ways:
+- using the artifact's SHA256 fingerprint which is calculated (based on the `--artifact-type` flag and the artifact name/path argument) or can be provided directly (with the `--fingerprint` flag).
+- using the artifact's name in the flow yaml template and the git commit from which the artifact is/will be created. Useful when reporting an attestation before creating/reporting the artifact.
 
 ```shell
 snyk [IMAGE-NAME | FILE-PATH | DIR-PATH] [flags]
@@ -29,13 +34,13 @@ snyk [IMAGE-NAME | FILE-PATH | DIR-PATH] [flags]
 |        --annotate stringToString  |  [optional] Annotate the attestation with data using key=value.  |
 |    -t, --artifact-type string  |  [conditional] The type of the artifact to calculate its SHA256 fingerprint. One of: [docker, file, dir]. Only required if you don't specify '--fingerprint'.  |
 |        --attachments strings  |  [optional] The comma-separated list of paths of attachments for the reported attestation. Attachments can be files or directories. All attachments are compressed and uploaded to Kosli's evidence vault.  |
-|    -g, --commit string  |  [optional] The git commit associated to the attestation. (defaulted in some CIs: https://docs.kosli.com/ci-defaults ).  |
+|    -g, --commit string  |  [conditional] The git commit for which the attestation is associated to. Becomes required when reporting an attestation for an artifact before reporting it to Kosli. (defaulted in some CIs: https://docs.kosli.com/ci-defaults ).  |
 |        --description string  |  [optional] attestation description  |
 |    -D, --dry-run  |  [optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors.  |
 |    -x, --exclude strings  |  [optional] The comma separated list of directories and files to exclude from fingerprinting. Can take glob patterns. Only applicable for --artifact-type dir.  |
 |        --external-fingerprint stringToString  |  [optional] A SHA256 fingerprint of an external attachment represented by --external-url. The format is label=fingerprint (labels cannot contain '.' or '='). This flag can be set multiple times. There must be an external url with a matching label for each external fingerprint.  |
 |        --external-url stringToString  |  [optional] Add labeled reference URL for an external resource. The format is label=url (labels cannot contain '.' or '='). This flag can be set multiple times. If the resource is a file or dir, you can optionally add its fingerprint via --external-fingerprint  |
-|    -F, --fingerprint string  |  [optional] The SHA256 fingerprint of the artifact to attach the attestation to.  |
+|    -F, --fingerprint string  |  [conditional] The SHA256 fingerprint of the artifact to attach the attestation to. Only required if the attestation is for an artifact and --artifact-type and artifact name/path are not used.  |
 |    -f, --flow string  |  The Kosli flow name.  |
 |    -h, --help  |  help for snyk  |
 |    -n, --name string  |  The name of the attestation as declared in the flow or trail yaml template.  |


### PR DESCRIPTION
- convert raw API error for attestations targeting artifacts by name only. relates to kosli-dev/server#1888
- improve attestation docs #203 