### PR TITLE
ci: trigger CLI docs update workflow on CLI repo tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,6 +219,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MESSAGE: "Release: {msg}"
 
+  docs-repo-dispatch:
+    needs: [pre-build, goreleaser]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ secrets.DOCS_REPO_ACCESS_TOKEN }}
+          repository: kosli-dev/docs
+          event-type: cli-release
+          client-payload: '{"kosli_cli_tag": "${{ needs.pre-build.outputs.tag }}"}'
+
   evidence-reporter-upload-package-and-deploy:
     needs: [pre-build, goreleaser]
     runs-on: ubuntu-latest
@@ -267,6 +279,7 @@ jobs:
         binary-provenance,
         homebrew-pr,
         docs-gen,
+        docs-repo-dispatch,
         evidence-reporter-upload-package-and-deploy,
         environment-reporter-upload-package-and-deploy,
         environment-reporter-upload-layer


### PR DESCRIPTION
## Summary
- Adds a `docs-repo-dispatch` job to the release workflow
- Fires a `repository_dispatch` event to `kosli-dev/docs` with the released CLI tag on each new release
- Enables automated docs site updates triggered by CLI releases

Closes kosli-dev/docs#30