### PR TITLE
docs: change permissions for environments and policies

### DIFF
--- a/docs.kosli.com/content/administration/managing_users/roles_in_kosli.md
+++ b/docs.kosli.com/content/administration/managing_users/roles_in_kosli.md
@@ -33,10 +33,10 @@ Kosli provides three user roles to help administrators manage access and permiss
 | **Resource Management** | | | |
 | Create flows | ✅ | ✅ | ❌ |
 | Update/delete flows | ✅ | ✅ | ❌ |
-| Create environments | ✅ | ✅ | ❌ |
-| Update/delete environments | ✅ | ✅ | ❌ |
-| Create policies | ✅ | ✅ | ❌ |
-| Update/delete policies | ✅ | ✅ | ❌ |
+| Create/update environments | ✅ | ✅ | ❌ |
+| Delete environments | ✅ | ❌ | ❌ |
+| Create/update policies | ✅ | ✅ | ❌ |
+| Delete policies | ❌ | ❌ | ❌ |
 | Create attestation types | ✅ | ✅ | ❌ |
 | Update/delete attestation types | ✅ | ✅ | ❌ |
 | **Attestations & Snapshots** | | | |


### PR DESCRIPTION
I learned that: 

* It requires admin privileges to archive an environment (secret updated in https://github.com/kosli-dev/secrets/pull/91)
* It's not possible to archive a policy (this may be a near future problem for the Terraform provider)

closes #641 