### PR TITLE
feat: Add CI ready Dockerfile

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,24 @@
+ARG ALPINE_VERSION=3.23
+ARG KOSLI_VERSION=2.13.1
+
+FROM ghcr.io/kosli-dev/cli:v${KOSLI_VERSION} AS builder
+
+FROM alpine:${ALPINE_VERSION}
+COPY --from=builder /bin/kosli /bin
+
+RUN apk add --no-cache git curl ca-certificates \
+    && ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" \
+    # Create a non-root user and group to switch to
+    && addgroup -S kosli \
+    && adduser -S -G kosli -h /workspace kosli \
+    && kosli version
+
+# Kosli reads org and token from ENV. Intentionally not populating API keys here
+ENV KOSLI_ORG="" \
+    KOSLI_HOST="https://app.kosli.com"
+
+WORKDIR /workspace
+
+USER kosli
+
+#ENTRYPOINT ["/bin/kosli"]


### PR DESCRIPTION
Related to: https://github.com/kosli-dev/server/pull/4702

Following up the conversations with a customer we need to provide a Dockerfile which can be used as part of CI (e.g. GitLab runners). Our current image doesn't provide anything besides CLI and runners would have additional requirements, e.g.: https://docs.gitlab.com/ci/docker/using_docker_images/#image-requirements

This `Dockerfile` is based on Alpine base image and should keep the securty footprint low. At this point we're not yet building and publishing the image and only providing Dockerfile.