### PR TITLE
always silence retryable client logging

### DIFF
--- a/internal/requests/requests.go
+++ b/internal/requests/requests.go
@@ -40,9 +40,7 @@ type Client struct {
 func NewKosliClient(httpProxyURL string, maxAPIRetries int, debug bool, logger *logger.Logger) (*Client, error) {
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = maxAPIRetries
-	if !debug {
-		retryClient.Logger = nil // this silences logging each individual attempt
-	}
+	retryClient.Logger = nil               // this silences logging each individual attempt
 	client := retryClient.StandardClient() // return a standard *http.Client from the retryable client
 	if httpProxyURL != "" {
 		proxyURL, err := url.Parse(httpProxyURL)


### PR DESCRIPTION
with v2.6.11, adding `--debug` causes duplicate logging with inconsistent formatting:

```
$ kosli list flows --debug 

[debug] processing config file [/Users/samialajrami/.kosli.yml]
[debug] using api token from [/Users/samialajrami/.kosli.yml].
2025/02/18 10:59:14 [DEBUG] GET https://app.kosli.com/api/v2/flows/kosli <==== this is duplicate and has a different format
[debug] request made to https://app.kosli.com/api/v2/flows/kosli and got status 200
```

without the duplicate logging, this is what it looks on a retry call:

```
$ kosli list flows --debug 

[debug] processing config file [/Users/samialajrami/.kosli.yml]
[debug] using api token from [/Users/samialajrami/.kosli.yml].
Error: Get "http://localhost/api/v2/flows/kosli": GET http://localhost/api/v2/flows/kosli giving up after 4 attempt(s)
```
which indicates that 4 attempts happened and failed