### PR TITLE
Added reporting an attestation to the relase pointing back to the never-alone-trail #2298

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,30 @@ jobs:
       kosli_api_token: ${{ secrets.KOSLI_API_TOKEN }}
       pr_github_token: ${{ secrets.GITHUB_TOKEN }}        
   
+  never-alone-link-in-relase:
+    needs: [pre-build, init-kosli, never-alone-trail]
+    runs-on: ubuntu-latest
+    permissions:
+        id-token: write
+        contents: write
+        pull-requests: read
+    steps:
+      - name: Report never-alone-trail
+        env:
+          FLOW_NAME: test-cli-release
+          TRAIL_NAME: v0.0.101
+          SOURCE_FLOW_NAME: test-cli-release-never-alone
+          KOSLI_ORG: kosli-public    
+          KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
+        run: |
+          KOSLI_HOST=${KOSLI_HOST:-https://app.kosli.com}
+          NEVER_ALONE_TRAIL_LINK="${KOSLI_HOST}/${KOSLI_ORG}/flows/${SOURCE_FLOW_NAME}/trails/${TRAIL_NAME}"
+          kosli attest generic github \
+            --flow ${FLOW_NAME} \
+            --trail ${TRAIL_NAME} \ 
+            --name never-alone-trail \
+            --annotate never_alone_trail="${NEVER_ALONE_TRAIL_LINK}"
+
   ### end
   test:
     needs: [pre-build]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           KOSLI_HOST=${KOSLI_HOST:-https://app.kosli.com}
           NEVER_ALONE_TRAIL_LINK="${KOSLI_HOST}/${KOSLI_ORG}/flows/${SOURCE_FLOW_NAME}/trails/${TRAIL_NAME}"
-          kosli attest generic github \
+          kosli attest generic \
             --flow ${FLOW_NAME} \
             --trail ${TRAIL_NAME} \ 
             --name never-alone-trail \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,51 +58,53 @@ jobs:
     uses: ./.github/workflows/never_alone_trail.yml
     with:
       FLOW_NAME: test-cli-release-never-alone
-      TRAIL_NAME: v0.0.102
+      TRAIL_NAME: v0.0.103
       SOURCE_FLOW_NAME: cli
       ATTESTATION_NAME: never-alone-data
+      PARENT_FLOW_NAME: test-cli-release
+      PARENT_TRAIL_NAME: v0.0.103
       KOSLI_ORG: kosli-public
     secrets:
       kosli_api_token: ${{ secrets.KOSLI_API_TOKEN }}
       pr_github_token: ${{ secrets.GITHUB_TOKEN }}        
   
-  never-alone-link-in-relase:
-    needs: [pre-build, init-kosli, never-alone-trail]
-    runs-on: ubuntu-latest
-    permissions:
-        id-token: write
-        contents: write
-        pull-requests: read
-    steps:
+  # never-alone-link-in-relase:
+  #   needs: [pre-build, init-kosli, never-alone-trail]
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #       id-token: write
+  #       contents: write
+  #       pull-requests: read
+  #   steps:
 
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 1
 
-      - name: setup-kosli-cli
-        uses: kosli-dev/setup-cli-action@v2
-        with:
-          version:
-              ${{ vars.KOSLI_CLI_VERSION }}
+  #     - name: setup-kosli-cli
+  #       uses: kosli-dev/setup-cli-action@v2
+  #       with:
+  #         version:
+  #             ${{ vars.KOSLI_CLI_VERSION }}
 
-      - name: Report never-alone-trail
-        env:
-          FLOW_NAME: test-cli-release
-          TRAIL_NAME: v0.0.102
-          SOURCE_FLOW_NAME: test-cli-release-never-alone
-          KOSLI_ORG: kosli-public    
-          KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
-        run: |
-          # only on test on real it is already there
-          kosli begin trail ${TRAIL_NAME} --flow ${FLOW_NAME}
+  #     - name: Report never-alone-trail
+  #       env:
+  #         FLOW_NAME: test-cli-release
+  #         TRAIL_NAME: v0.0.102
+  #         SOURCE_FLOW_NAME: test-cli-release-never-alone
+  #         KOSLI_ORG: kosli-public    
+  #         KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
+  #       run: |
+  #         # only on test on real it is already there
+  #         kosli begin trail ${TRAIL_NAME} --flow ${FLOW_NAME}
 
-          KOSLI_HOST=${KOSLI_HOST:-https://app.kosli.com}
-          NEVER_ALONE_TRAIL_LINK="${KOSLI_HOST}/${KOSLI_ORG}/flows/${SOURCE_FLOW_NAME}/trails/${TRAIL_NAME}"
-          kosli attest generic \
-            --flow ${FLOW_NAME} \
-            --trail ${TRAIL_NAME} \
-            --name never-alone-trail \
-            --annotate never_alone_trail="${NEVER_ALONE_TRAIL_LINK}"
+  #         KOSLI_HOST=${KOSLI_HOST:-https://app.kosli.com}
+  #         NEVER_ALONE_TRAIL_LINK="${KOSLI_HOST}/${KOSLI_ORG}/flows/${SOURCE_FLOW_NAME}/trails/${TRAIL_NAME}"
+  #         kosli attest generic \
+  #           --flow ${FLOW_NAME} \
+  #           --trail ${TRAIL_NAME} \
+  #           --name never-alone-trail \
+  #           --annotate never_alone_trail="${NEVER_ALONE_TRAIL_LINK}"
 
   ### end
   test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,11 +58,11 @@ jobs:
     uses: ./.github/workflows/never_alone_trail.yml
     with:
       FLOW_NAME: test-cli-release-never-alone
-      TRAIL_NAME: v0.0.103
+      TRAIL_NAME: v0.0.104
       SOURCE_FLOW_NAME: cli
       ATTESTATION_NAME: never-alone-data
       PARENT_FLOW_NAME: test-cli-release
-      PARENT_TRAIL_NAME: v0.0.103
+      PARENT_TRAIL_NAME: v0.0.104
       KOSLI_ORG: kosli-public
     secrets:
       kosli_api_token: ${{ secrets.KOSLI_API_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
     uses: ./.github/workflows/never_alone_trail.yml
     with:
       FLOW_NAME: test-cli-release-never-alone
-      TRAIL_NAME: v0.0.101
+      TRAIL_NAME: v0.0.102
       SOURCE_FLOW_NAME: cli
       ATTESTATION_NAME: never-alone-data
       KOSLI_ORG: kosli-public
@@ -88,7 +88,7 @@ jobs:
       - name: Report never-alone-trail
         env:
           FLOW_NAME: test-cli-release
-          TRAIL_NAME: v0.0.101
+          TRAIL_NAME: v0.0.102
           SOURCE_FLOW_NAME: test-cli-release-never-alone
           KOSLI_ORG: kosli-public    
           KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,21 @@ jobs:
       kosli_api_token: ${{ secrets.KOSLI_API_TOKEN }}
       pr_github_token: ${{ secrets.GITHUB_TOKEN }}
 
-
+  # Only to test CI on a branch
+  never-alone-trail:
+    needs: [pre-build, init-kosli]
+    uses: ./.github/workflows/never_alone_trail.yml
+    with:
+      FLOW_NAME: test-cli-release-never-alone
+      TRAIL_NAME: v0.0.101
+      SOURCE_FLOW_NAME: cli
+      ATTESTATION_NAME: never-alone-data
+      KOSLI_ORG: kosli-public
+    secrets:
+      kosli_api_token: ${{ secrets.KOSLI_API_TOKEN }}
+      pr_github_token: ${{ secrets.GITHUB_TOKEN }}        
+  
+  ### end
   test:
     needs: [pre-build]
     uses: ./.github/workflows/test.yml
@@ -75,19 +89,19 @@ jobs:
       snyk_token: ${{ secrets.SNYK_TOKEN }}
       kosli_api_token: ${{ secrets.KOSLI_API_TOKEN }}
 
-  docker:
-    needs: [pre-build, test, init-kosli]
-    uses: ./.github/workflows/docker.yml
-    with:
-      tag: ${{ needs.pre-build.outputs.tag }}
-      platforms: linux/amd64
-      flow_name: cli
-      trail_name: ${{ needs.pre-build.outputs.trail_name }}
-      kosli_org: kosli-public
-    secrets:
-      slack_webhook: ${{ secrets.MERKELY_SLACK_CI_FAILURES_WEBHOOK }}
-      slack_channel: ${{ secrets.MERKELY_SLACK_CI_FAILURES_CHANNEL }} 
-      ghcr_user: ${{ secrets.GHCR_USER }}
-      ghcr_token: ${{ secrets.GHCR_TOKEN }}
-      kosli_api_token: ${{ secrets.KOSLI_API_TOKEN }}
-      snyk_token: ${{ secrets.SNYK_TOKEN }}
+  # docker:
+  #   needs: [pre-build, test, init-kosli]
+  #   uses: ./.github/workflows/docker.yml
+  #   with:
+  #     tag: ${{ needs.pre-build.outputs.tag }}
+  #     platforms: linux/amd64
+  #     flow_name: cli
+  #     trail_name: ${{ needs.pre-build.outputs.trail_name }}
+  #     kosli_org: kosli-public
+  #   secrets:
+  #     slack_webhook: ${{ secrets.MERKELY_SLACK_CI_FAILURES_WEBHOOK }}
+  #     slack_channel: ${{ secrets.MERKELY_SLACK_CI_FAILURES_CHANNEL }} 
+  #     ghcr_user: ${{ secrets.GHCR_USER }}
+  #     ghcr_token: ${{ secrets.GHCR_TOKEN }}
+  #     kosli_api_token: ${{ secrets.KOSLI_API_TOKEN }}
+  #     snyk_token: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,61 +52,7 @@ jobs:
       kosli_api_token: ${{ secrets.KOSLI_API_TOKEN }}
       pr_github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  # Only to test CI on a branch
-  never-alone-trail:
-    needs: [pre-build, init-kosli]
-    uses: ./.github/workflows/never_alone_trail.yml
-    with:
-      FLOW_NAME: test-cli-release-never-alone
-      TRAIL_NAME: v0.0.104
-      SOURCE_FLOW_NAME: cli
-      ATTESTATION_NAME: never-alone-data
-      PARENT_FLOW_NAME: test-cli-release
-      PARENT_TRAIL_NAME: v0.0.104
-      KOSLI_ORG: kosli-public
-    secrets:
-      kosli_api_token: ${{ secrets.KOSLI_API_TOKEN }}
-      pr_github_token: ${{ secrets.GITHUB_TOKEN }}        
-  
-  # never-alone-link-in-relase:
-  #   needs: [pre-build, init-kosli, never-alone-trail]
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #       id-token: write
-  #       contents: write
-  #       pull-requests: read
-  #   steps:
 
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 1
-
-  #     - name: setup-kosli-cli
-  #       uses: kosli-dev/setup-cli-action@v2
-  #       with:
-  #         version:
-  #             ${{ vars.KOSLI_CLI_VERSION }}
-
-  #     - name: Report never-alone-trail
-  #       env:
-  #         FLOW_NAME: test-cli-release
-  #         TRAIL_NAME: v0.0.102
-  #         SOURCE_FLOW_NAME: test-cli-release-never-alone
-  #         KOSLI_ORG: kosli-public    
-  #         KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
-  #       run: |
-  #         # only on test on real it is already there
-  #         kosli begin trail ${TRAIL_NAME} --flow ${FLOW_NAME}
-
-  #         KOSLI_HOST=${KOSLI_HOST:-https://app.kosli.com}
-  #         NEVER_ALONE_TRAIL_LINK="${KOSLI_HOST}/${KOSLI_ORG}/flows/${SOURCE_FLOW_NAME}/trails/${TRAIL_NAME}"
-  #         kosli attest generic \
-  #           --flow ${FLOW_NAME} \
-  #           --trail ${TRAIL_NAME} \
-  #           --name never-alone-trail \
-  #           --annotate never_alone_trail="${NEVER_ALONE_TRAIL_LINK}"
-
-  ### end
   test:
     needs: [pre-build]
     uses: ./.github/workflows/test.yml
@@ -129,19 +75,19 @@ jobs:
       snyk_token: ${{ secrets.SNYK_TOKEN }}
       kosli_api_token: ${{ secrets.KOSLI_API_TOKEN }}
 
-  # docker:
-  #   needs: [pre-build, test, init-kosli]
-  #   uses: ./.github/workflows/docker.yml
-  #   with:
-  #     tag: ${{ needs.pre-build.outputs.tag }}
-  #     platforms: linux/amd64
-  #     flow_name: cli
-  #     trail_name: ${{ needs.pre-build.outputs.trail_name }}
-  #     kosli_org: kosli-public
-  #   secrets:
-  #     slack_webhook: ${{ secrets.MERKELY_SLACK_CI_FAILURES_WEBHOOK }}
-  #     slack_channel: ${{ secrets.MERKELY_SLACK_CI_FAILURES_CHANNEL }} 
-  #     ghcr_user: ${{ secrets.GHCR_USER }}
-  #     ghcr_token: ${{ secrets.GHCR_TOKEN }}
-  #     kosli_api_token: ${{ secrets.KOSLI_API_TOKEN }}
-  #     snyk_token: ${{ secrets.SNYK_TOKEN }}
+  docker:
+    needs: [pre-build, test, init-kosli]
+    uses: ./.github/workflows/docker.yml
+    with:
+      tag: ${{ needs.pre-build.outputs.tag }}
+      platforms: linux/amd64
+      flow_name: cli
+      trail_name: ${{ needs.pre-build.outputs.trail_name }}
+      kosli_org: kosli-public
+    secrets:
+      slack_webhook: ${{ secrets.MERKELY_SLACK_CI_FAILURES_WEBHOOK }}
+      slack_channel: ${{ secrets.MERKELY_SLACK_CI_FAILURES_CHANNEL }} 
+      ghcr_user: ${{ secrets.GHCR_USER }}
+      ghcr_token: ${{ secrets.GHCR_TOKEN }}
+      kosli_api_token: ${{ secrets.KOSLI_API_TOKEN }}
+      snyk_token: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,11 @@ jobs:
         contents: write
         pull-requests: read
     steps:
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - name: setup-kosli-cli
         uses: kosli-dev/setup-cli-action@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,12 @@ jobs:
         contents: write
         pull-requests: read
     steps:
+      - name: setup-kosli-cli
+        uses: kosli-dev/setup-cli-action@v2
+        with:
+          version:
+              ${{ vars.KOSLI_CLI_VERSION }}
+
       - name: Report never-alone-trail
         env:
           FLOW_NAME: test-cli-release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,11 +88,14 @@ jobs:
           KOSLI_ORG: kosli-public    
           KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
         run: |
+          # only on test on real it is already there
+          kosli begin trail ${TRAIL_NAME} --flow ${FLOW_NAME}
+
           KOSLI_HOST=${KOSLI_HOST:-https://app.kosli.com}
           NEVER_ALONE_TRAIL_LINK="${KOSLI_HOST}/${KOSLI_ORG}/flows/${SOURCE_FLOW_NAME}/trails/${TRAIL_NAME}"
           kosli attest generic \
             --flow ${FLOW_NAME} \
-            --trail ${TRAIL_NAME} \ 
+            --trail ${TRAIL_NAME} \
             --name never-alone-trail \
             --annotate never_alone_trail="${NEVER_ALONE_TRAIL_LINK}"
 

--- a/.github/workflows/never_alone_trail.yml
+++ b/.github/workflows/never_alone_trail.yml
@@ -8,12 +8,18 @@ on:
             type: string
           trail_name:
             required: true
-            type: string
+            type: string          
           source_flow_name:
             required: true
             type: string
           attestation_name:
             required: true
+            type: string
+          parent_flow_name:
+            required: false
+            type: string
+          parent_trail_name:
+            required: false
             type: string
           kosli_org:
             required: true
@@ -64,6 +70,6 @@ jobs:
               -f ${{inputs.flow_name}} \
               -t ${{inputs.trail_name}} \
               -b ${BASE_COMMIT} \
-              -p ${GITHUB_SHA} \
+              -c ${GITHUB_SHA} \
               -s ${{inputs.source_flow_name}} \
               -n ${{inputs.attestation_name}}

--- a/.github/workflows/never_alone_trail.yml
+++ b/.github/workflows/never_alone_trail.yml
@@ -8,7 +8,7 @@ on:
             type: string
           trail_name:
             required: true
-            type: string          
+            type: string
           source_flow_name:
             required: true
             type: string

--- a/.github/workflows/never_alone_trail.yml
+++ b/.github/workflows/never_alone_trail.yml
@@ -72,4 +72,6 @@ jobs:
               -b ${BASE_COMMIT} \
               -c ${GITHUB_SHA} \
               -s ${{inputs.source_flow_name}} \
-              -n ${{inputs.attestation_name}}
+              -n ${{inputs.attestation_name}} \
+              -p ${{inputs.parent_flow_name}} \
+              -q ${{inputs.parent_trail_name}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,8 @@ jobs:
         TRAIL_NAME: ${{ needs.pre-build.outputs.trail_name }}
         SOURCE_FLOW_NAME: cli
         ATTESTATION_NAME: never-alone-data
+        PARENT_FLOW_NAME: cli-release
+        PARENT_TRAIL_NAME: ${{ needs.pre-build.outputs.trail_name }}
         KOSLI_ORG: kosli-public
       secrets:
         kosli_api_token: ${{ secrets.KOSLI_API_TOKEN }}

--- a/bin/never_alone/create_never_alone_trail.sh
+++ b/bin/never_alone/create_never_alone_trail.sh
@@ -241,9 +241,6 @@ function main
     done
 
     if [ -n "${PARENT_FLOW}" ]; then
-        # only for test. On real it is already there
-        kosli begin trail ${PARENT_TRAIL} --flow ${PARENT_FLOW}
-
         attest_never_alone_trail_to_parent  ${FLOW_NAME} ${TRAIL_NAME} ${PARENT_FLOW} ${PARENT_TRAIL}
     fi
 }

--- a/bin/never_alone/create_never_alone_trail.sh
+++ b/bin/never_alone/create_never_alone_trail.sh
@@ -241,6 +241,9 @@ function main
     done
 
     if [ -n "${PARENT_FLOW}" ]; then
+        # only for test. On real it is already there
+        kosli begin trail ${PARENT_TRAIL} --flow ${PARENT_FLOW}
+
         attest_never_alone_trail_to_parent  ${FLOW_NAME} ${TRAIL_NAME} ${PARENT_FLOW} ${PARENT_TRAIL}
     fi
 }

--- a/bin/never_alone/get_commit_and_pr_info.sh
+++ b/bin/never_alone/get_commit_and_pr_info.sh
@@ -105,6 +105,9 @@ function get_never_alone_data
     local -r commit=$1; shift
     local -r result_file=$1; shift
     
+    # We have seen that the 'gh search commits' sometimes return an empty list
+    # Have added getting data with graphql also, and some echo messages further down
+    # Only for debugging at the moment, but we could use graphql to get both commit and pr data
     commit_data_graphql=$(get_commit_data_using_graphql $commit)
     pr_data=$(gh pr list --search "${commit}" --state merged --json author,reviews,mergeCommit,mergedAt,reviewDecision,url)
     commit_data=$(gh search commits --hash "${commit}" --json commit)


### PR DESCRIPTION
- **Took out docker part of build to speed up**
- **Started on adding a never-alone-trail attestation to the cli-release**
- **Added setup of kosli cli before report of never-alone-trail**
- **fixed extra argument to kosli attest**
- **Fixed trailing white space**
- **Added git repo of depth 1**
- **Updated to a new release number**
- **Moved attestation of never-alone-trail into bash script**
- **Added begin trail for the test parent flow**
- **Added -p and -q options when calling create_never_alone_trail**
- **Some cleanup**
