### PR TITLE
feat: check for latest version

### DIFF
--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -312,6 +312,7 @@ func newRootCmd(out, errOut io.Writer, args []string) (*cobra.Command, error) {
 		Use:              "kosli",
 		Short:            "The Kosli CLI.",
 		Long:             globalUsage,
+		Version:          fmt.Sprintf("%#v", version.Get()),
 		SilenceUsage:     true,
 		SilenceErrors:    true,
 		TraverseChildren: true,
@@ -323,8 +324,10 @@ func newRootCmd(out, errOut io.Writer, args []string) (*cobra.Command, error) {
 			}
 
 			// Fire update check in background — result collected in PostRun
-			// Skip if we're running version command
-			if cmd.Name() != "version" {
+			// Skip for version (runs check synchronously) and Cobra's internal
+			// completion commands (__complete, __completeNoDesc) which fire on
+			// every Tab press.
+			if cmd.Name() != "version" && !strings.HasPrefix(cmd.Name(), "__") {
 				go func() {
 					notice, _ := version.CheckForUpdate(version.GetVersion())
 					updateNoticeCh <- notice
@@ -364,6 +367,7 @@ func newRootCmd(out, errOut io.Writer, args []string) (*cobra.Command, error) {
 			}
 		},
 	}
+	cmd.SetVersionTemplate("{{.Version}}\n")
 	cmd.PersistentFlags().StringVarP(&global.ApiToken, "api-token", "a", "", apiTokenFlag)
 	cmd.PersistentFlags().StringVar(&global.Org, "org", "", orgFlag)
 	cmd.PersistentFlags().StringVarP(&global.Host, "host", "H", defaultHost, hostFlag)

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -323,11 +323,13 @@ func newRootCmd(out, errOut io.Writer, args []string) (*cobra.Command, error) {
 				return err
 			}
 
-			// Fire update check in background — result collected in PostRun
-			// Skip for version (runs check synchronously) and Cobra's internal
-			// completion commands (__complete, __completeNoDesc) which fire on
-			// every Tab press.
-			if cmd.Name() != "version" && cmd.Name() != "--version" && !strings.HasPrefix(cmd.Name(), "__") {
+			// Fire update check in background — result collected in PostRun.
+			// Skip when:
+			//   - "version" subcommand: runs the check synchronously itself
+			//   - "__complete*": Cobra shell-completion commands fire on every Tab press
+			//   - --version flag: Cobra handles it internally and skips PersistentPostRun,
+			//     so the goroutine result would always be silently discarded
+			if cmd.Name() != "version" && !strings.HasPrefix(cmd.Name(), "__") && !cmd.Root().Flags().Changed("version") {
 				go func() {
 					notice, _ := version.CheckForUpdate(version.GetVersion())
 					updateNoticeCh <- notice
@@ -379,7 +381,7 @@ func newRootCmd(out, errOut io.Writer, args []string) (*cobra.Command, error) {
 	// Add subcommands
 	cmd.AddCommand(
 
-		newVersionCmd(out),
+		newVersionCmd(out, errOut),
 		newFingerprintCmd(out),
 		newAssertCmd(out),
 		newStatusCmd(out),

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -327,7 +327,7 @@ func newRootCmd(out, errOut io.Writer, args []string) (*cobra.Command, error) {
 			// Skip for version (runs check synchronously) and Cobra's internal
 			// completion commands (__complete, __completeNoDesc) which fire on
 			// every Tab press.
-			if cmd.Name() != "version" && !strings.HasPrefix(cmd.Name(), "__") {
+			if cmd.Name() != "version" && cmd.Name() != "--version" && !strings.HasPrefix(cmd.Name(), "__") {
 				go func() {
 					notice, _ := version.CheckForUpdate(version.GetVersion())
 					updateNoticeCh <- notice

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -357,7 +357,7 @@ func newRootCmd(out, errOut io.Writer, args []string) (*cobra.Command, error) {
 			select {
 			case notice := <-updateNoticeCh:
 				if notice != "" {
-					fmt.Fprint(errOut, notice) // stderr — doesn't pollute piped stdout
+					_, _ = fmt.Fprint(errOut, notice) // stderr — doesn't pollute piped stdout
 				}
 			default:
 				// goroutine not done yet (took > command duration) — skip silently

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kosli-dev/cli/internal/requests"
 	"github.com/kosli-dev/cli/internal/security"
+	"github.com/kosli-dev/cli/internal/version"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -304,6 +305,9 @@ func getConfigFileFlagDefault() string {
 
 func newRootCmd(out, errOut io.Writer, args []string) (*cobra.Command, error) {
 	global = new(GlobalOpts)
+
+	var updateNoticeCh = make(chan string, 1) // buffered — goroutine never blocks
+
 	cmd := &cobra.Command{
 		Use:              "kosli",
 		Short:            "The Kosli CLI.",
@@ -312,6 +316,15 @@ func newRootCmd(out, errOut io.Writer, args []string) (*cobra.Command, error) {
 		SilenceErrors:    true,
 		TraverseChildren: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// Fire update check in background — result collected in PostRun
+			// Skip if we're running version command
+			if cmd.Name() != "version" {
+				go func() {
+					notice, _ := version.CheckForUpdate(version.GetVersion())
+					updateNoticeCh <- notice
+				}()
+			}
+
 			// You can bind cobra and viper in a few locations, but PersistencePreRunE on the root command works well
 			err := initialize(cmd, out, errOut)
 			if err != nil {
@@ -339,6 +352,16 @@ func newRootCmd(out, errOut io.Writer, args []string) (*cobra.Command, error) {
 			})
 
 			return flagError
+		},
+		PersistentPostRun: func(cmd *cobra.Command, args []string) {
+			select {
+			case notice := <-updateNoticeCh:
+				if notice != "" {
+					fmt.Fprint(errOut, notice) // stderr — doesn't pollute piped stdout
+				}
+			default:
+				// goroutine not done yet (took > command duration) — skip silently
+			}
 		},
 	}
 	cmd.PersistentFlags().StringVarP(&global.ApiToken, "api-token", "a", "", apiTokenFlag)

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -316,6 +316,12 @@ func newRootCmd(out, errOut io.Writer, args []string) (*cobra.Command, error) {
 		SilenceErrors:    true,
 		TraverseChildren: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// You can bind cobra and viper in a few locations, but PersistencePreRunE on the root command works well
+			err := initialize(cmd, out, errOut)
+			if err != nil {
+				return err
+			}
+
 			// Fire update check in background — result collected in PostRun
 			// Skip if we're running version command
 			if cmd.Name() != "version" {
@@ -323,12 +329,6 @@ func newRootCmd(out, errOut io.Writer, args []string) (*cobra.Command, error) {
 					notice, _ := version.CheckForUpdate(version.GetVersion())
 					updateNoticeCh <- notice
 				}()
-			}
-
-			// You can bind cobra and viper in a few locations, but PersistencePreRunE on the root command works well
-			err := initialize(cmd, out, errOut)
-			if err != nil {
-				return err
 			}
 
 			if global.ApiToken == "DRY_RUN" {

--- a/cmd/kosli/version.go
+++ b/cmd/kosli/version.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/kosli-dev/cli/internal/version"
 	"github.com/spf13/cobra"
@@ -25,7 +24,7 @@ type versionOptions struct {
 	short bool
 }
 
-func newVersionCmd(out io.Writer) *cobra.Command {
+func newVersionCmd(out, errOut io.Writer) *cobra.Command {
 	o := new(versionOptions)
 	cmd := &cobra.Command{
 		Use:     "version",
@@ -34,7 +33,7 @@ func newVersionCmd(out io.Writer) *cobra.Command {
 		Long:    versionLongDesc,
 		Args:    cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			o.run(out)
+			o.run(out, errOut)
 		},
 	}
 
@@ -43,12 +42,12 @@ func newVersionCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
-func (o *versionOptions) run(out io.Writer) {
+func (o *versionOptions) run(out, errOut io.Writer) {
 	logger.Info(formatVersion(o.short))
 
 	notice, _ := version.CheckForUpdate(version.GetVersion())
 	if notice != "" {
-		_, _ = fmt.Fprint(os.Stderr, notice)
+		_, _ = fmt.Fprint(errOut, notice) // stderr — doesn't pollute piped stdout
 	}
 }
 

--- a/cmd/kosli/version.go
+++ b/cmd/kosli/version.go
@@ -10,7 +10,7 @@ import (
 
 const versionShortDesc = `Print the version of a Kosli CLI.  `
 const versionLongDesc = versionShortDesc + `
-The output will look something like this:  
+The output will look something like this:
 version.BuildInfo{Version:"v0.0.1", GitCommit:"fe51cd1e31e6a202cba7dead9552a6d418ded79a", GitTreeState:"clean", GoVersion:"go1.16.3"}
 
 - Version is the semantic version of the release.
@@ -27,10 +27,11 @@ type versionOptions struct {
 func newVersionCmd(out io.Writer) *cobra.Command {
 	o := new(versionOptions)
 	cmd := &cobra.Command{
-		Use:   "version",
-		Short: versionShortDesc,
-		Long:  versionLongDesc,
-		Args:  cobra.NoArgs,
+		Use:     "version",
+		Aliases: []string{"ver"},
+		Short:   versionShortDesc,
+		Long:    versionLongDesc,
+		Args:    cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			o.run(out)
 		},
@@ -43,6 +44,11 @@ func newVersionCmd(out io.Writer) *cobra.Command {
 
 func (o *versionOptions) run(out io.Writer) {
 	logger.Info(formatVersion(o.short))
+
+	notice, _ := version.CheckForUpdate(version.GetVersion())
+	if notice != "" {
+		logger.Info(notice)
+	}
 }
 
 func formatVersion(short bool) string {

--- a/cmd/kosli/version.go
+++ b/cmd/kosli/version.go
@@ -45,6 +45,8 @@ func newVersionCmd(out, errOut io.Writer) *cobra.Command {
 func (o *versionOptions) run(out, errOut io.Writer) {
 	logger.Info(formatVersion(o.short))
 
+	// Synchronous check — version command always shows the update notice,
+	// unlike other commands where the check may be skipped if slower than the command.
 	notice, _ := version.CheckForUpdate(version.GetVersion())
 	if notice != "" {
 		_, _ = fmt.Fprint(errOut, notice) // stderr — doesn't pollute piped stdout

--- a/cmd/kosli/version.go
+++ b/cmd/kosli/version.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/kosli-dev/cli/internal/version"
 	"github.com/spf13/cobra"
@@ -47,7 +48,7 @@ func (o *versionOptions) run(out io.Writer) {
 
 	notice, _ := version.CheckForUpdate(version.GetVersion())
 	if notice != "" {
-		logger.Info(notice)
+		_, _ = fmt.Fprint(os.Stderr, notice)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v2 v2.3.0
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/andygrunwald/go-jira v1.17.0
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
@@ -59,7 +60,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
 	github.com/BurntSushi/toml v1.5.0 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.2.0 // indirect
 	github.com/agnivade/levenshtein v1.2.1 // indirect

--- a/internal/version/update_check.go
+++ b/internal/version/update_check.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	semver "github.com/Masterminds/semver/v3"
 )
 
 const (
@@ -48,7 +50,8 @@ func checkForUpdateWithURL(currentVersion string, apiURL string) (string, error)
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("User-Agent", fmt.Sprintf("kosli-cli/%s", currentVersion))
 
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{Timeout: updateCheckTimeout}
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", nil
 	}
@@ -63,20 +66,19 @@ func checkForUpdateWithURL(currentVersion string, apiURL string) (string, error)
 		return "", nil
 	}
 
-	latestVersion := release.TagName
-	// Strip leading 'v' for semver comparison
-	if latestVersion != "" && latestVersion[0] == 'v' {
-		latestVersion = latestVersion[1:]
+	latestVer, err := semver.NewVersion(release.TagName)
+	if err != nil {
+		return "", nil
 	}
-	current := currentVersion
-	if len(current) > 0 && current[0] == 'v' {
-		current = current[1:]
+	currentVer, err := semver.NewVersion(currentVersion)
+	if err != nil {
+		return "", nil
 	}
 
-	if latestVersion != "" && current != latestVersion {
+	if latestVer.GreaterThan(currentVer) {
 		return fmt.Sprintf(
-			"\nA new version of the Kosli CLI is available: v%s (you have v%s)\nUpgrade: https://docs.kosli.com/getting_started/install/\n",
-			latestVersion, current,
+			"\nA new version of the Kosli CLI is available: %s (you have %s)\nUpgrade: https://docs.kosli.com/getting_started/install/\n",
+			release.TagName, currentVersion,
 		), nil
 	}
 	return "", nil

--- a/internal/version/update_check.go
+++ b/internal/version/update_check.go
@@ -50,7 +50,7 @@ func checkForUpdateWithURL(currentVersion string, apiURL string) (string, error)
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("User-Agent", fmt.Sprintf("kosli-cli/%s", currentVersion))
 
-	client := &http.Client{Timeout: updateCheckTimeout}
+	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", nil

--- a/internal/version/update_check.go
+++ b/internal/version/update_check.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	githubLatestReleaseURL = "https://api.github.com/repos/kosli-dev/cli/releases/latest"
-	updateCheckTimeout     = 3 * time.Second
+	updateCheckTimeout     = 2 * time.Second
 )
 
 type githubRelease struct {

--- a/internal/version/update_check.go
+++ b/internal/version/update_check.go
@@ -1,0 +1,83 @@
+package version
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	githubLatestReleaseURL = "https://api.github.com/repos/kosli-dev/cli/releases/latest"
+	updateCheckTimeout     = 3 * time.Second
+)
+
+type githubRelease struct {
+	TagName string `json:"tag_name"`
+}
+
+// CheckForUpdate is the public entry point — uses the real GitHub URL
+func CheckForUpdate(currentVersion string) (string, error) {
+	return checkForUpdateWithURL(currentVersion, githubLatestReleaseURL)
+}
+
+// CheckForUpdate queries the GitHub API for the latest release and returns
+// a non-empty notice string if the current version is outdated.
+// It returns silently (empty string, nil) on any network or parse error,
+// so it never blocks or fails a command.
+// Set KOSLI_NO_UPDATE_CHECK=1 to skip entirely.
+// checkForUpdateWithURL is the testable implementation
+func checkForUpdateWithURL(currentVersion string, apiURL string) (string, error) {
+	if os.Getenv("KOSLI_NO_UPDATE_CHECK") != "" {
+		return "", nil
+	}
+	if currentVersion == "" || strings.HasPrefix(currentVersion, "main") || strings.Contains(currentVersion, "+unreleased") {
+		return "", nil // dev build — skip
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), updateCheckTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, githubLatestReleaseURL, nil)
+	if err != nil {
+		return "", nil
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", fmt.Sprintf("kosli-cli/%s", currentVersion))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", nil
+	}
+
+	var release githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return "", nil
+	}
+
+	latestVersion := release.TagName
+	// Strip leading 'v' for semver comparison
+	if latestVersion != "" && latestVersion[0] == 'v' {
+		latestVersion = latestVersion[1:]
+	}
+	current := currentVersion
+	if len(current) > 0 && current[0] == 'v' {
+		current = current[1:]
+	}
+
+	if latestVersion != "" && current != latestVersion {
+		return fmt.Sprintf(
+			"\nA new version of the Kosli CLI is available: v%s (you have v%s)\nUpgrade: https://docs.kosli.com/getting_started/install/\n",
+			latestVersion, current,
+		), nil
+	}
+	return "", nil
+}

--- a/internal/version/update_check.go
+++ b/internal/version/update_check.go
@@ -26,12 +26,12 @@ func CheckForUpdate(currentVersion string) (string, error) {
 	return checkForUpdateWithURL(currentVersion, githubLatestReleaseURL)
 }
 
-// CheckForUpdate queries the GitHub API for the latest release and returns
-// a non-empty notice string if the current version is outdated.
+// checkForUpdateWithURL is the internal, testable implementation.
+// It queries the given URL for the latest release and returns a non-empty
+// notice string if the current version is outdated.
 // It returns silently (empty string, nil) on any network or parse error,
 // so it never blocks or fails a command.
 // Set KOSLI_NO_UPDATE_CHECK=1 to skip entirely.
-// checkForUpdateWithURL is the testable implementation
 func checkForUpdateWithURL(currentVersion string, apiURL string) (string, error) {
 	if os.Getenv("KOSLI_NO_UPDATE_CHECK") != "" {
 		return "", nil

--- a/internal/version/update_check.go
+++ b/internal/version/update_check.go
@@ -40,6 +40,7 @@ func checkForUpdateWithURL(currentVersion string, apiURL string) (string, error)
 		return "", nil // dev build — skip
 	}
 
+	// context provides the timeout and not http.Client
 	ctx, cancel := context.WithTimeout(context.Background(), updateCheckTimeout)
 	defer cancel()
 

--- a/internal/version/update_check.go
+++ b/internal/version/update_check.go
@@ -41,7 +41,7 @@ func checkForUpdateWithURL(currentVersion string, apiURL string) (string, error)
 	ctx, cancel := context.WithTimeout(context.Background(), updateCheckTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, githubLatestReleaseURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
 		return "", nil
 	}
@@ -52,7 +52,7 @@ func checkForUpdateWithURL(currentVersion string, apiURL string) (string, error)
 	if err != nil {
 		return "", nil
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", nil

--- a/internal/version/update_check_test.go
+++ b/internal/version/update_check_test.go
@@ -15,7 +15,6 @@ func TestCheckForUpdate_NewVersionAvailable(t *testing.T) {
 		_, _ = fmt.Fprintf(w, `{"tag_name":"v9.99.0"}`)
 	}))
 	defer srv.Close()
-	// (override URL via a package-level var for testability — see note below)
 
 	notice, err := checkForUpdateWithURL("v0.1.0", srv.URL)
 	assert.NoError(t, err)
@@ -51,6 +50,13 @@ func TestCheckForUpdate_NewerThanLatest(t *testing.T) {
 func TestCheckForUpdate_OptOut(t *testing.T) {
 	t.Setenv("KOSLI_NO_UPDATE_CHECK", "1")
 	notice, _ := CheckForUpdate("v0.1.0")
+	assert.Empty(t, notice)
+}
+
+func TestCheckForUpdate_DevBuild(t *testing.T) {
+	// dev builds should be skipped without any HTTP call
+	notice, err := checkForUpdateWithURL("main", "http://should-not-be-called")
+	assert.NoError(t, err)
 	assert.Empty(t, notice)
 }
 

--- a/internal/version/update_check_test.go
+++ b/internal/version/update_check_test.go
@@ -60,6 +60,12 @@ func TestCheckForUpdate_DevBuild(t *testing.T) {
 	assert.Empty(t, notice)
 }
 
+func TestCheckForUpdate_UnreleasedBuild(t *testing.T) {
+	notice, err := checkForUpdateWithURL("v1.0.0+unreleased", "http://should-not-be-called")
+	assert.NoError(t, err)
+	assert.Empty(t, notice)
+}
+
 func TestCheckForUpdate_NetworkError(t *testing.T) {
 	notice, err := checkForUpdateWithURL("v0.1.0", "http://localhost:1") // nothing listening
 	assert.NoError(t, err)                                               // must be silent

--- a/internal/version/update_check_test.go
+++ b/internal/version/update_check_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,7 +12,7 @@ import (
 func TestCheckForUpdate_NewVersionAvailable(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"tag_name":"v9.99.0"}`)
+		_, _ = fmt.Fprintf(w, `{"tag_name":"v9.99.0"}`)
 	}))
 	defer srv.Close()
 	// (override URL via a package-level var for testability — see note below)
@@ -26,7 +25,7 @@ func TestCheckForUpdate_NewVersionAvailable(t *testing.T) {
 func TestCheckForUpdate_AlreadyLatest(t *testing.T) {
 	current := GetVersion() // always reflects the real built version
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, `{"tag_name":"%s"}`, current)
+		_, _ = fmt.Fprintf(w, `{"tag_name":"%s"}`, current)
 	}))
 	defer srv.Close()
 
@@ -36,8 +35,7 @@ func TestCheckForUpdate_AlreadyLatest(t *testing.T) {
 }
 
 func TestCheckForUpdate_OptOut(t *testing.T) {
-	os.Setenv("KOSLI_NO_UPDATE_CHECK", "1")
-	defer os.Unsetenv("KOSLI_NO_UPDATE_CHECK")
+	t.Setenv("KOSLI_NO_UPDATE_CHECK", "1")
 	notice, _ := CheckForUpdate("v0.1.0")
 	assert.Empty(t, notice)
 }

--- a/internal/version/update_check_test.go
+++ b/internal/version/update_check_test.go
@@ -23,13 +23,26 @@ func TestCheckForUpdate_NewVersionAvailable(t *testing.T) {
 }
 
 func TestCheckForUpdate_AlreadyLatest(t *testing.T) {
-	current := GetVersion() // always reflects the real built version
+	current := "v9.99.0"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = fmt.Fprintf(w, `{"tag_name":"%s"}`, current)
 	}))
 	defer srv.Close()
 
 	notice, err := checkForUpdateWithURL(current, srv.URL)
+	assert.NoError(t, err)
+	assert.Empty(t, notice)
+}
+
+func TestCheckForUpdate_NewerThanLatest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"tag_name":"v1.0.0"}`)
+	}))
+	defer srv.Close()
+
+	// User has a newer version — should NOT show an update notice
+	notice, err := checkForUpdateWithURL("v2.0.0", srv.URL)
 	assert.NoError(t, err)
 	assert.Empty(t, notice)
 }

--- a/internal/version/update_check_test.go
+++ b/internal/version/update_check_test.go
@@ -28,8 +28,6 @@ func TestCheckForUpdate_AlreadyLatest(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = fmt.Fprintf(w, `{"tag_name":"%s"}`, current)
 	}))
-		_, _ = fmt.Fprintf(w, `{"tag_name":"%s"}`, current)
-	}))
 	defer srv.Close()
 
 	notice, err := checkForUpdateWithURL(current, srv.URL)
@@ -59,5 +57,27 @@ func TestCheckForUpdate_OptOut(t *testing.T) {
 func TestCheckForUpdate_NetworkError(t *testing.T) {
 	notice, err := checkForUpdateWithURL("v0.1.0", "http://localhost:1") // nothing listening
 	assert.NoError(t, err)                                               // must be silent
+	assert.Empty(t, notice)
+}
+
+func TestCheckForUpdate_BadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, `not json`)
+	}))
+	defer srv.Close()
+
+	notice, err := checkForUpdateWithURL("v0.1.0", srv.URL)
+	assert.NoError(t, err)
+	assert.Empty(t, notice)
+}
+
+func TestCheckForUpdate_Non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	notice, err := checkForUpdateWithURL("v0.1.0", srv.URL)
+	assert.NoError(t, err)
 	assert.Empty(t, notice)
 }

--- a/internal/version/update_check_test.go
+++ b/internal/version/update_check_test.go
@@ -25,6 +25,9 @@ func TestCheckForUpdate_NewVersionAvailable(t *testing.T) {
 func TestCheckForUpdate_AlreadyLatest(t *testing.T) {
 	current := "v9.99.0"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"tag_name":"%s"}`, current)
+	}))
 		_, _ = fmt.Fprintf(w, `{"tag_name":"%s"}`, current)
 	}))
 	defer srv.Close()

--- a/internal/version/update_check_test.go
+++ b/internal/version/update_check_test.go
@@ -1,0 +1,49 @@
+package version
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckForUpdate_NewVersionAvailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"tag_name":"v9.99.0"}`)
+	}))
+	defer srv.Close()
+	// (override URL via a package-level var for testability — see note below)
+
+	notice, err := checkForUpdateWithURL("v0.1.0", srv.URL)
+	assert.NoError(t, err)
+	assert.Contains(t, notice, "v9.99.0")
+}
+
+func TestCheckForUpdate_AlreadyLatest(t *testing.T) {
+	current := GetVersion() // always reflects the real built version
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"tag_name":"%s"}`, current)
+	}))
+	defer srv.Close()
+
+	notice, err := checkForUpdateWithURL(current, srv.URL)
+	assert.NoError(t, err)
+	assert.Empty(t, notice)
+}
+
+func TestCheckForUpdate_OptOut(t *testing.T) {
+	os.Setenv("KOSLI_NO_UPDATE_CHECK", "1")
+	defer os.Unsetenv("KOSLI_NO_UPDATE_CHECK")
+	notice, _ := CheckForUpdate("v0.1.0")
+	assert.Empty(t, notice)
+}
+
+func TestCheckForUpdate_NetworkError(t *testing.T) {
+	notice, err := checkForUpdateWithURL("v0.1.0", "http://localhost:1") // nothing listening
+	assert.NoError(t, err)                                               // must be silent
+	assert.Empty(t, notice)
+}


### PR DESCRIPTION
* check for latest version when running CLI and print out a message when not on latest
* check for version async on all commands except `version`
* add `KOSLI_NO_UPDATE_CHECK` to disable checking
* add `ver` as an alias for `version` command
* enable cobra `--version/-v` flag