### PR TITLE
Remove leading dollar from all bash fragments

### DIFF
--- a/docs.kosli.com/content/tutorials/attest_snyk.md
+++ b/docs.kosli.com/content/tutorials/attest_snyk.md
@@ -28,13 +28,13 @@ To follow the steps in this tutorial, you need to:
 * [Get a Kosli API token](/getting_started/service-accounts/).
 * Set the `KOSLI_ORG` environment variable to your personal org name and `KOSLI_API_TOKEN` to your token:
   ```shell {.command}
-  $ export KOSLI_ORG=<your-personal-kosli-org-name>
-  $ export KOSLI_API_TOKEN=<your-api-token>
+  export KOSLI_ORG=<your-personal-kosli-org-name>
+  export KOSLI_API_TOKEN=<your-api-token>
   ```
 * Clone the Kosli CLI git repo
   ```shell {.command}
-  $ git clone https://github.com/kosli-dev/cli.git 
-  $ cd cli
+  git clone https://github.com/kosli-dev/cli.git 
+  cd cli
   ```
 
 ## Creating a Flow and Trail
@@ -42,7 +42,7 @@ To follow the steps in this tutorial, you need to:
 We will start by creating a flow in Kosli to contain Trails and Artifacts for this demo.
 
 ```shell {.command}
-$ kosli create flow snyk-demo --use-empty-template
+kosli create flow snyk-demo --use-empty-template
 ```
 
 {{<hint info>}}
@@ -52,7 +52,7 @@ $ kosli create flow snyk-demo --use-empty-template
 Then, we can start a trail to bind our snyk attestations to.
 
 ```shell {.command}
-$ kosli begin trail test-1 --flow snyk-demo
+kosli begin trail test-1 --flow snyk-demo
 ```
 
 Now we can start running Snyk scans and attest them to this trail.
@@ -68,9 +68,9 @@ After each attestation in the sections below, you can navigate to:
 
 You can run a snyk opens source scan and report it to Kosli as follows:
 ```shell {.command}
-$ snyk test --sarif-file-output=os.json
+snyk test --sarif-file-output=os.json
 
-$ kosli attest snyk --flow snyk-demo --trail test-1 --name open-source-scan --scan-results os.json --commit HEAD
+kosli attest snyk --flow snyk-demo --trail test-1 --name open-source-scan --scan-results os.json --commit HEAD
 ```
 
 {{<hint info>}}
@@ -84,9 +84,9 @@ $ kosli attest snyk --flow snyk-demo --trail test-1 --name open-source-scan --sc
 
 You can run a snyk code scan and report it to Kosli as follows:
 ```shell {.command}
-$ snyk code test --sarif-file-output=code.json
+snyk code test --sarif-file-output=code.json
 
-$ kosli attest snyk --flow snyk-demo --trail test-1 --name code-scan --scan-results code.json --commit HEAD
+kosli attest snyk --flow snyk-demo --trail test-1 --name code-scan --scan-results code.json --commit HEAD
 ```
 
 ## Snyk Container scan
@@ -96,10 +96,10 @@ $ kosli attest snyk --flow snyk-demo --trail test-1 --name code-scan --scan-resu
 You can run a snyk container scan and report it to Kosli as follows:
 ```shell {.command}
 # pull the cli docker image before scanning it
-$ docker pull ghcr.io/kosli-dev/cli:v2.8.3
-$ snyk container test ghcr.io/kosli-dev/cli:v2.8.3  --file=Dockerfile --sarif-file-output=container.json
+docker pull ghcr.io/kosli-dev/cli:v2.8.3
+snyk container test ghcr.io/kosli-dev/cli:v2.8.3  --file=Dockerfile --sarif-file-output=container.json
 
-$ kosli attest snyk --flow snyk-demo --trail test-1 --name container-scan --scan-results container.json --commit HEAD
+kosli attest snyk --flow snyk-demo --trail test-1 --name container-scan --scan-results container.json --commit HEAD
 ```
 
 ## Snyk IaC scan
@@ -108,14 +108,14 @@ $ kosli attest snyk --flow snyk-demo --trail test-1 --name container-scan --scan
 
 We can run a snyk IaC scan on the K8S reporter Helm chart and report it to Kosli as follows:
 ```shell {.command}
-$ helm template ./charts/k8s-reporter --output-dir helm \
-   --set kosliApiToken.secretName=secret \
-   --set reporterConfig.kosliEnvironmentName=foo \
-   --set reporterConfig.kosliOrg=bar
+helm template ./charts/k8s-reporter --output-dir helm \
+  --set kosliApiToken.secretName=secret \
+  --set reporterConfig.kosliEnvironmentName=foo \
+  --set reporterConfig.kosliOrg=bar
 
-$ snyk iac test helm  --sarif-file-output=helm.json
+snyk iac test helm  --sarif-file-output=helm.json
 
-$ kosli attest snyk --flow snyk-demo --trail test-1 --name helm-scan --scan-results helm.json --commit HEAD
+kosli attest snyk --flow snyk-demo --trail test-1 --name helm-scan --scan-results helm.json --commit HEAD
 ```
 
 You can refer to the [Snyk docs](https://docs.snyk.io/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac/test-your-iac-files) for more information on supported IaC configuration formats and how you can run snyk scans on them.

--- a/docs.kosli.com/content/tutorials/cli_and_http_proxy.md
+++ b/docs.kosli.com/content/tutorials/cli_and_http_proxy.md
@@ -26,13 +26,13 @@ The same steps apply for different HTTP proxies and machines, but commands will 
 1. Start Tinyproxy using docker:
 
 ```shell {.command}
-$ cat <<EOF > tinyproxy.conf
+cat <<EOF > tinyproxy.conf
 User nobody
 Group nobody
 Port 8888
 EOF
 
-$ docker run -p 8888:8888 -v $(PWD)/tinyproxy.conf:/etc/tinyproxy/tinyproxy.conf:ro kalaksi/tinyproxy
+docker run -p 8888:8888 -v $(PWD)/tinyproxy.conf:/etc/tinyproxy/tinyproxy.conf:ro kalaksi/tinyproxy
 ```
 
 
@@ -44,7 +44,7 @@ Now you have an HTTP proxy running at http://localhost:8888
 To verify if the setup works, you can run this command to list environments of the public demo org `Cyber Dojo`:
 
 ```shell {.command}
-$ kosli list envs --org cyber-dojo --http-proxy http://localhost:8888 --api-token <<your-token>>
+kosli list envs --org cyber-dojo --http-proxy http://localhost:8888 --api-token <<your-token>>
 ```
 
 Your request goes through the HTTP proxy and is then forwarded to Kosli. If successful, you should see a similar output to this:

--- a/docs.kosli.com/content/tutorials/querying_kosli.md
+++ b/docs.kosli.com/content/tutorials/querying_kosli.md
@@ -23,7 +23,7 @@ You need to:
 
 You can use `kosli search` command to find out if Kosli knows of any artifact that was build using that commit - both short and full shas are accepted:
 
-```
+```shell {.command}
 kosli search 0f5c9e1
 ```
 
@@ -54,7 +54,7 @@ The information returned by `kosli search` - like Flow, Fingerprint or History -
 
 When you search in Kosli you often need to refer to a specific flow. If you don't remember all the flows' names it is easy to list them with `kosli list flows` command:
 
-```
+```shell {.command}
 kosli list flows
 ```
 
@@ -76,7 +76,7 @@ web                     UX for practicing TDD               public
 
 And if you want to check metadata of a specific flow (like description or template) use `kosli get flow`
 
-```
+```shell {.command}
 kosli get flow creator
 ```
 
@@ -92,7 +92,7 @@ Last Deployment At:  Wed, 14 Sep 2022 10:51:43 CEST • one month ago
 
 To find the information about artifacts reported to a specific flow in Kosli use `kosli list artifacts` command
 
-```
+```shell {.command}
 kosli list artifacts --flow creator
 ```
 
@@ -115,17 +115,17 @@ The output of the command is shortened above, for readability purposes.
 The amount of artifacts may be really long and by default you can see the last 15 artifacts - the first page of the result list. You can use `-n` flag to limit the amount of artifacts displayed per page, and `--page` to select which page of the result list you want to see.
 
 E.g. to see last five artifacts you'd use:
-```
+```shell {.command}
 kosli list artifacts --flow creator -n 5
 ```
 
 And to see the next page:
-```
+```shell {.command}
 kosli list artifacts --flow creator -n 5 --page 2
 ```
 
 You can also use the `--output` flag to change the format of the response. By default the response comes in a *table* format, but you can choose to switch to *json*:
-```
+```shell {.command}
 kosli list artifacts --flow creator --output json
 ```
 ## Get artifact
@@ -137,8 +137,8 @@ OR
 
 Both are available in the output of `kosli list artifacts` command
 
-```
-# search for artifact by its fingerprint
+```shell {.command}
+# search for an artifact by its fingerprint
 kosli get artifact creator@817a72609041c51cd2a3bbbcbeb048c687677986b5a273399c6938b5e6aa1ded
 ```
 
@@ -171,9 +171,14 @@ History:
     Started running in aws-beta#265 environment    Wed, 19 Oct 2022 09:46:42 CEST
     No longer running in aws-prod#257 environment  Fri, 21 Oct 2022 11:02:28 CEST
     Started running in aws-prod#259 environment    Fri, 21 Oct 2022 11:05:28 CEST
+```
 
-# search for artifact by its commit sha
-$ kosli get artifact creator:344430d
+```shell {.command}
+# search for an artifact by its commit sha
+kosli get artifact creator:344430d
+```
+
+```
 Name:                     cyberdojo/creator:344430d
 Flow:                     creator
 Fingerprint:              817a72609041c51cd2a3bbbcbeb048c687677986b5a273399c6938b5e6aa1ded
@@ -208,7 +213,7 @@ History:
 
 As is the case for flows and artifacts, you can list all the Kosli environments you created under your organization
 
-```
+```shell {.command}
 kosli list environments
 ```
 
@@ -222,7 +227,7 @@ prod      K8S   2022-06-15T11:40:01+02:00  2022-06-15T11:40:01+02:00
 
 And get the metadata (including the type) of each environment:
 
-```
+```shell {.command}
 kosli get environment aws-beta
 ```
 
@@ -238,7 +243,7 @@ Last Reported At:  Sun, 30 Oct 2022 14:55:42 CET • 5 seconds ago
 
 When you have the name of the environment you want to dig into use `kosli list snapshots` or `kosli log environment` to browse snapshots and changes in the environment, or `kosli get snapshot` to have a look at a specific snapshot.
 
-```
+```shell {.command}
 kosli list snapshots aws-beta
 ```
 
@@ -265,7 +270,7 @@ By default, you can see the last 15 changes to the environment. You can choose t
 
 You can also choose to see the actual events from each snapshot, using `kosli log environment` command:
 
-```
+```shell {.command}
 kosli log environment aws-beta
 ```
 
@@ -289,7 +294,7 @@ SNAPSHOT  EVENT                                                                 
 
 You can also use an *interval* expression, like `262..264` (to see specified snapshot list)
 
-```
+```shell {.command}
 kosli log environment aws-beta 262..264
 ```
 
@@ -302,7 +307,7 @@ SNAPSHOT  FROM                            TO                              DURATI
 
 or `~4..NOW` (to get a list of snapshots starting from 4 behind a currently running one and the current one)
 
-```
+```shell {.command}
 kosli log environment aws-beta ~4..NOW
 ```
 
@@ -319,7 +324,7 @@ SNAPSHOT  FROM                            TO                              DURATI
 
 To have a look at what is or was running in a given snapshot use `kosli get snapshot` command. You can use just the environment name as the argument, which will give you the latest snapshot, add `#` and snapshot number, to get a specific one, or `~n` where *n* is a number, to get *n-th* snapshot behind a current one:
 
-``` 
+``` shell {.command}
 kosli get snapshot aws-beta
 ```
 
@@ -336,7 +341,7 @@ d90a3e4  Name: 244531986313.dkr.ecr.eu-central-1.amazonaws.com/dashboard:d90a3e4
 [...]
 ```
 
-```
+```shell {.command}
 kosli get snapshot aws-beta#256
 ```
 
@@ -353,7 +358,7 @@ d90a3e4  Name: 244531986313.dkr.ecr.eu-central-1.amazonaws.com/dashboard:d90a3e4
 [...]
 ```
 
-```
+```shell {.command}
 kosli get snapshot aws-beta~19
 ```
 
@@ -374,7 +379,7 @@ The same expressions (with `#` and `~`) can be used to reference snapshots when 
 
 In the example below there was only one difference between snapshots: one new artifact started running in the latest snapshot. 
 
-```
+```shell {.command}
 kosli diff snapshots aws-beta aws-beta~1
 ```
 
@@ -392,7 +397,7 @@ Only present in aws-beta (snapshot: aws-beta#266)
 
 You can use `diff` to compare snapshots of two different environments or different snapshots of the same environment:
 
-```
+```shell {.command}
 kosli diff snapshots aws-beta~3 aws-prod
 ```
 

--- a/docs.kosli.com/content/tutorials/querying_kosli.md
+++ b/docs.kosli.com/content/tutorials/querying_kosli.md
@@ -24,7 +24,10 @@ You need to:
 You can use `kosli search` command to find out if Kosli knows of any artifact that was build using that commit - both short and full shas are accepted:
 
 ```
-$ kosli search 0f5c9e1
+kosli search 0f5c9e1
+```
+
+```
 Search result resolved to commit 0f5c9e19c4d4f948d19ce4c8495b2a44745cda96
 Name:              cyberdojo/web:0f5c9e1
 Fingerprint:       62e1d2909cc59193b31bfd120276fcb8ba5e42dd6becd873218a41e4ce022505
@@ -52,7 +55,10 @@ The information returned by `kosli search` - like Flow, Fingerprint or History -
 When you search in Kosli you often need to refer to a specific flow. If you don't remember all the flows' names it is easy to list them with `kosli list flows` command:
 
 ```
-$ kosli list flows 
+kosli list flows
+```
+
+```
 NAME                    DESCRIPTION                         VISIBILITY
 creator                 UX for Group/Kata creation          public
 custom-start-points     Custom exercises choices            public
@@ -71,7 +77,10 @@ web                     UX for practicing TDD               public
 And if you want to check metadata of a specific flow (like description or template) use `kosli get flow`
 
 ```
-$ kosli get flow creator
+kosli get flow creator
+```
+
+```
 Name:                creator
 Description:         UX for Group/Kata creation
 Visibility:          public
@@ -84,7 +93,10 @@ Last Deployment At:  Wed, 14 Sep 2022 10:51:43 CEST • one month ago
 To find the information about artifacts reported to a specific flow in Kosli use `kosli list artifacts` command
 
 ```
-$ kosli list artifacts --flow creator
+kosli list artifacts --flow creator
+```
+
+```
 COMMIT   ARTIFACT                                  STATE       CREATED_AT
 344430d  Name: cyberdojo/creator:344430d           COMPLIANT   Wed, 14 Sep 2022 10:48:09 CEST
          Fingerprint: 817a72(...)6b5a273399c693             
@@ -104,17 +116,17 @@ The amount of artifacts may be really long and by default you can see the last 1
 
 E.g. to see last five artifacts you'd use:
 ```
-$ kosli list artifacts --flow creator -n 5
+kosli list artifacts --flow creator -n 5
 ```
 
 And to see the next page:
 ```
-$ kosli list artifacts --flow creator -n 5 --page 2
+kosli list artifacts --flow creator -n 5 --page 2
 ```
 
 You can also use the `--output` flag to change the format of the response. By default the response comes in a *table* format, but you can choose to switch to *json*:
 ```
-$ kosli list artifacts --flow creator --output json
+kosli list artifacts --flow creator --output json
 ```
 ## Get artifact
 
@@ -127,7 +139,10 @@ Both are available in the output of `kosli list artifacts` command
 
 ```
 # search for artifact by its fingerprint
-$ kosli get artifact creator@817a72609041c51cd2a3bbbcbeb048c687677986b5a273399c6938b5e6aa1ded
+kosli get artifact creator@817a72609041c51cd2a3bbbcbeb048c687677986b5a273399c6938b5e6aa1ded
+```
+
+```
 Name:                     cyberdojo/creator:344430d
 Flow:                     creator
 Fingerprint:              817a72609041c51cd2a3bbbcbeb048c687677986b5a273399c6938b5e6aa1ded
@@ -194,7 +209,10 @@ History:
 As is the case for flows and artifacts, you can list all the Kosli environments you created under your organization
 
 ```
-$ kosli list environments
+kosli list environments
+```
+
+```
 NAME      TYPE  LAST REPORT                LAST MODIFIED
 aws-beta  ECS   2022-10-30T14:51:42+01:00  2022-10-30T14:51:42+01:00
 aws-prod  ECS   2022-10-30T14:51:28+01:00  2022-10-30T14:51:28+01:00
@@ -205,7 +223,10 @@ prod      K8S   2022-06-15T11:40:01+02:00  2022-06-15T11:40:01+02:00
 And get the metadata (including the type) of each environment:
 
 ```
-$ kosli get environment aws-beta
+kosli get environment aws-beta
+```
+
+```
 Name:              aws-beta
 Type:              ECS
 Description:       The ECS beta namespace
@@ -218,7 +239,10 @@ Last Reported At:  Sun, 30 Oct 2022 14:55:42 CET • 5 seconds ago
 When you have the name of the environment you want to dig into use `kosli list snapshots` or `kosli log environment` to browse snapshots and changes in the environment, or `kosli get snapshot` to have a look at a specific snapshot.
 
 ```
-$ kosli list snapshots aws-beta
+kosli list snapshots aws-beta
+```
+
+```
 SNAPSHOT  FROM                            TO                              DURATION
 266       Wed, 19 Oct 2022 09:47:42 CEST  now                             11 days
 265       Wed, 19 Oct 2022 09:46:42 CEST  Wed, 19 Oct 2022 09:47:42 CEST  59 seconds
@@ -237,12 +261,15 @@ SNAPSHOT  FROM                            TO                              DURATI
 252       Mon, 10 Oct 2022 08:47:42 CEST  Thu, 13 Oct 2022 09:04:42 CEST  3 days
 ```
 
-By default you can see the last 15 changes to the environment. You can choose to only print e.g. last 3 events (`-n` flag).
+By default, you can see the last 15 changes to the environment. You can choose to only print e.g. last 3 events (`-n` flag).
 
 You can also choose to see the actual events from each snapshot, using `kosli log environment` command:
 
 ```
-$ kosli log environment aws-beta
+kosli log environment aws-beta
+```
+
+```
 SNAPSHOT  EVENT                                                                          FLOW       DEPLOYMENTS
 #266      Artifact: 244531986313.dkr.ecr.eu-central-1.amazonaws.com/dashboard:d90a3e4    dashboard  #15 
           Fingerprint: dd5308fdcda117c1ff3963e192a069ae390c2fe9e10e8abfa2430224265efe98             
@@ -260,16 +287,26 @@ SNAPSHOT  EVENT                                                                 
           Reported at: Wed, 19 Oct 2022 09:46:42 CEST  
 ```
 
-You can also use an *interval* expression, like `262..264` (to see specified snapshot list) , or `~4..NOW` (to get a list of snapshots starting from 4 behind a currently running one and the current one)
+You can also use an *interval* expression, like `262..264` (to see specified snapshot list)
 
 ```
-$ kosli log environment aws-beta 262..264
+kosli log environment aws-beta 262..264
+```
+
+```
 SNAPSHOT  FROM                            TO                              DURATION
 264       Wed, 19 Oct 2022 09:45:42 CEST  Wed, 19 Oct 2022 09:46:42 CEST  about a minute
 263       Wed, 19 Oct 2022 09:42:42 CEST  Wed, 19 Oct 2022 09:45:42 CEST  3 minutes
 262       Wed, 19 Oct 2022 09:32:42 CEST  Wed, 19 Oct 2022 09:42:42 CEST  10 minutes
+```
 
-$ kosli log environment aws-beta ~4..NOW
+or `~4..NOW` (to get a list of snapshots starting from 4 behind a currently running one and the current one)
+
+```
+kosli log environment aws-beta ~4..NOW
+```
+
+```
 SNAPSHOT  FROM                            TO                              DURATION
 266       Wed, 19 Oct 2022 09:47:42 CEST  now                             11 days
 265       Wed, 19 Oct 2022 09:46:42 CEST  Wed, 19 Oct 2022 09:47:42 CEST  59 seconds
@@ -283,7 +320,10 @@ SNAPSHOT  FROM                            TO                              DURATI
 To have a look at what is or was running in a given snapshot use `kosli get snapshot` command. You can use just the environment name as the argument, which will give you the latest snapshot, add `#` and snapshot number, to get a specific one, or `~n` where *n* is a number, to get *n-th* snapshot behind a current one:
 
 ``` 
-$ kosli get snapshot aws-beta
+kosli get snapshot aws-beta
+```
+
+```
 COMMIT   ARTIFACT                                                                              FLOW      RUNNING_SINCE  REPLICAS
 d90a3e4  Name: 244531986313.dkr.ecr.eu-central-1.amazonaws.com/dashboard:d90a3e4               N/A       11 days ago    1
          Fingerprint: dd5308fdcda117c1ff3963e192a069ae390c2fe9e10e8abfa2430224265efe98                                  
@@ -294,8 +334,13 @@ d90a3e4  Name: 244531986313.dkr.ecr.eu-central-1.amazonaws.com/dashboard:d90a3e4
 1c162e4  Name: 244531986313.dkr.ecr.eu-central-1.amazonaws.com/differ:1c162e4                  N/A       11 days ago    1
          Fingerprint: b7fd766dd2514b2610c0c8d70d8f762de4921931f97fdd6fbbfcc9745ac3ce3b                                  
 [...]
+```
 
-$ kosli get snapshot aws-beta#256
+```
+kosli get snapshot aws-beta#256
+```
+
+```
 COMMIT   ARTIFACT                                                                              FLOW      RUNNING_SINCE  REPLICAS
 6fe0d30  Name: 244531986313.dkr.ecr.eu-central-1.amazonaws.com/repler:6fe0d30                  N/A       16 days ago    1
          Fingerprint: a0c03099c832e4ce5f23f5e33dac9889c0b7ccd61297fffdaf1c67e7b99e6f8f                                  
@@ -306,8 +351,13 @@ d90a3e4  Name: 244531986313.dkr.ecr.eu-central-1.amazonaws.com/dashboard:d90a3e4
 1c162e4  Name: 244531986313.dkr.ecr.eu-central-1.amazonaws.com/differ:1c162e4                  N/A       16 days ago    1
          Fingerprint: b7fd766dd2514b2610c0c8d70d8f762de4921931f97fdd6fbbfcc9745ac3ce3b                                  
 [...]
+```
 
-$ kosli get snapshot aws-beta~19
+```
+kosli get snapshot aws-beta~19
+```
+
+```
 COMMIT   ARTIFACT                                                                              FLOW      RUNNING_SINCE  REPLICAS
 2e8646c  Name: 244531986313.dkr.ecr.eu-central-1.amazonaws.com/shas:2e8646c                    N/A       one month ago  1
          Fingerprint: a3158c3e79c83905fd3613e06b8cf5a45141c50cf49d4f99de90a2d081b77771                                  
@@ -325,7 +375,10 @@ The same expressions (with `#` and `~`) can be used to reference snapshots when 
 In the example below there was only one difference between snapshots: one new artifact started running in the latest snapshot. 
 
 ```
-$ kosli diff snapshots aws-beta aws-beta~1
+kosli diff snapshots aws-beta aws-beta~1
+```
+
+```
 Only present in aws-beta (snapshot: aws-beta#266)
                    
      Name:         244531986313.dkr.ecr.eu-central-1.amazonaws.com/dashboard:d90a3e4
@@ -340,7 +393,10 @@ Only present in aws-beta (snapshot: aws-beta#266)
 You can use `diff` to compare snapshots of two different environments or different snapshots of the same environment:
 
 ```
-$ kosli diff snapshots aws-beta~3 aws-prod
+kosli diff snapshots aws-beta~3 aws-prod
+```
+
+```
 Only present in aws-prod (snapshot: aws-prod#261)
                    
      Name:         274425519734.dkr.ecr.eu-central-1.amazonaws.com/saver:8d724a1

--- a/docs.kosli.com/content/tutorials/report_aws_envs.md
+++ b/docs.kosli.com/content/tutorials/report_aws_envs.md
@@ -46,7 +46,7 @@ export AWS_SECRET_ACCESS_KEY=yourAWSSecretAccessKey
 
 {{< tab "ECS" >}}
 ```shell {.command}
-$ kosli snapshot ecs aws-env-tutorial \
+kosli snapshot ecs aws-env-tutorial \
     --cluster <your-ecs-cluster-name> \
 	--api-token <your-api-token-here> \
     --org <your-kosli-org-name>
@@ -55,7 +55,7 @@ $ kosli snapshot ecs aws-env-tutorial \
 
 {{< tab "Lambda" >}}
 ```shell {.command}
-$ kosli snapshot lambda aws-env-tutorial \
+kosli snapshot lambda aws-env-tutorial \
     --function-names function1,function2 \
 	--api-token <your-api-token-here> \
     --org <your-kosli-org-name>
@@ -64,7 +64,7 @@ $ kosli snapshot lambda aws-env-tutorial \
 
 {{< tab "S3" >}}
 ```shell {.command}
-$ kosli snapshot s3 aws-env-tutorial \
+kosli snapshot s3 aws-env-tutorial \
     --bucket <your-bucket-name> \
 	--api-token <your-api-token-here> \
     --org <your-kosli-org-name>
@@ -285,8 +285,8 @@ module "lambda_reporter" {
 4. Initialize and run Terraform by running:
 
 ```shell {.command}
-$ terraform init
-$ terraform apply
+terraform init
+terraform apply
 ```
 
 5. To check Lambda reporter logs you can go to the AWS console -> Lambda service -> choose your lambda reporter function -> Monitor tab -> Logs tab.

--- a/docs.kosli.com/content/tutorials/report_k8s_envs.md
+++ b/docs.kosli.com/content/tutorials/report_k8s_envs.md
@@ -41,7 +41,7 @@ This option is **only suitable for testing purposes**.
 To report the **artifacts running in an entire cluster**, you can run the following command:
 
 ```shell {.command}
-$ kosli snapshot k8s k8s-tutorial \
+kosli snapshot k8s k8s-tutorial \
     --api-token <your-api-token-here> \
     --org <your-kosli-org-name>
 ```
@@ -49,7 +49,7 @@ $ kosli snapshot k8s k8s-tutorial \
 To report **artifacts running in one or more namespaces**, you can run the following command:
 
 ```shell {.command}
-$ kosli snapshot k8s k8s-tutorial \
+kosli snapshot k8s k8s-tutorial \
     --namespaces namespace1,namespace2 \
     --api-token <your-api-token-here> \
     --org <your-kosli-org-name>
@@ -58,7 +58,7 @@ $ kosli snapshot k8s k8s-tutorial \
 To report **artifacts running in the entire cluster except from some namespaces**, you can run the following command:
 
 ```shell {.command}
-$ kosli snapshot k8s k8s-tutorial \
+kosli snapshot k8s k8s-tutorial \
     --exclude-namespaces namespace1,namespace2 \
     --api-token <your-api-token-here> \
     --org <your-kosli-org-name>
@@ -73,7 +73,7 @@ The chart creates a cronjob that will run the Kosli CLI inside a pod to report t
 1. Create a K8S secret to contain your Kosli API token.
 
 ```shell {.command}
-$ kubectl create secret generic kosli-api-token --from-literal=apikey=<your-kosli-api-token>
+kubectl create secret generic kosli-api-token --from-literal=apikey=<your-kosli-api-token>
 ```
 
 > Make sure the secret value does not contain any trailing whitespace.
@@ -109,15 +109,15 @@ reporterConfig:
 3. Install the Kosli helm chart
 
 ```shell {.command}
-$ helm repo add kosli https://charts.kosli.com/
-$ helm repo update
-$ helm install kosli-reporter kosli/k8s-reporter -f tutorial-values.yaml
+helm repo add kosli https://charts.kosli.com/
+helm repo update
+helm install kosli-reporter kosli/k8s-reporter -f tutorial-values.yaml
 ```
 
 4. Confirm the cronjob is created in the cluster:
 
 ```shell {.command}
-$ kubectl get cronjobs
+kubectl get cronjobs
 ```
 
 Now, the cronjob will run every 5 minutes and report what is running in the entire cluster to Kosli.


### PR DESCRIPTION
In the Swiss Digital Network training there were several times when Olivier (for example) copied a fragment from the tutorials, pasted it into a text editor, and then had to delete the leading dollar symbols.