### PR TITLE
Remove dead Pipedrive chat widget from docs footer

### DIFF
--- a/docs.kosli.com/layouts/partials/docs/footer.html
+++ b/docs.kosli.com/layouts/partials/docs/footer.html
@@ -49,5 +49,3 @@
 {{ with $script.Content }}
   <script>{{ . | safeJS }}</script>
 {{ end }}
-
-<script>window.pipedriveLeadboosterConfig = {base: 'leadbooster-chat.pipedrive.com',companyId: 7960593,playbookUuid: 'e9cfffae-9683-42c1-9ff2-8e20452ce61c',version: 2};(function () {var w = window;if (w.LeadBooster) {console.warn('LeadBooster already exists');} else {w.LeadBooster = {q: [],on: function (n, h) {this.q.push({ t: 'o', n: n, h: h });},trigger: function (n) {this.q.push({ t: 't', n: n });},};}})();</script><script src="https://leadbooster-chat.pipedrive.com/assets/loader.js" async></script>

--- a/docs.kosli.com/netlify.toml
+++ b/docs.kosli.com/netlify.toml
@@ -20,4 +20,4 @@
 [[context.production.plugins]]
 package = "netlify-plugin-checklinks"
   [context.production.plugins.inputs]
-  skipPatterns = [".netlify.app", "https://docs.kosli.com/ci-defaults%29", "https://fonts.googleapis.com/", "https://docs.kosli.com/legacy_ref/", "https://leadbooster-chat.pipedrive.com/"]
+  skipPatterns = [".netlify.app", "https://docs.kosli.com/ci-defaults%29", "https://fonts.googleapis.com/", "https://docs.kosli.com/legacy_ref/"]

--- a/docs.kosli.com/netlify.toml
+++ b/docs.kosli.com/netlify.toml
@@ -20,4 +20,4 @@
 [[context.production.plugins]]
 package = "netlify-plugin-checklinks"
   [context.production.plugins.inputs]
-  skipPatterns = [".netlify.app", "https://docs.kosli.com/ci-defaults%29", "https://fonts.googleapis.com/", "https://docs.kosli.com/legacy_ref/"]
+  skipPatterns = [".netlify.app", "https://docs.kosli.com/ci-defaults%29", "https://fonts.googleapis.com/", "https://docs.kosli.com/legacy_ref/", "https://leadbooster-chat.pipedrive.com/"]


### PR DESCRIPTION
## Summary

- Removes the Pipedrive LeadBooster chat widget script from `docs.kosli.com/layouts/partials/docs/footer.html`.
- We no longer use Pipedrive — the widget renders nothing visible on the live site (verified at https://docs.kosli.com/) but every page was still loading the loader script and pinging an abandoned Pipedrive account (`companyId 7960593`, playbook `e9cfffae-9683-42c1-9ff2-8e20452ce61c`).
- Side effect: unblocks Netlify deploys. The link checker has been timing out (`ETIMEDOUT`) on `https://leadbooster-chat.pipedrive.com/assets/loader.js` from Netlify's build infra, blocking every deploy. Removing the script tag means the link checker doesn't see the URL anymore — no skipPattern needed.

## Why delete rather than skip-pattern

The first version of this PR added a checklinks `skipPattern` for the Pipedrive URL. After checking the live site, the chat widget isn't actually rendering anything — so the script is dead code calling out to a third party we don't use. Deleting it is better than masking it: removes a third-party script we don't need, stops sending visitor data to an inactive Pipedrive workspace, and fixes the deploy as a side effect.

The branch has two commits — the second reverts the skipPattern from the first, so the net diff against `main` is just the deletion of the script tag from the footer.

## Test plan

- [ ] Netlify deploys `docs-main` successfully after merge
- [ ] Visit https://docs.kosli.com/ — no chat bubble (same as before)
- [ ] DevTools → Network: no request to `leadbooster-chat.pipedrive.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)