### PR TITLE
Fix CLI command syntax for creating an environment in documentation

### DIFF
--- a/docs.kosli.com/content/getting_started/environments.md
+++ b/docs.kosli.com/content/getting_started/environments.md
@@ -22,7 +22,7 @@ To create an environment via CLI, you would run a command like this:
 
 ```shell {.command}
 kosli create environment quickstart \
-    --environment-type docker \
+    --type docker \
     --description "quickstart environment for tutorial"
 ```
 


### PR DESCRIPTION
Updated the documentation to match the CLI command in https://docs.kosli.com/client_reference/kosli_create_environment/