### PR TITLE
restore http retry logs but with consistent format with the rest of t…

### DIFF
--- a/cmd/kosli/attestArtifact.go
+++ b/cmd/kosli/attestArtifact.go
@@ -193,7 +193,7 @@ func (o *attestArtifactOptions) run(args []string) error {
 
 	o.payload.RepoUrl, err = gitView.RepoURL()
 	if err != nil {
-		logger.Warning("Repo URL will not be reported, %s", err.Error())
+		logger.Warn("Repo URL will not be reported, %s", err.Error())
 	}
 
 	url := fmt.Sprintf("%s/api/v2/artifacts/%s/%s", global.Host, global.Org, o.flowName)

--- a/cmd/kosli/main.go
+++ b/cmd/kosli/main.go
@@ -71,7 +71,7 @@ func innerMain(cmd *cobra.Command, args []string) error {
 	}
 	if global.DryRun {
 		logger.Info("Error: %s", err.Error())
-		logger.Warning("Encountered an error but --dry-run is enabled. Exiting with 0 exit code.")
+		logger.Warn("Encountered an error but --dry-run is enabled. Exiting with 0 exit code.")
 		return nil
 	}
 	return err

--- a/cmd/kosli/reportArtifact.go
+++ b/cmd/kosli/reportArtifact.go
@@ -148,7 +148,7 @@ func (o *reportArtifactOptions) run(args []string) error {
 
 	o.payload.RepoUrl, err = gitView.RepoURL()
 	if err != nil {
-		logger.Warning("Repo URL will not be reported, %s", err.Error())
+		logger.Warn("Repo URL will not be reported, %s", err.Error())
 	}
 
 	url := fmt.Sprintf("%s/api/v2/artifacts/%s/%s", global.Host, global.Org, o.flowName)

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -485,14 +485,14 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) {
 				// get encryption key
 				key, err := security.GetSecretFromCredentialsStore(credentialsStoreKeySecretName)
 				if err != nil {
-					logger.Warning("failed to decrypt api token from [%s]. Failed to get api token encryption key from credentials store: %s", global.ConfigFile, err)
-					logger.Warning("using api token from [%s] as plain text. It is recommended to encrypt your api token by setting it with: kosli config --api-token <token>", global.ConfigFile)
+					logger.Warn("failed to decrypt api token from [%s]. Failed to get api token encryption key from credentials store: %s", global.ConfigFile, err)
+					logger.Warn("using api token from [%s] as plain text. It is recommended to encrypt your api token by setting it with: kosli config --api-token <token>", global.ConfigFile)
 				} else {
 					// decrypt token
 					decryptedBytes, err := security.AESDecrypt([]byte(val.(string)), []byte(key))
 					if err != nil {
-						logger.Warning("failed to decrypt api token from [%s]: %s", global.ConfigFile, err)
-						logger.Warning("using api token from [%s] as plain text. It is recommended to encrypt your api token by setting it with: kosli config --api-token <token>", global.ConfigFile)
+						logger.Warn("failed to decrypt api token from [%s]: %s", global.ConfigFile, err)
+						logger.Warn("using api token from [%s] as plain text. It is recommended to encrypt your api token by setting it with: kosli config --api-token <token>", global.ConfigFile)
 					} else {
 						val = string(decryptedBytes)
 						logger.Debug("using api token from [%s].", global.ConfigFile)

--- a/internal/gitview/gitView.go
+++ b/internal/gitview/gitView.go
@@ -154,7 +154,7 @@ func (gv *GitView) ChangeLog(currentCommit, previousCommit string, logger *logge
 	if previousCommit != "" {
 		commitsList, err := gv.CommitsBetween(previousCommit, currentCommit, logger)
 		if err != nil {
-			logger.Warning(err.Error())
+			logger.Warn(err.Error())
 		} else {
 			return commitsList, nil
 		}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -52,7 +52,7 @@ func (l *Logger) Debug(format string, v ...interface{}) {
 	}
 }
 
-func (l *Logger) Warning(format string, v ...interface{}) {
+func (l *Logger) Warn(format string, v ...interface{}) {
 	format = fmt.Sprintf("[warning] %s\n", format)
 	l.warnLog.Printf(format, v...)
 }

--- a/internal/requests/requests.go
+++ b/internal/requests/requests.go
@@ -52,7 +52,7 @@ func (cl *CustomLogger) Printf(format string, args ...interface{}) {
 	msg = strings.TrimPrefix(msg, "[DEBUG]")
 
 	// Call the underlying log.Logger's Printf method with the cleaned message
-	cl.Logger.Printf(msg)
+	cl.Logger.Print(msg)
 }
 
 func NewKosliClient(httpProxyURL string, maxAPIRetries int, debug bool, logger *logger.Logger) (*Client, error) {


### PR DESCRIPTION
…he logs

The output will now look like (on a failed request with retries):

```
[debug] processing config file [/Users/samialajrami/.kosli.yml]
[debug] GET http://localhost/api/v2/flows/kosli
[debug] GET http://localhost/api/v2/flows/kosli (status: 500): retrying in 1s (3 left)
[debug] GET http://localhost/api/v2/flows/kosli (status: 500): retrying in 2s (2 left)
[debug] GET http://localhost/api/v2/flows/kosli (status: 500): retrying in 4s (1 left)
Error: Get "http://localhost/api/v2/flows/kosli": GET http://localhost/api/v2/flows/kosli giving up after 4 attempt(s)
```

and on a successful call:

```
[debug] processing config file [/Users/samialajrami/.kosli.yml]
[debug] GET http://localhost/api/v2/flows/kosli
[debug] request made to http://localhost/api/v2/flows/kosli and got status 200
```