### PR TITLE
ci: add harden-runner to all GitHub Actions workflows

### DIFF
--- a/.github/workflows/binary_provenance.yml
+++ b/.github/workflows/binary_provenance.yml
@@ -34,6 +34,11 @@ jobs:
             matrix:
                 artifact: ${{fromJson(inputs.artifacts)}}
         steps:
+        - name: Harden Runner
+          uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+          with:
+            egress-policy: audit
+
         - uses: actions/checkout@v6
 
         - uses: actions/download-artifact@v8

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -26,6 +26,11 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -74,6 +79,11 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/daily-cli-tests.yml
+++ b/.github/workflows/daily-cli-tests.yml
@@ -11,6 +11,11 @@ jobs:
     outputs:
       trail_name: ${{ steps.prep.outputs.trail_name }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@v6
 
       - name: Prepare
@@ -61,6 +66,11 @@ jobs:
       ]
     if: ${{ always() && contains(join(needs.*.result, ','), 'failure') && github.ref == 'refs/heads/master' }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
       - name: Slack Notification on Failure
         uses: kosli-dev/reusable-actions/.github/actions/send-ci-failure-slack-message@main
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,6 +58,11 @@ jobs:
       packages: write
 
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+      with:
+        egress-policy: audit
+
     - uses: actions/checkout@v6
       with:
         fetch-depth: 3

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -16,6 +16,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
       - name: Generate token
         id: generate_token
         uses: actions/create-github-app-token@v3

--- a/.github/workflows/init_kosli.yml
+++ b/.github/workflows/init_kosli.yml
@@ -39,6 +39,11 @@ jobs:
             pull-requests: read
         steps:
 
+        - name: Harden Runner
+          uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+          with:
+            egress-policy: audit
+
         - uses: actions/checkout@v6
           with:
             fetch-depth: 0

--- a/.github/workflows/install-script-tests.yml
+++ b/.github/workflows/install-script-tests.yml
@@ -24,6 +24,11 @@ jobs:
                 os: [ubuntu-latest, macos-latest, windows-latest]
 
         steps:
+        - name: Harden Runner
+          uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+          with:
+            egress-policy: audit
+
         - name: Checkout repository
           uses: actions/checkout@v6
 
@@ -38,6 +43,11 @@ jobs:
         runs-on: macos-latest
 
         steps:
+        - name: Harden Runner
+          uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+          with:
+            egress-policy: audit
+
         - name: Checkout repository
           uses: actions/checkout@v6
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,11 @@ jobs:
       checkout_ref: ${{ steps.prep.outputs.checkout_ref }}
       report_to_kosli: ${{ steps.prep.outputs.report_to_kosli }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -130,6 +135,11 @@ jobs:
       ]
     if: ${{ always() && contains(join(needs.*.result, ','), 'failure') && github.ref == 'refs/heads/master' }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
       - name: Slack Notification on Failure
         uses: kosli-dev/reusable-actions/.github/actions/send-ci-failure-slack-message@main
         with:

--- a/.github/workflows/never_alone_trail.yml
+++ b/.github/workflows/never_alone_trail.yml
@@ -40,6 +40,11 @@ jobs:
             pull-requests: read
         steps:
 
+        - name: Harden Runner
+          uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+          with:
+            egress-policy: audit
+
         - uses: actions/checkout@v6
           with:
             fetch-depth: 0

--- a/.github/workflows/publish_branch_docs.yml
+++ b/.github/workflows/publish_branch_docs.yml
@@ -10,6 +10,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@v6
       
       - name: Generate json

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -14,6 +14,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@v6
 
       # Deploy to local repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,11 @@ jobs:
       trail_name: ${{ steps.prep.outputs.trail_name }}
       trail_template_file: ${{ steps.prep.outputs.trail_template_file }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@v6
 
       - name: Get tag
@@ -110,6 +115,11 @@ jobs:
     outputs:
       artifacts: ${{ steps.prepare-artifacts-list.outputs.artifacts }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -187,6 +197,11 @@ jobs:
     name: Bump Homebrew formula
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
       - uses: mislav/bump-homebrew-formula-action@v4
         if: ${{ !contains(github.ref, '-') }} # skip prereleases
         with:
@@ -200,6 +215,11 @@ jobs:
     needs: [goreleaser, pre-build]
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -237,6 +257,11 @@ jobs:
     needs: [pre-build, goreleaser]
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v4
         with:
@@ -249,6 +274,11 @@ jobs:
     needs: [pre-build, goreleaser]
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v4
         with:
@@ -261,6 +291,11 @@ jobs:
     needs: [pre-build, goreleaser]
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v4
         with:
@@ -300,6 +335,11 @@ jobs:
       ]
     if: ${{ always() && contains(join(needs.*.result, ','), 'failure') && github.ref == 'refs/heads/master' }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
       - name: Slack Notification on Failure
         uses: kosli-dev/reusable-actions/.github/actions/send-ci-failure-slack-message@main
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,11 @@ jobs:
       contents: write
     steps:
 
+    - name: Harden Runner
+      uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+      with:
+        egress-policy: audit
+
     - uses: actions/checkout@v6
       with:
         ref: ${{ inputs.checkout_ref || github.sha }}
@@ -113,6 +118,11 @@ jobs:
       id-token: write
       contents: write
     steps:
+
+    - name: Harden Runner
+      uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+      with:
+        egress-policy: audit
 
     - uses: actions/checkout@v6
       with:
@@ -185,6 +195,11 @@ jobs:
       contents: write
     steps:
 
+    - name: Harden Runner
+      uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+      with:
+        egress-policy: audit
+
     - uses: actions/checkout@v6
       with:
         ref: ${{ inputs.checkout_ref || github.sha }}
@@ -223,6 +238,11 @@ jobs:
       id-token: write
       contents: write
     steps:
+
+    - name: Harden Runner
+      uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+      with:
+        egress-policy: audit
 
     - uses: actions/checkout@v6
       with:

--- a/.github/workflows/upload-cli-layer.yml
+++ b/.github/workflows/upload-cli-layer.yml
@@ -20,6 +20,11 @@ jobs:
       id-token: write
       contents: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@v6
 
       - name: Configure AWS credentials


### PR DESCRIPTION
## Summary

- Add `step-security/harden-runner` v2.16.1 as the first step in every job across all 14 workflow files
- Pinned to SHA `fe104658747b27e96e4f7e80cd0a94068e53901d`
- Configured with `egress-policy: audit` to monitor outbound traffic without blocking
- Improves CI/CD supply chain security posture