### PR TITLE
Fix multihost printing

### DIFF
--- a/cmd/kosli/multiHost_test.go
+++ b/cmd/kosli/multiHost_test.go
@@ -118,7 +118,7 @@ func (suite *MultiHostTestSuite) TestRunDoubledHost() {
 		{
 			name:   "only returns primary call output when both (2) calls succeed",
 			args:   doubledArgs([]string{"kosli", "status"}),
-			stdOut: []string{"[http://localhost:8001]", "OK", ""},
+			stdOut: []string{"OK", ""},
 			err:    error(nil),
 		},
 	} {
@@ -153,7 +153,7 @@ func (suite *MultiHostTestSuite) TestRunTripledHost() {
 		{
 			name:   "only returns primary call output when all three calls succeed",
 			args:   tripledArgs([]string{"kosli", "status"}),
-			stdOut: []string{"[http://localhost:8001]", "OK", ""},
+			stdOut: []string{"OK", ""},
 			err:    error(nil),
 		},
 	} {


### PR DESCRIPTION
A previous commit https://github.com/kosli-dev/cli/commit/fda38e93c0740cbb8415b80405560bc03c6ce11c prefixed *all* output on stdout with the hostname when in multi-host mode. This broke clients (cyber-dojo) making CLI calls with the `--output=json` which of course no longer produced JSON. Doh!
This PR fixes this so stdout is prefixed with the hostname (in multi-host mode) only in debug mode.