### PR TITLE
fix: serialize type_schema as JSON in attestation type table output

### DIFF
--- a/cmd/kosli/getAttestationType.go
+++ b/cmd/kosli/getAttestationType.go
@@ -172,7 +172,11 @@ func printVersionedAttestationTypeAsTable(raw map[string]interface{}, rows []str
 	rows = append(rows, fmt.Sprintf("	Created By:\t%s", attestationType["created_by"]))
 
 	if typeSchema, ok := attestationType["type_schema"]; ok {
-		rows = append(rows, fmt.Sprintf("	Type schema:\t%s", typeSchema))
+		typeSchemaJSON, err := json.Marshal(typeSchema)
+		if err != nil {
+			return []string{}, err
+		}
+		rows = append(rows, fmt.Sprintf("	Type schema:\t%s", string(typeSchemaJSON)))
 	}
 
 	if evaluator, ok := attestationType["evaluator"].(map[string]interface{}); ok {

--- a/cmd/kosli/testdata/output/get/get-archived-attestation-type.txt
+++ b/cmd/kosli/testdata/output/get/get-archived-attestation-type.txt
@@ -8,7 +8,7 @@ Versions:
                    Version:      1
                    Timestamp:    Sat, 16 Jan 2016 00:00:00 UTC • 2016-01-16
                    Created By:   docs-cmd-test-user
-                   Type schema:  {'type': 'object', 'additionalProperties': True, 'properties': {'name': {'type': 'string'}, 'age': {'type': 'integer'}}}
+                   Type schema:  \{"additionalProperties":true,"properties":\{"age":\{"type":"integer"\},"name":\{"type":"string"\}\},"type":"object"\}
                    Evaluator:
                                  Content Type:  jq
                                  Rules:

--- a/cmd/kosli/testdata/output/get/get-attestation-type-version.txt
+++ b/cmd/kosli/testdata/output/get/get-attestation-type-version.txt
@@ -5,7 +5,7 @@ Versions:
                Version:      1
                Timestamp:    Sat, 16 Jan 2016 00:00:00 UTC • 2016-01-16
                Created By:   docs-cmd-test-user
-               Type schema:  {'type': 'object', 'additionalProperties': True, 'properties': {'name': {'type': 'string'}, 'age': {'type': 'integer'}}}
+               Type schema:  \{"additionalProperties":true,"properties":\{"age":\{"type":"integer"\},"name":\{"type":"string"\}\},"type":"object"\}
                Evaluator:
                              Content Type:  jq
                              Rules:

--- a/cmd/kosli/testdata/output/get/get-attestation-type.txt
+++ b/cmd/kosli/testdata/output/get/get-attestation-type.txt
@@ -8,7 +8,7 @@ Versions:
                    Version:      1
                    Timestamp:    Sat, 16 Jan 2016 00:00:00 UTC • 2016-01-16
                    Created By:   docs-cmd-test-user
-                   Type schema:  {'type': 'object', 'additionalProperties': True, 'properties': {'name': {'type': 'string'}, 'age': {'type': 'integer'}}}
+                   Type schema:  \{"additionalProperties":true,"properties":\{"age":\{"type":"integer"\},"name":\{"type":"string"\}\},"type":"object"\}
                    Evaluator:
                                  Content Type:  jq
                                  Rules:


### PR DESCRIPTION
The server now returns type_schema as a JSON object instead of a Python repr string. The CLI was printing it with fmt %s, producing Go's map representation. Marshal it back to JSON for proper display.