### PR TITLE
Add a filesystem monitoring option for the snapshot paths command

### DIFF
--- a/bin/flyio_env_report.sh
+++ b/bin/flyio_env_report.sh
@@ -5,6 +5,8 @@ SCRIPT_NAME=flyio_env_report.sh
 USAGE="$SCRIPT_NAME [options] <protocol://hostname> <owner> <environment-name>"
 
 
+
+
 die()
 {
     echo "Error: $1" >&2

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -207,6 +207,7 @@ The service principal needs to have the following permissions:
 	setTagsFlag                          = "[optional] The key-value pairs to tag the resource with. The format is: key=value"
 	unsetTagsFlag                        = "[optional] The list of tag keys to remove from the resource."
 	pathsSpecFileFlag                    = "The path to a paths file in YAML/JSON/TOML format. Cannot be used together with --path ."
+	pathsWatchFlag                       = "[optional] Watch the filesystem for changes and report snapshots of artifacts running in specific filesystem paths to Kosli."
 	snapshotPathPathFlag                 = "The base path for the artifact to snapshot."
 	snapshotPathExcludeFlag              = "[optional] The comma-separated list of literal paths or glob patterns to exclude when fingerprinting the artifact."
 	snapshotPathArtifactNameFlag         = "The reported name of the artifact."

--- a/cmd/kosli/snapshotPaths.go
+++ b/cmd/kosli/snapshotPaths.go
@@ -103,6 +103,11 @@ func (o *snapshotPathsOptions) run(args []string) error {
 
 	// snapshot the paths
 	if o.watch {
+		err := reportArtifacts(ps, url, envName)
+		if err != nil {
+			return err
+		}
+
 		watch_for_changes(ps, url, envName)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.31.0
 	github.com/aws/smithy-go v1.13.5
 	github.com/docker/docker v24.0.9+incompatible
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/go-git/go-git/v5 v5.11.0
 	github.com/go-playground/validator/v10 v10.19.0
@@ -91,7 +92,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.2.0 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect

--- a/kosli-paths.yaml
+++ b/kosli-paths.yaml
@@ -1,0 +1,4 @@
+version: 1
+artifacts:
+  service-a:
+    path: bin/

--- a/kosli-paths.yaml
+++ b/kosli-paths.yaml
@@ -2,3 +2,5 @@ version: 1
 artifacts:
   service-a:
     path: bin/
+  service-b:
+    path: hack/


### PR DESCRIPTION
This PR adds a feature to the `kosli snapshot paths` command that uses a select poll to wait for filesystem changes to send snapshots.  This will be mostly used in demos.