### PR TITLE
Update helm chart to add option of custom pod labels

### DIFF
--- a/charts/k8s-reporter/templates/cronjob.yaml
+++ b/charts/k8s-reporter/templates/cronjob.yaml
@@ -14,6 +14,11 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels: 
+            {{- range $key, $value :=  .Values.podLabels }}
+              {{ $key }}: {{ $value }}
+            {{ end }}    
         spec:
           serviceAccountName: {{ include "reporter.serviceAccountName" . }}
           containers:

--- a/charts/k8s-reporter/values.yaml
+++ b/charts/k8s-reporter/values.yaml
@@ -29,6 +29,9 @@ serviceAccount:
 # -- the cron schedule at which the reporter is triggered to report to Kosli  
 cronSchedule: "*/5 * * * *"
 
+# -- custom labels to add to pods
+podLabels: {}
+
 kosliApiToken:
   # -- the name of the secret containing the kosli API token
   secretName: "kosli-api-token"


### PR DESCRIPTION
This adds an optional value for adding a map of pod labels to the cron job. 

This capability is required if for example pod Labels are required for selecting pods to run on eks fargate nodes.

Range was used to ensure that key and values are formatted with correct indents otherwise yaml to json mapping errors can occur. This should take into account multiple label values

This has been tested locally through a helm release referencing multiple labels, a single label and 0 labels to ensure correct templating