### PR TITLE
Add release-notes.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ docs.kosli.com/.netlify
 # keep it uncommented on main
 docs.kosli.com/assets/metadata.json
 tmp/
+release_notes.md
 junit.xml
 junit-test-results/.
 .claude/settings.local.json


### PR DESCRIPTION
Goreleaser was erroring with dirty state on release-notes.md it was being sent via file from tag was dirtying the git state.