### PR TITLE
fix: use explicit input instead of github.ref for Kosli reporting conditions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,8 +27,8 @@ on:
         default: ''
       report_to_kosli:
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: 'none'
     secrets:
       slack_channel:
         required: true
@@ -138,7 +138,7 @@ jobs:
 
 
     - name: Report Docker image to Kosli
-      if: ${{ inputs.report_to_kosli }}
+      if: ${{ inputs.report_to_kosli != 'none' }}
       env:
         KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
       run:
@@ -153,7 +153,7 @@ jobs:
 
 
     - name: Report SBOM to Kosli
-      if: ${{ inputs.report_to_kosli }}
+      if: ${{ inputs.report_to_kosli != 'none' }}
       env:
         KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
       run:
@@ -178,7 +178,7 @@ jobs:
 
 
     - name: Report Snyk Docker scan results attestation to Kosli
-      if:  ${{ inputs.report_to_kosli && (success() || failure()) }}
+      if:  ${{ inputs.report_to_kosli != 'none' && (success() || failure()) }}
       env:
         KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
       run:
@@ -202,7 +202,7 @@ jobs:
           list environments
 
     - name: Report Docker smoke test attestation to Kosli
-      if:  ${{ inputs.report_to_kosli && (success() || failure()) }}
+      if:  ${{ inputs.report_to_kosli != 'none' && (success() || failure()) }}
       env:
         KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
         SMOKE_TEST_OUTCOME: ${{ steps.smoke-test.outcome}}

--- a/.github/workflows/init_kosli.yml
+++ b/.github/workflows/init_kosli.yml
@@ -21,12 +21,8 @@ on:
             default: ''
           report_to_kosli:
             required: false
-            type: boolean
-            default: false
-          report_pr_attestations:
-            required: false
-            type: boolean
-            default: false
+            type: string
+            default: 'none'
         secrets:        
             kosli_api_token:
                 required: true
@@ -62,7 +58,7 @@ jobs:
             if_false: "CLI main branch changes"
 
         - name: Update Kosli Flow
-          if: ${{ inputs.report_to_kosli }}
+          if: ${{ inputs.report_to_kosli != 'none' }}
           env:
             KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
           run: kosli create flow ${{inputs.flow_name}}
@@ -71,7 +67,7 @@ jobs:
                 --org ${{inputs.kosli_org}}
 
         - name: Init Kosli Trail
-          if: ${{ inputs.report_to_kosli }}
+          if: ${{ inputs.report_to_kosli != 'none' }}
           env:
             KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
           run: kosli begin trail ${{inputs.trail_name}} 
@@ -79,7 +75,7 @@ jobs:
                 --org ${{inputs.kosli_org}}
 
         - name: Report pull-request attestation to Kosli
-          if: ${{ inputs.report_pr_attestations }}
+          if: ${{ inputs.report_to_kosli == 'all' }}
           env:
             KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
           run: kosli attest pullrequest github
@@ -91,7 +87,7 @@ jobs:
         
 
         - name: Report never-alone attestation to Kosli
-          if: ${{ inputs.report_pr_attestations }}
+          if: ${{ inputs.report_to_kosli == 'all' }}
           env:
             KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
             KOSLI_ORG: ${{ inputs.kosli_org }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,6 @@ jobs:
       trail_template_file: ${{ steps.prep.outputs.trail_template_file }}
       checkout_ref: ${{ steps.prep.outputs.checkout_ref }}
       report_to_kosli: ${{ steps.prep.outputs.report_to_kosli }}
-      report_pr_attestations: ${{ steps.prep.outputs.report_pr_attestations }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -52,16 +51,12 @@ jobs:
           echo "TRAIL_TEMPLATE_FILE=${TRAIL_TEMPLATE_FILE}" >> $GITHUB_ENV
           echo "trail_template_file=$TRAIL_TEMPLATE_FILE" >> $GITHUB_OUTPUT
 
-          if [ "${{ github.event_name }}" == "push" ] && { [ "${GITHUB_REF}" == "refs/heads/main" ] || [[ "${GITHUB_REF}" == refs/tags/* ]]; }; then
-            echo "report_to_kosli=true" >> $GITHUB_OUTPUT
-          else
-            echo "report_to_kosli=false" >> $GITHUB_OUTPUT
-          fi
-
           if [ "${{ github.event_name }}" == "push" ] && [ "${GITHUB_REF}" == "refs/heads/main" ]; then
-            echo "report_pr_attestations=true" >> $GITHUB_OUTPUT
+            echo "report_to_kosli=all" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" == "push" ] && [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "report_to_kosli=release" >> $GITHUB_OUTPUT
           else
-            echo "report_pr_attestations=false" >> $GITHUB_OUTPUT
+            echo "report_to_kosli=none" >> $GITHUB_OUTPUT
           fi
 
   init-kosli:
@@ -73,8 +68,7 @@ jobs:
       FLOW_TEMPLATE_FILE: ${{ needs.pre-build.outputs.trail_template_file }}
       KOSLI_ORG: kosli-public
       checkout_ref: ${{ needs.pre-build.outputs.checkout_ref }}
-      report_to_kosli: ${{ needs.pre-build.outputs.report_to_kosli == 'true' }}
-      report_pr_attestations: ${{ needs.pre-build.outputs.report_pr_attestations == 'true' }}
+      report_to_kosli: ${{ needs.pre-build.outputs.report_to_kosli }}
     secrets:
       kosli_api_token: ${{ secrets.KOSLI_PUBLIC_API_TOKEN }}
       pr_github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -89,7 +83,7 @@ jobs:
       TRAIL_NAME: ${{ needs.pre-build.outputs.trail_name }}
       KOSLI_ORG: kosli-public
       checkout_ref: ${{ needs.pre-build.outputs.checkout_ref }}
-      report_results: ${{ needs.pre-build.outputs.report_to_kosli == 'true' }}
+      report_to_kosli: ${{ needs.pre-build.outputs.report_to_kosli }}
     secrets:
       github_access_token: ${{ secrets.KOSLI_GITHUB_TOKEN }}
       gitlab_access_token: ${{ secrets.KOSLI_GITLAB_TOKEN }}
@@ -115,7 +109,7 @@ jobs:
       trail_name: ${{ needs.pre-build.outputs.trail_name }}
       kosli_org: kosli-public
       checkout_ref: ${{ needs.pre-build.outputs.checkout_ref }}
-      report_to_kosli: ${{ needs.pre-build.outputs.report_to_kosli == 'true' }}
+      report_to_kosli: ${{ needs.pre-build.outputs.report_to_kosli }}
     secrets:
       slack_webhook: ${{ secrets.MERKELY_SLACK_CI_FAILURES_WEBHOOK }}
       slack_channel: ci-failures

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       TRAIL_NAME: ${{ needs.pre-build.outputs.trail_name }}
       FLOW_TEMPLATE_FILE: ${{ needs.pre-build.outputs.trail_template_file }}
       KOSLI_ORG: kosli-public
-      report_to_kosli: true
+      report_to_kosli: release
     secrets:
       kosli_api_token: ${{ secrets.KOSLI_PUBLIC_API_TOKEN }}
       pr_github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -68,7 +68,7 @@ jobs:
       FLOW_NAME: cli-release
       TRAIL_NAME: ${{ needs.pre-build.outputs.trail_name }}
       KOSLI_ORG: kosli-public
-      report_results: true
+      report_to_kosli: release
     secrets:
       github_access_token: ${{ secrets.KOSLI_GITHUB_TOKEN }}
       gitlab_access_token: ${{ secrets.KOSLI_GITLAB_TOKEN }}
@@ -93,7 +93,7 @@ jobs:
       flow_name: cli-release
       trail_name: ${{ needs.pre-build.outputs.trail_name }}
       kosli_org: kosli-public
-      report_to_kosli: true
+      report_to_kosli: release
     secrets:
       slack_webhook: ${{ secrets.MERKELY_SLACK_CI_FAILURES_WEBHOOK }}
       slack_channel: ci-failures

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,10 @@ on:
         required: false
         type: boolean
         default: true
-      report_results:
+      report_to_kosli:
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: 'none'
       checkout_ref:
         required: false
         type: string
@@ -96,7 +96,7 @@ jobs:
         args: --timeout=5m -v
 
     - name: Report lint to Kosli
-      if:  ${{ (success() || failure()) && inputs.report_results }}
+      if:  ${{ (success() || failure()) && inputs.report_to_kosli != 'none' }}
       env:
         KOSLI_API_TOKEN: ${{ secrets.kosli_reporting_api_token }}
       run: kosli attest generic
@@ -162,7 +162,7 @@ jobs:
         make test_integration_full
 
     - name: Report test to Kosli
-      if:  ${{ (success() || failure()) && inputs.report_results }}
+      if:  ${{ (success() || failure()) && inputs.report_to_kosli != 'none' }}
       env:
         KOSLI_API_TOKEN: ${{ secrets.kosli_reporting_api_token }}
       run: kosli attest junit
@@ -173,7 +173,7 @@ jobs:
            --org ${{ inputs.KOSLI_ORG }}
 
     - name: Upload coverage reports to Codecov
-      if: ${{ inputs.report_results }}
+      if: ${{ inputs.report_to_kosli != 'none' }}
       uses: codecov/codecov-action@v4
 
   snyk-code-test:
@@ -205,7 +205,7 @@ jobs:
           snyk code test --sarif --policy-path=.snyk  --sarif-file-output=snyk-code.json --prune-repeated-subdependencies
 
     - name: Report Snyk Code to Kosli
-      if:  ${{ (success() || failure()) && inputs.report_results }}
+      if:  ${{ (success() || failure()) && inputs.report_to_kosli != 'none' }}
       env:
         KOSLI_API_TOKEN: ${{ secrets.kosli_reporting_api_token }}
       run: kosli attest snyk
@@ -244,7 +244,7 @@ jobs:
           snyk test --sarif --policy-path=.snyk  --sarif-file-output=snyk-dependency.json --prune-repeated-subdependencies
 
     - name: Report Snyk Test to Kosli
-      if:  ${{ (success() || failure()) && inputs.report_results }}
+      if:  ${{ (success() || failure()) && inputs.report_to_kosli != 'none' }}
       env:
         KOSLI_API_TOKEN: ${{ secrets.kosli_reporting_api_token }}
       run: kosli attest snyk


### PR DESCRIPTION
In pull_request_target events, github.ref resolves to the base branch (e.g. refs/heads/main), not the PR head. This meant Kosli reporting conditions like `github.ref == 'refs/heads/main'` were true for every PR targeting main, potentially causing spurious reports.

The fix computes a `report_to_kosli` boolean once in the caller (main.yml pre-build) based on the actual event and ref, then passes it as an explicit input to the reusable workflows (init_kosli.yml, test.yml, docker.yml). This also fixes two operator-precedence bugs in docker.yml where `||` vs `&&` grouping was wrong.