### PR TITLE
Update GoReleaser configuration for improved build settings and forma…

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 project_name: kosli
 before:
   hooks:
@@ -22,6 +23,9 @@ builds:
       - amd64
       - arm64
       - arm
+    ignore:
+      - goos: windows
+        goarch: arm
     main: ./cmd/kosli/
 
 archives:
@@ -31,7 +35,7 @@ archives:
     # Default is empty.
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 
 # docs for nfpm can be found here:  https://goreleaser.com/customization/nfpm/
@@ -48,7 +52,7 @@ nfpms:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
 
-    builds:
+    ids:
       - kosli
 
     vendor: Kosli Inc.


### PR DESCRIPTION
Also skips the obsolete windows/arm configuration,  but windows/arm64 is still built

Fixes the following complaints from "goreleaser check"
  • only version: 2 configuration files are supported, yours is version: 0, please update your configuration
  • checking                                  path=.goreleaser.yml
  ⨯ broken target, use at your own risk              target=windows_arm_6
  • DEPRECATED: archives.format_overrides.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
  • DEPRECATED: nfpms.builds should not be used anymore, check https://goreleaser.com/deprecations#nfpmsbuilds for more info
  • .goreleaser.yml                                  error=configuration is valid, but uses deprecated properties
  ⨯ check failed                                     error=1 out of 1 configuration file(s) have issues