### PR TITLE
add: include email notification configuration in actions documentation

### DIFF
--- a/docs.kosli.com/content/integrations/actions.md
+++ b/docs.kosli.com/content/integrations/actions.md
@@ -91,6 +91,12 @@ Custom webhook notifications empower you to implement automation workflows for "
 }
 ```
 
+## Email
+
+For emails, you need to provide a comma seperated list of recievers.
+
+The emails will come from `noreply@kosli.com`.
+
 # Manage Actions in the UI
 
 You can manage Actions for your organization in the Kosli UI from the `Actions` section in the left navigation menu. The Actions sections enables you to:


### PR DESCRIPTION
We did not write anything about the email action we have in the system, including what the email sender is.
Therefore this small PR.