### PR TITLE
Bump goreleaser-action version to v7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
           fi
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: latest
           args: release --clean ${{ steps.get-tag-notes.outputs.args }}


### PR DESCRIPTION
Seeing error "only configurations files on version: 1 are supported, yours is version: 2, please update your configuration" goreleaser-action@v7 supports the new configuration version