### PR TITLE
Added option to include a secondary source for jira issue attestation

### DIFF
--- a/cmd/kosli/reportEvidenceCommitJira.go
+++ b/cmd/kosli/reportEvidenceCommitJira.go
@@ -175,7 +175,7 @@ func (o *reportEvidenceCommitJiraOptions) run(args []string) error {
 	// more info: https://support.atlassian.com/jira-software-cloud/docs/what-is-an-issue/#Workingwithissues-Projectandissuekeys
 	jiraIssueKeyPattern := `[A-Z][A-Z0-9]{1,9}-[0-9]+`
 
-	issueIDs, commitInfo, err := gv.MatchPatternInCommitMessageORBranchName(jiraIssueKeyPattern, o.payload.CommitSHA)
+	issueIDs, commitInfo, err := gv.MatchPatternInCommitMessageORBranchName(jiraIssueKeyPattern, o.payload.CommitSHA, "")
 	if err != nil {
 		return err
 	}

--- a/cmd/kosli/reportEvidenceCommitJira_test.go
+++ b/cmd/kosli/reportEvidenceCommitJira_test.go
@@ -90,13 +90,13 @@ func (suite *CommitEvidenceJiraCommandTestSuite) TestCommitEvidenceJiraCommandCm
 			},
 		},
 		{
-			name: "report existing and non existing Jira commit evidence with reference in midle of line works",
+			name: "report existing and non existing Jira commit evidence with reference in middle of line works",
 			cmd: fmt.Sprintf(`report evidence commit jira --name jira-validation 
 					--jira-base-url https://kosli-test.atlassian.net  --jira-username tore@kosli.com
 					--repo-root %s
 					--build-url http://www.example.com %s`, suite.tmpDir, suite.defaultKosliArguments),
 			goldenRegex: "Jira evidence is reported to commit: [0-9a-f]{40}\n" +
-				".*Issues references reported:.*\n.*EX-1: issue found\n.*SAMI-1: issue not found",
+				".*Issues references reported:.*\n.*SAMI-1: issue not found\n.*EX-1: issue found",
 			additionalConfig: jiraTestsAdditionalConfig{
 				commitMessage: "go EX-1 SAMI-1 test commit",
 			},

--- a/cmd/kosli/reportEvidenceCommitJira_test.go
+++ b/cmd/kosli/reportEvidenceCommitJira_test.go
@@ -96,7 +96,7 @@ func (suite *CommitEvidenceJiraCommandTestSuite) TestCommitEvidenceJiraCommandCm
 					--repo-root %s
 					--build-url http://www.example.com %s`, suite.tmpDir, suite.defaultKosliArguments),
 			goldenRegex: "Jira evidence is reported to commit: [0-9a-f]{40}\n" +
-				".*Issues references reported:.*\n.*SAMI-1: issue not found\n.*EX-1: issue found",
+				".*Issues references reported:.*\n.*EX-1: issue found\n.*SAMI-1: issue not found",
 			additionalConfig: jiraTestsAdditionalConfig{
 				commitMessage: "go EX-1 SAMI-1 test commit",
 			},

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -115,6 +115,7 @@ The ^.kosli_ignore^ will be treated as part of the artifact like any other file,
 	jiraAPITokenFlag                     = "Jira API token (for Jira Cloud)"
 	jiraPATFlag                          = "Jira personal access token (for self-hosted Jira)"
 	jiraIssueFieldFlag                   = "[optional] The comma separated list of fields to include from the Jira issue. Default no fields are included. '*all' will give all fields."
+	jiraSecondarySourceFlag              = "[optional] An optional string to search for Jira ticket reference, e.g. '--jira-secondary-source ${{ github.head_ref }}'"
 	envDescriptionFlag                   = "[optional] The environment description."
 	flowDescriptionFlag                  = "[optional] The Kosli flow description."
 	trailDescriptionFlag                 = "[optional] The Kosli trail description."

--- a/internal/gitview/gitView.go
+++ b/internal/gitview/gitView.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/go-git/go-git/v5"
@@ -299,6 +300,7 @@ func (gv *GitView) MatchPatternInCommitMessageORBranchName(pattern, commitSHA, s
 	for match := range uniqueMatches {
 		matches = append(matches, match)
 	}
+	sort.Strings(matches)
 
 	return matches, commitInfo, nil
 }

--- a/internal/gitview/gitView_test.go
+++ b/internal/gitview/gitView_test.go
@@ -424,6 +424,14 @@ func (suite *GitViewTestSuite) TestMatchPatternInCommitMessageORBranchName() {
 			wantError:     false,
 		},
 		{
+			name:          "Same Jira references found in commit and branch name is not duplicated",
+			pattern:       "[A-Z][A-Z0-9]{1,9}-[0-9]+",
+			commitMessage: "DUP-1 some test commit",
+			branchName:    "DUP-1-test-commit",
+			want:          []string{"DUP-1"},
+			wantError:     false,
+		},
+		{
 			name:            "Jira references found in commit, branch name and secondary source",
 			pattern:         "[A-Z][A-Z0-9]{1,9}-[0-9]+",
 			commitMessage:   "ALL-1 some test commit",


### PR DESCRIPTION
- **Added jira-secondary-source argument to jira attest command**
- **Added test of duplicate keys found**
- **Updated order in test result**
- **Sort jira issues**
