### PR TITLE
fix(docgen): escape MDX-incompatible patterns in Mintlify output

### DIFF
--- a/internal/docgen/mintlify_test.go
+++ b/internal/docgen/mintlify_test.go
@@ -200,6 +200,26 @@ func TestEscapeMintlifyProse(t *testing.T) {
 			want:  "Use <a href=\"x\">link</a>",
 		},
 		{
+			name:  "lowercase angle brackets with pipes converted",
+			input: "Use <hours|days|weeks|months> for time",
+			want:  "Use `hours|days|weeks|months` for time",
+		},
+		{
+			name:  "uppercase angle brackets with pipes converted",
+			input: "Format: <COMMIT_SHA1|ARTIFACT_FINGERPRINT>",
+			want:  "Format: `COMMIT_SHA1|ARTIFACT_FINGERPRINT`",
+		},
+		{
+			name:  "lowercase single-word placeholders converted",
+			input: "flowName@<fingerprint> or flowName:<commit_sha>",
+			want:  "flowName@`fingerprint` or flowName:`commit_sha`",
+		},
+		{
+			name:  "double curly braces escaped",
+			input: "--jira-secondary-source ${{ github.head_ref }}",
+			want:  "--jira-secondary-source $\\{\\{ github.head_ref \\}\\}",
+		},
+		{
 			name:  "code fence content not escaped",
 			input: "text ```\n{code}\n<FOO>\n``` more {text}",
 			want:  "text ```\n{code}\n<FOO>\n``` more \\{text\\}",


### PR DESCRIPTION
## Summary

- Escape angle-bracket placeholders with pipes (e.g. `<hours|days|weeks|months>`) and lowercase placeholders (e.g. `<fingerprint>`, `<commit_sha>`) that MDX interprets as invalid JSX tags
- Apply `escapeMintlifyProse()` to flag section content — previously only the synopsis was escaped, leaving `${{ github.head_ref }}` unescaped in flag table descriptions
- Simplify the angle bracket regex to a single pattern that matches all non-HTML placeholder patterns

## Fixed parsing errors

- `kosli_attest_jira.md` — `${{ github.head_ref }}` in flag table
- `kosli_diff_snapshots.md` / `kosli_get_snapshot.md` — `<hours|days|weeks|months>`
- `kosli_get_artifact.md` — `<fingerprint>`, `<commit_sha>`

## Test plan

- [x] All existing `docgen` tests pass
- [x] Added test cases for lowercase placeholders, pipe patterns, and double curly braces
- [x] Regenerate docs with `kosli docs --mintlify` and verify no MDX parsing errors in `mint dev`