### PR TITLE
increase kubernetes client throttling limits

### DIFF
--- a/internal/kube/kube.go
+++ b/internal/kube/kube.go
@@ -84,6 +84,11 @@ func NewK8sClientSet(kubeconfigPath string) (*K8SConnection, error) {
 		}
 	}
 
+	// set the QPS and burst for the config to control the rate of requests to the API server
+	//  defaults are 5 QPS and 10 burst which is too low for large clusters
+	config.QPS = 50
+	config.Burst = 100
+
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR is in response to kosli-dev/server#4467 where kuberentes SDK client throttling slows down the snapshotting of large clusters.
This PR increases the throttling config which speeds the snapshotting of 1000 namespaces from ~5 mins to <20 seconds.

This is one step of 2 to improve the concurrency of k8s snapshotting for large clusters.