### PR TITLE
Added minimum _test.go files for files that does not have tests.

### DIFF
--- a/internal/bitbucket/bitbucket_test.go
+++ b/internal/bitbucket/bitbucket_test.go
@@ -1,0 +1,9 @@
+package bitbucket_test
+
+import "testing"
+
+func TestPlaceholder(t *testing.T) {
+	// We use the tool cover for coverage, but if there is no _test.go file, then
+	// Go use the tool covdata. At the same time, they removed covdata as a precompiled
+	// binary in the distribution. This made the coverage calculation fail for some of us.
+}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,9 @@
+package logger_test
+
+import "testing"
+
+func TestPlaceholder(t *testing.T) {
+	// We use the tool cover for coverage, but if there is no _test.go file, then
+	// Go use the tool covdata. At the same time, they removed covdata as a precompiled
+	// binary in the distribution. This made the coverage calculation fail for some of us.
+}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1,0 +1,9 @@
+package output_test
+
+import "testing"
+
+func TestPlaceholder(t *testing.T) {
+	// We use the tool cover for coverage, but if there is no _test.go file, then
+	// Go use the tool covdata. At the same time, they removed covdata as a precompiled
+	// binary in the distribution. This made the coverage calculation fail for some of us.
+}

--- a/internal/sonar/sonar_test.go
+++ b/internal/sonar/sonar_test.go
@@ -1,0 +1,9 @@
+package sonar_test
+
+import "testing"
+
+func TestPlaceholder(t *testing.T) {
+	// We use the tool cover for coverage, but if there is no _test.go file, then
+	// Go use the tool covdata. At the same time, they removed covdata as a precompiled
+	// binary in the distribution. This made the coverage calculation fail for some of us.
+}

--- a/internal/testHelpers/testHelpers_test.go
+++ b/internal/testHelpers/testHelpers_test.go
@@ -1,0 +1,9 @@
+package testHelpers_test
+
+import "testing"
+
+func TestPlaceholder(t *testing.T) {
+	// We use the tool cover for coverage, but if there is no _test.go file, then
+	// Go use the tool covdata. At the same time, they removed covdata as a precompiled
+	// binary in the distribution. This made the coverage calculation fail for some of us.
+}


### PR DESCRIPTION
We use the tool cover for coverage, but if there is no _test.go file,
then Go use the tool covdata. At the same time, they removed covdata
as a precompiled binary in the distribution. This made the coverage
calculation fail for some of us.

As described in this discussion
  https://github.com/golang/go/issues/75031
there is an other option to fix this by modifying the
GOTOOLCHAIN variable, but that is too much magic for me and
could be very hard to debug for the next person who stumbles
over this.
