### PR TITLE
Trim leading periods from artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
             if ($item.type == "Archive") then
                 . + [{ template_name: ($item.goos + "-" + $item.goarch), path: $item.path }]
             elif ($item.type == "Linux Package") then
-                . + [{ template_name: ($item.extra.Ext + "-pkg-" + $item.goarch), path: $item.path }]
+                . + [{ template_name: (($item.extra.Ext | ltrimstr(".")) + "-pkg-" + $item.goarch), path: $item.path }]
             else
                 .
             end


### PR DESCRIPTION
Kosli cli rejects artifact names that begin with a . so have to trim them