### PR TITLE
default commit url when git providers are self-hosted

### DIFF
--- a/internal/gitview/gitView.go
+++ b/internal/gitview/gitView.go
@@ -261,7 +261,10 @@ func getCommitURL(repoURL, commitHash string) string {
 	case strings.Contains(host, "dev.azure.com"):
 		return fmt.Sprintf("%s/commit/%s", repoURL, commitHash)
 	default:
-		return ""
+		// self-hosted instances can have custom domain names.
+		// in this case, we default to repoURL/commit/commitHash
+		// which works except for Bitbucket Data Center (self hosted)
+		return fmt.Sprintf("%s/commit/%s", repoURL, commitHash)
 	}
 }
 

--- a/internal/gitview/gitView_test.go
+++ b/internal/gitview/gitView_test.go
@@ -310,6 +310,12 @@ func (suite *GitViewTestSuite) TestGetCommitURL() {
 			commitHash: "089615f84caedd6280689da694e71052cbdfb84d",
 			want:       "https://dev.azure.com/kosli/kosli-azure/_git/cli/commit/089615f84caedd6280689da694e71052cbdfb84d",
 		},
+		{
+			name:       "github enterprise",
+			repoURL:    "https://custom-domain-name.com/kosli-dev/cli",
+			commitHash: "089615f84caedd6280689da694e71052cbdfb84d",
+			want:       "https://custom-domain-name.com/kosli-dev/cli/commit/089615f84caedd6280689da694e71052cbdfb84d",
+		},
 	} {
 		suite.Run(t.name, func() {
 			actual := getCommitURL(t.repoURL, t.commitHash)


### PR DESCRIPTION
default commit url when git providers are self-hosted and have custom domains.
Caveat: this won't work for self-hosted Bitbucket (Bitbucket Data Center)