### PR TITLE
Add extra not-found error check for analyses deleted by SonarQube

### DIFF
--- a/cmd/kosli/attestSonar_test.go
+++ b/cmd/kosli/attestSonar_test.go
@@ -159,7 +159,7 @@ func (suite *AttestSonarCommandTestSuite) TestAttestSonarCmd() {
 			wantError: true,
 			name:      "if outdated task given (i.e. we try to get results for an older scan that SonarCloud has deleted), we get an error",
 			cmd:       fmt.Sprintf("attest sonar --name cli.foo --commit HEAD --origin-url http://www.example.com --sonar-working-dir testdata/sonar/sonarcloud/.scannerwork-old %s", suite.defaultKosliArguments),
-			golden:    "Error: analysis with ID AZERk4xKSYJCvL0vWjio not found. Snapshot may have been deleted by SonarQube\n",
+			golden:    "Error: analysis not found on https://sonarcloud.io. Snapshot may have been deleted by SonarQube\n",
 		},
 		{
 			wantError: true,

--- a/cmd/kosli/testdata/sonar/sonarcloud/.scannerwork-old/report-task.txt
+++ b/cmd/kosli/testdata/sonar/sonarcloud/.scannerwork-old/report-task.txt
@@ -3,6 +3,6 @@ projectKey=FayeSGW_Hangman
 serverUrl=https://sonarcloud.io
 serverVersion=8.0.0.56246
 dashboardUrl=https://sonarcloud.io/dashboard?id=FayeSGW_Hangman
-ceTaskId=AZE2jzvUF2N-a1ygL1sM
+ceTaskId=AZERk4uWpzGpahwkB9ac
 ceTaskUrl=https://sonarcloud.io/api/ce/task?id=AZERk4uWpzGpahwkB9ac
 


### PR DESCRIPTION
Just a quick adjustment to get tests passing again since SonarQube seem to have deleted some data being used in one of the test cases.
I'll go through a do a full update of tests later.