### PR TITLE
add support for reporting multiple k8s envs with one reporter command

### DIFF
--- a/cmd/kosli/snapshotK8S.go
+++ b/cmd/kosli/snapshotK8S.go
@@ -6,12 +6,15 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/kosli-dev/cli/internal/filters"
 	"github.com/kosli-dev/cli/internal/kube"
 	"github.com/kosli-dev/cli/internal/requests"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 const snapshotK8SShortDesc = `Report a snapshot of running pods in a K8S cluster or namespace(s) to Kosli.  `
@@ -52,11 +55,99 @@ kosli snapshot k8s yourEnvironmentName \
 	--org yourOrgName
 `
 
+const k8sConfigFileFlag = "[optional] The path to a YAML config file that maps multiple Kosli environments to namespace selectors. Cannot be used with a positional environment name argument or namespace flags."
+
+type k8sSnapshotConfig struct {
+	Environments []k8sEnvironmentConfig `yaml:"environments"`
+}
+
+type k8sEnvironmentConfig struct {
+	Name                   string   `yaml:"name"`
+	Namespaces             []string `yaml:"namespaces"`
+	NamespacesRegex        []string `yaml:"namespacesRegex"`
+	ExcludeNamespaces      []string `yaml:"excludeNamespaces"`
+	ExcludeNamespacesRegex []string `yaml:"excludeNamespacesRegex"`
+}
+
+func (e *k8sEnvironmentConfig) toFilter() *filters.ResourceFilterOptions {
+	return &filters.ResourceFilterOptions{
+		IncludeNames:      e.Namespaces,
+		IncludeNamesRegex: e.NamespacesRegex,
+		ExcludeNames:      e.ExcludeNamespaces,
+		ExcludeNamesRegex: e.ExcludeNamespacesRegex,
+	}
+}
+
+func parseK8SSnapshotConfig(path string) (*k8sSnapshotConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file '%s': %w", path, err)
+	}
+
+	var config k8sSnapshotConfig
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	if err := validateK8SSnapshotConfig(&config); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+func validateK8SSnapshotConfig(config *k8sSnapshotConfig) error {
+	if len(config.Environments) == 0 {
+		return fmt.Errorf("invalid config: 'environments' list must contain at least one entry")
+	}
+
+	seen := make(map[string]bool)
+	for i, env := range config.Environments {
+		if env.Name == "" {
+			return fmt.Errorf("invalid config: environment entry %d is missing required field 'name'", i+1)
+		}
+
+		if seen[env.Name] {
+			return fmt.Errorf("invalid config: duplicate environment name '%s'", env.Name)
+		}
+		seen[env.Name] = true
+
+		hasInclude := len(env.Namespaces) > 0 || len(env.NamespacesRegex) > 0
+		hasExclude := len(env.ExcludeNamespaces) > 0 || len(env.ExcludeNamespacesRegex) > 0
+		if hasInclude && hasExclude {
+			includeType := "namespaces"
+			if len(env.Namespaces) == 0 {
+				includeType = "namespacesRegex"
+			}
+			excludeType := "excludeNamespaces"
+			if len(env.ExcludeNamespaces) == 0 {
+				excludeType = "excludeNamespacesRegex"
+			}
+			return fmt.Errorf("invalid config for environment '%s': cannot combine '%s' with '%s'",
+				env.Name, includeType, excludeType)
+		}
+
+		for _, pattern := range env.NamespacesRegex {
+			if _, err := regexp.Compile(pattern); err != nil {
+				return fmt.Errorf("invalid config for environment '%s': invalid regex '%s': %v",
+					env.Name, pattern, err)
+			}
+		}
+		for _, pattern := range env.ExcludeNamespacesRegex {
+			if _, err := regexp.Compile(pattern); err != nil {
+				return fmt.Errorf("invalid config for environment '%s': invalid regex '%s': %v",
+					env.Name, pattern, err)
+			}
+		}
+	}
+
+	return nil
+}
+
 type snapshotK8SOptions struct {
-	kubeconfig string
-	// namespaces        []string
-	// excludeNamespaces []string
-	filter *filters.ResourceFilterOptions
+	kubeconfig     string
+	configFilePath string
+	filter         *filters.ResourceFilterOptions
 }
 
 func newSnapshotK8SCmd(out io.Writer) *cobra.Command {
@@ -68,20 +159,56 @@ func newSnapshotK8SCmd(out io.Writer) *cobra.Command {
 		Short:   snapshotK8SShortDesc,
 		Long:    snapshotK8SLongDesc,
 		Example: snapshotK8SExample,
-		Args:    cobra.ExactArgs(1),
+		Args: func(cmd *cobra.Command, args []string) error {
+			configFileFlag := cmd.Flags().Lookup("config-file")
+			hasConfigFile := configFileFlag != nil && configFileFlag.Changed
+			if hasConfigFile && len(args) > 0 {
+				return fmt.Errorf("cannot use '--config-file' together with a positional environment name argument")
+			}
+			if !hasConfigFile && len(args) == 0 {
+				return fmt.Errorf("requires either a positional environment name argument or --config-file")
+			}
+			if !hasConfigFile && len(args) > 1 {
+				return fmt.Errorf("accepts at most 1 arg(s), received %d", len(args))
+			}
+			return nil
+		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			err := RequireGlobalFlags(global, []string{"Org", "ApiToken"})
 			if err != nil {
 				return ErrorBeforePrintingUsage(cmd, err.Error())
 			}
+
+			configFileFlag := cmd.Flags().Lookup("config-file")
+			hasConfigFile := configFileFlag != nil && configFileFlag.Changed
+			if hasConfigFile {
+				namespaceFlagNames := []string{"namespaces", "exclude-namespaces", "namespaces-regex", "exclude-namespaces-regex"}
+				for _, flagName := range namespaceFlagNames {
+					if f := cmd.Flags().Lookup(flagName); f != nil && f.Changed {
+						return fmt.Errorf("cannot use '--config-file' together with '--%s'", flagName)
+					}
+				}
+				return nil
+			}
+
 			return MuXRequiredFlags(cmd, []string{"namespaces", "exclude-namespaces"}, false)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return o.run(args)
+			clientset, err := kube.NewK8sClientSet(o.kubeconfig)
+			if err != nil {
+				return err
+			}
+			if o.configFilePath != "" {
+				return o.runMultiEnv(clientset)
+			}
+			return o.run(clientset, args)
 		},
 	}
 
 	cmd.Flags().StringVarP(&o.kubeconfig, "kubeconfig", "k", defaultKubeConfigPath(), kubeconfigFlag)
+	// Shadows the global --config-file persistent flag intentionally.
+	// The global Kosli config can still be set via KOSLI_CONFIG_FILE env var.
+	cmd.Flags().StringVar(&o.configFilePath, "config-file", "", k8sConfigFileFlag)
 	cmd.Flags().StringSliceVarP(&o.filter.IncludeNames, "namespaces", "n", []string{}, namespacesFlag)
 	cmd.Flags().StringSliceVar(&o.filter.IncludeNamesRegex, "namespaces-regex", []string{}, namespacesRegexFlag)
 	cmd.Flags().StringSliceVarP(&o.filter.ExcludeNames, "exclude-namespaces", "x", []string{}, excludeNamespacesFlag)
@@ -90,32 +217,45 @@ func newSnapshotK8SCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
-func (o *snapshotK8SOptions) run(args []string) error {
-	envName := args[0]
-	url := fmt.Sprintf("%s/api/v2/environments/%s/%s/report/K8S", global.Host, global.Org, envName)
-	clientset, err := kube.NewK8sClientSet(o.kubeconfig)
-	if err != nil {
-		return err
-	}
-	podsData, err := clientset.GetPodsData(o.filter, logger)
+func (o *snapshotK8SOptions) run(clientset *kube.K8SConnection, args []string) error {
+	return o.reportEnvironment(clientset, args[0], o.filter)
+}
+
+func (o *snapshotK8SOptions) runMultiEnv(clientset *kube.K8SConnection) error {
+	config, err := parseK8SSnapshotConfig(o.configFilePath)
 	if err != nil {
 		return err
 	}
 
-	payload := &kube.K8sEnvRequest{
-		Artifacts: podsData,
+	var errs []string
+	for _, env := range config.Environments {
+		if err := o.reportEnvironment(clientset, env.Name, env.toFilter()); err != nil {
+			errs = append(errs, fmt.Sprintf("environment '%s': %v", env.Name, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%s", strings.Join(errs, "\n"))
+	}
+	return nil
+}
+
+func (o *snapshotK8SOptions) reportEnvironment(clientset *kube.K8SConnection, envName string, filter *filters.ResourceFilterOptions) error {
+	podsData, err := clientset.GetPodsData(filter, logger)
+	if err != nil {
+		return err
 	}
 
 	reqParams := &requests.RequestParams{
 		Method:  http.MethodPut,
-		URL:     url,
-		Payload: payload,
+		URL:     fmt.Sprintf("%s/api/v2/environments/%s/%s/report/K8S", global.Host, global.Org, envName),
+		Payload: &kube.K8sEnvRequest{Artifacts: podsData},
 		DryRun:  global.DryRun,
 		Token:   global.ApiToken,
 	}
 	_, err = kosliClient.Do(reqParams)
 	if err == nil && !global.DryRun {
-		logger.Info("[%d] pods were reported to environment %s", len(payload.Artifacts), envName)
+		logger.Info("[%d] pods were reported to environment %s", len(podsData), envName)
 	}
 	return err
 }

--- a/cmd/kosli/snapshotK8S_test.go
+++ b/cmd/kosli/snapshotK8S_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -38,19 +40,136 @@ func (suite *SnapshotK8STestSuite) TestSnapshotK8SCmd() {
 		},
 		{
 			wantError: true,
-			name:      "snapshot K8S fails if 2 args are provided",
-			cmd:       fmt.Sprintf(`snapshot k8s %s xxx %s`, suite.envName, suite.defaultKosliArguments),
-			golden:    "Error: accepts 1 arg(s), received 2\n",
+			name:      "snapshot K8S fails if no args and no --config-file",
+			cmd:       fmt.Sprintf(`snapshot k8s %s`, suite.defaultKosliArguments),
+			golden:    "Error: requires either a positional environment name argument or --config-file\n",
 		},
 		{
 			wantError: true,
-			name:      "snapshot K8S fails if no args are set",
-			cmd:       fmt.Sprintf(`snapshot k8s %s`, suite.defaultKosliArguments),
-			golden:    "Error: accepts 1 arg(s), received 0\n",
+			name:      "snapshot K8S fails if --config-file and positional arg are both provided",
+			cmd:       fmt.Sprintf(`snapshot k8s %s --config-file testdata/k8s-config/valid-single.yaml %s`, suite.envName, suite.defaultKosliArguments),
+			golden:    "Error: cannot use '--config-file' together with a positional environment name argument\n",
+		},
+		{
+			wantError: true,
+			name:      "snapshot K8S fails if --config-file and --namespaces are both provided",
+			cmd:       fmt.Sprintf(`snapshot k8s --config-file testdata/k8s-config/valid-single.yaml --namespaces default %s`, suite.defaultKosliArguments),
+			golden:    "Error: cannot use '--config-file' together with '--namespaces'\n",
+		},
+		{
+			wantError: true,
+			name:      "snapshot K8S fails if --config-file and --exclude-namespaces are both provided",
+			cmd:       fmt.Sprintf(`snapshot k8s --config-file testdata/k8s-config/valid-single.yaml --exclude-namespaces default %s`, suite.defaultKosliArguments),
+			golden:    "Error: cannot use '--config-file' together with '--exclude-namespaces'\n",
+		},
+		{
+			wantError: true,
+			name:      "snapshot K8S fails if config file not found",
+			cmd:       fmt.Sprintf(`snapshot k8s --config-file /nonexistent/path.yaml %s`, suite.defaultKosliArguments),
+			golden:    "Error: failed to read config file '/nonexistent/path.yaml': open /nonexistent/path.yaml: no such file or directory\n",
+		},
+		{
+			wantError: true,
+			name:      "snapshot K8S fails if config file has invalid YAML",
+			cmd:       fmt.Sprintf(`snapshot k8s --config-file testdata/k8s-config/invalid-yaml.yaml %s`, suite.defaultKosliArguments),
+			goldenRegex: "Error: failed to parse config file.*",
+		},
+		{
+			wantError: true,
+			name:      "snapshot K8S fails if config file has empty environments list",
+			cmd:       fmt.Sprintf(`snapshot k8s --config-file testdata/k8s-config/empty-environments.yaml %s`, suite.defaultKosliArguments),
+			golden:    "Error: invalid config: 'environments' list must contain at least one entry\n",
+		},
+		{
+			wantError: true,
+			name:      "snapshot K8S fails if config file has entry missing name",
+			cmd:       fmt.Sprintf(`snapshot k8s --config-file testdata/k8s-config/missing-name.yaml %s`, suite.defaultKosliArguments),
+			golden:    "Error: invalid config: environment entry 1 is missing required field 'name'\n",
+		},
+		{
+			wantError: true,
+			name:      "snapshot K8S fails if config file has duplicate environment names",
+			cmd:       fmt.Sprintf(`snapshot k8s --config-file testdata/k8s-config/duplicate-names.yaml %s`, suite.defaultKosliArguments),
+			golden:    "Error: invalid config: duplicate environment name 'prod-env'\n",
+		},
+		{
+			wantError: true,
+			name:      "snapshot K8S fails if config file has conflicting filters",
+			cmd:       fmt.Sprintf(`snapshot k8s --config-file testdata/k8s-config/conflicting-filters.yaml %s`, suite.defaultKosliArguments),
+			golden:    "Error: invalid config for environment 'bad-env': cannot combine 'namespaces' with 'excludeNamespaces'\n",
+		},
+		{
+			wantError: true,
+			name:      "snapshot K8S fails if config file has invalid regex",
+			cmd:       fmt.Sprintf(`snapshot k8s --config-file testdata/k8s-config/invalid-regex.yaml %s`, suite.defaultKosliArguments),
+			goldenRegex: `Error: invalid config for environment 'bad-regex-env': invalid regex '\[invalid'.*`,
 		},
 	}
 
 	runTestCmd(suite.T(), tests)
+}
+
+func TestParseK8SSnapshotConfig(t *testing.T) {
+	t.Run("valid single environment config", func(t *testing.T) {
+		config, err := parseK8SSnapshotConfig("testdata/k8s-config/valid-single.yaml")
+		require.NoError(t, err)
+		require.Len(t, config.Environments, 1)
+		assert.Equal(t, "prod-env", config.Environments[0].Name)
+		assert.Equal(t, []string{"prod-ns1", "prod-ns2"}, config.Environments[0].Namespaces)
+	})
+
+	t.Run("valid multi-environment config", func(t *testing.T) {
+		config, err := parseK8SSnapshotConfig("testdata/k8s-config/valid-multi.yaml")
+		require.NoError(t, err)
+		require.Len(t, config.Environments, 3)
+		assert.Equal(t, "prod-env", config.Environments[0].Name)
+		assert.Equal(t, "staging-env", config.Environments[1].Name)
+		assert.Equal(t, "infra-env", config.Environments[2].Name)
+		assert.Equal(t, []string{"^staging-.*"}, config.Environments[1].NamespacesRegex)
+		assert.Equal(t, []string{"prod-ns1", "prod-ns2", "default"}, config.Environments[2].ExcludeNamespaces)
+	})
+
+	t.Run("file not found", func(t *testing.T) {
+		_, err := parseK8SSnapshotConfig("/nonexistent/path.yaml")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read config file")
+	})
+
+	t.Run("invalid YAML", func(t *testing.T) {
+		_, err := parseK8SSnapshotConfig("testdata/k8s-config/invalid-yaml.yaml")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse config file")
+	})
+
+	t.Run("empty environments list", func(t *testing.T) {
+		_, err := parseK8SSnapshotConfig("testdata/k8s-config/empty-environments.yaml")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "'environments' list must contain at least one entry")
+	})
+
+	t.Run("missing environment name", func(t *testing.T) {
+		_, err := parseK8SSnapshotConfig("testdata/k8s-config/missing-name.yaml")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "environment entry 1 is missing required field 'name'")
+	})
+
+	t.Run("duplicate environment names", func(t *testing.T) {
+		_, err := parseK8SSnapshotConfig("testdata/k8s-config/duplicate-names.yaml")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate environment name 'prod-env'")
+	})
+
+	t.Run("conflicting filters", func(t *testing.T) {
+		_, err := parseK8SSnapshotConfig("testdata/k8s-config/conflicting-filters.yaml")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot combine 'namespaces' with 'excludeNamespaces'")
+	})
+
+	t.Run("invalid regex", func(t *testing.T) {
+		_, err := parseK8SSnapshotConfig("testdata/k8s-config/invalid-regex.yaml")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid regex")
+	})
 }
 
 // In order for 'go test' to run this suite, we need to create

--- a/cmd/kosli/testdata/k8s-config/conflicting-filters.yaml
+++ b/cmd/kosli/testdata/k8s-config/conflicting-filters.yaml
@@ -1,0 +1,4 @@
+environments:
+  - name: bad-env
+    namespaces: [prod-ns]
+    excludeNamespaces: [staging-ns]

--- a/cmd/kosli/testdata/k8s-config/duplicate-names.yaml
+++ b/cmd/kosli/testdata/k8s-config/duplicate-names.yaml
@@ -1,0 +1,5 @@
+environments:
+  - name: prod-env
+    namespaces: [ns1]
+  - name: prod-env
+    namespaces: [ns2]

--- a/cmd/kosli/testdata/k8s-config/empty-environments.yaml
+++ b/cmd/kosli/testdata/k8s-config/empty-environments.yaml
@@ -1,0 +1,1 @@
+environments: []

--- a/cmd/kosli/testdata/k8s-config/invalid-regex.yaml
+++ b/cmd/kosli/testdata/k8s-config/invalid-regex.yaml
@@ -1,0 +1,3 @@
+environments:
+  - name: bad-regex-env
+    namespacesRegex: ["[invalid"]

--- a/cmd/kosli/testdata/k8s-config/invalid-yaml.yaml
+++ b/cmd/kosli/testdata/k8s-config/invalid-yaml.yaml
@@ -1,0 +1,3 @@
+environments:
+  - name: bad
+    namespaces: [

--- a/cmd/kosli/testdata/k8s-config/missing-name.yaml
+++ b/cmd/kosli/testdata/k8s-config/missing-name.yaml
@@ -1,0 +1,2 @@
+environments:
+  - namespaces: [prod-ns]

--- a/cmd/kosli/testdata/k8s-config/valid-multi.yaml
+++ b/cmd/kosli/testdata/k8s-config/valid-multi.yaml
@@ -1,0 +1,7 @@
+environments:
+  - name: prod-env
+    namespaces: [prod-ns1, prod-ns2]
+  - name: staging-env
+    namespacesRegex: ["^staging-.*"]
+  - name: infra-env
+    excludeNamespaces: [prod-ns1, prod-ns2, default]

--- a/cmd/kosli/testdata/k8s-config/valid-single.yaml
+++ b/cmd/kosli/testdata/k8s-config/valid-single.yaml
@@ -1,0 +1,3 @@
+environments:
+  - name: prod-env
+    namespaces: [prod-ns1, prod-ns2]


### PR DESCRIPTION
## Summary

related to kosli-dev/server#4720
Adds a `--config-file` flag to `kosli snapshot k8s` that allows reporting multiple Kosli environments in a single command invocation. Previously, users had to run the command once per environment; now they can define all environment-to-namespace mappings in a single YAML file.

## How it works

When `--config-file` is provided, the command reads a YAML file with an `environments` list, where each entry specifies:
- `name` — the Kosli environment name
- `namespaces` / `namespacesRegex` — namespaces to include
- `excludeNamespaces` / `excludeNamespacesRegex` — namespaces to exclude

Example config file:
```yaml
environments:
  - name: prod-env
    namespaces: [prod-ns1, prod-ns2]
  - name: staging-env
    namespacesRegex: ["^staging-.*"]
  - name: infra-env
    excludeNamespaces: [prod-ns1, prod-ns2, default]
```

The `--config-file` flag is mutually exclusive with the positional environment name argument and with any namespace flags (`--namespaces`, `--exclude-namespaces`, etc.).

> **Note:** `--config-file` shadows the global Kosli `--config-file` persistent flag for this subcommand. The global Kosli config can still be set via the `KOSLI_CONFIG_FILE` environment variable.

## Changes

- New `k8sSnapshotConfig` / `k8sEnvironmentConfig` structs and YAML parsing logic
- Config validation: at least one environment required, no duplicate names, no mixing of include and exclude filters, valid regex patterns
- New `runMultiEnv` method that reports each environment, collecting and surfacing all errors at the end
- Refactored `run` to share `reportEnvironment` logic with the multi-env path
- Comprehensive unit and CLI tests, with testdata fixture files covering valid and invalid config scenarios