### PR TITLE
Update actions/checkout to v6 across all workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,6 @@ jobs:
     steps:
 
     - uses: actions/checkout@v6
-    
       with:
         ref: ${{ inputs.checkout_ref || github.sha }}
 


### PR DESCRIPTION
Bump actions/checkout to v6 in all GitHub Actions workflow files so that we are moved off the old Node20.