### PR TITLE
Improve Claude PR review with static analysis and balanced feedback

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -80,6 +80,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ".go-version"
+          check-latest: true
+
       - name: Claude review (general)
         uses: anthropics/claude-code-action@v1
         env:
@@ -92,11 +98,25 @@ jobs:
           claude_args: |
             --max-turns 30
             --model claude-opus-4-6
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(go build:*),Bash(go vet:*),Bash(go mod tidy:*),Bash(git diff:*),Bash(golangci-lint:*)"
 
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Read CLAUDE.md in the repo root for build commands, architecture details, and testing patterns.
+            Use this context to assess whether the PR follows established conventions.
+
+            ## Phase 1: Static Analysis (run these BEFORE reading code)
+
+            Run the following checks and note any failures:
+            1. `go build ./...` — verify the code compiles
+            2. `go vet ./...` — catch common Go mistakes
+            3. `go mod tidy && git diff --exit-code go.mod go.sum` — check for missing or unused dependencies
+
+            Include any failures from these checks in your review as high-priority issues.
+
+            ## Phase 2: Code Review
 
             Review this PR for:
 
@@ -107,6 +127,11 @@ jobs:
             5. **Testability and testing** – whether new/changed behavior is testable and whether tests are present and sufficient; suggest extra tests or coverage gaps where relevant.
             6. **Security implications** – potential security vulnerabilities, data exposure, and other security risks.
             7. **Performance considerations** – potential performance bottlenecks, scalability issues, and other performance risks.
+
+            ## Phase 3: Acknowledge Good Work
+
+            Briefly note any well-designed patterns, good testing practices, or thoughtful improvements in the PR.
+            A good review balances constructive criticism with recognition of quality work.
 
             Note: The PR branch is already checked out in the current working directory.
             Be concise and actionable. Prefer inline suggestions where possible; add a short summary at the end.


### PR DESCRIPTION
## Why this change

We ran a structured evaluation of the Claude PR review workflow by creating a test PR ([#722](https://github.com/kosli-dev/cli/pull/722)) with 8 deliberately planted issues (security flaws, logic bugs, Docker problems, missing dependencies, documentation errors) and 7 genuinely good patterns. We then scored Claude's review against a cheat sheet.

### Results

**Claude scored 24.5/33** — catching 7 of 8 planted bugs but acknowledging only 0.5 of 7 good things.

| What Claude caught | What Claude missed |
|---|---|
| Hardcoded API key in source (critical) | `github.com/google/uuid` import without go.mod update |
| Inverted error check `err != nil` vs `err == nil` (critical) | Almost all positive feedback (0.5/7) |
| Auth token logged in debug mode (security) | |
| `client.Timeout = 0` contradicting the PR's purpose | |
| HEALTHCHECK on scratch Docker image | |
| Non-existent `--request-timeout` flag in docs | |
| Test that would fail due to the inverted error check | |

### Root cause of the go.mod miss

The current workflow gives Claude **no access to Go tooling**. It can only read the diff and post comments — pure text analysis. It never compiles the code, so it can't detect that a new import has no corresponding module entry. This is a mechanical check that a compiler catches instantly, but an LLM reviewing a diff has no signal for.

### What this PR changes

Three targeted improvements to the `review-general` job:

**1. Add Go setup step + expand allowed tools**

```yaml
- name: Set up Go
  uses: actions/setup-go@v5
  with:
    go-version: '1.25.0'
```

Claude can now run `go build`, `go vet`, `go mod tidy`, `git diff`, and `golangci-lint`. This turns the review from pure text analysis into analysis backed by compiler output.

**2. Restructure the prompt into 3 phases**

- **Phase 1 — Static Analysis**: Run `go build ./...`, `go vet ./...`, and `go mod tidy && git diff --exit-code go.mod go.sum` *before* reading code. Any failures become high-priority review findings. This is where the go.mod miss would have been caught.
- **Phase 2 — Code Review**: The existing 7-point review criteria (unchanged).
- **Phase 3 — Acknowledge Good Work**: Explicitly ask Claude to note well-designed patterns and good practices. Our evaluation showed Claude produced a purely adversarial review (all criticism, no praise) — which risks developers tuning out the feedback.

**3. Add CLAUDE.md awareness**

The repo has a detailed `CLAUDE.md` with build commands, architecture docs, and test patterns. The prompt now explicitly tells Claude to read it, so reviews are informed by project conventions rather than generic Go best practices.

### What this PR does NOT change

- The `review-dependency-updates` job (dependabot PRs) — unchanged
- No new workflow files — this is purely changes to the existing Claude review
- No changes to the build/test pipeline (`main.yml`, `test.yml`) — a separate compile-check workflow for PRs is worth discussing with the team but is out of scope here

### Expected impact

Based on our evaluation scoring, these changes should push Claude's review score from ~24/33 to 30+/33 by:
- Catching mechanical issues like missing go.mod entries via Phase 1 (+2 points)
- Providing balanced feedback via Phase 3 (+5-6 points)
- Better convention adherence via CLAUDE.md context
