### PR TITLE
Upgrade ubuntu version for package steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,7 +221,7 @@ jobs:
 
   evidence-reporter-upload-package-and-deploy:
     needs: [pre-build, goreleaser]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v2
@@ -233,7 +233,7 @@ jobs:
 
   environment-reporter-upload-package-and-deploy:
     needs: [pre-build, goreleaser]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v2


### PR DESCRIPTION
The runner used in the packaging steps needed to be upgraded to the latest version, to keep current with the runners available within Github actions.