### PR TITLE
allow handling sarif files with schema from main branch

### DIFF
--- a/internal/snyk/sarif-code.json
+++ b/internal/snyk/sarif-code.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+    "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
     "version": "2.1.0",
     "runs": [
       {

--- a/internal/snyk/snyk.go
+++ b/internal/snyk/snyk.go
@@ -47,7 +47,7 @@ func ProcessSnykResultFile(file string) (*SnykData, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !strings.HasPrefix(report.Schema, "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-") && !strings.HasPrefix(report.Schema, "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json") {
+	if !strings.HasPrefix(report.Schema, "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/") && !strings.HasPrefix(report.Schema, "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-") && !strings.HasPrefix(report.Schema, "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json") {
 		return nil, fmt.Errorf("invalid sarif file")
 	}
 	data := &SnykData{


### PR DESCRIPTION
Every now then the sarif schema urls change in generated Sarif files by different tools. Most often, these changes are to paths or branch names and don't actually change anything about the schema itself. This change makes the CLI accept any schema from the main branch in the oasis-tcs repo.