### PR TITLE
Remove dead Pipedrive chat widget from docs footer

### DIFF
--- a/docs.kosli.com/layouts/partials/docs/footer.html
+++ b/docs.kosli.com/layouts/partials/docs/footer.html
@@ -49,5 +49,3 @@
 {{ with $script.Content }}
   <script>{{ . | safeJS }}</script>
 {{ end }}
-
-<script>window.pipedriveLeadboosterConfig = {base: 'leadbooster-chat.pipedrive.com',companyId: 7960593,playbookUuid: 'e9cfffae-9683-42c1-9ff2-8e20452ce61c',version: 2};(function () {var w = window;if (w.LeadBooster) {console.warn('LeadBooster already exists');} else {w.LeadBooster = {q: [],on: function (n, h) {this.q.push({ t: 'o', n: n, h: h });},trigger: function (n) {this.q.push({ t: 't', n: n });},};}})();</script><script src="https://leadbooster-chat.pipedrive.com/assets/loader.js" async></script>


### PR DESCRIPTION
## Summary

- Removes the Pipedrive LeadBooster chat widget script from `docs.kosli.com/layouts/partials/docs/footer.html`.
- We migrated off Pipedrive to HubSpot almost a year ago, but the LeadBooster loader was still embedded on every docs page — silently pinging an abandoned Pipedrive workspace (`companyId 7960593`) on every visit and rendering nothing visible (verified at https://docs.kosli.com/).
- Side effect: unblocks Netlify deploys. The checklinks plugin has been timing out (`ETIMEDOUT`) on `https://leadbooster-chat.pipedrive.com/assets/loader.js` from Netlify's build infra, blocking every deploy. Removing the script tag means the URL is no longer in the built site.

## Test plan

- [ ] Netlify deploys `docs-main` successfully after merge
- [ ] Visit https://docs.kosli.com/ — no chat bubble (same as before, since the widget wasn't rendering anyway)
- [ ] DevTools → Network: no request to `leadbooster-chat.pipedrive.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)