### PR TITLE
feat: use appVersion as a default CLI version

### DIFF
--- a/charts/k8s-reporter/Chart.yaml
+++ b/charts/k8s-reporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.0
+version: 2.2.1
 
 # This is the version number of the (CLI) application being deployed. This version number should be
 # incremented each time you make changes to the application. They should reflect the version the

--- a/charts/k8s-reporter/Chart.yaml
+++ b/charts/k8s-reporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: k8s-reporter
-description: A Helm chart for installing the Kosli K8S reporter as a cronjob.
+description: A Helm chart for installing the Kosli K8S reporter as a CronJob.
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -17,8 +17,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 2.2.0
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
-appVersion: "2.12.0"
+# This is the version number of the (CLI) application being deployed. This version number should be
+# incremented each time you make changes to the application. They should reflect the version the
+# application is using. It is recommended to use it with quotes.
+appVersion: "v2.12.0"

--- a/charts/k8s-reporter/templates/cronjob.yaml
+++ b/charts/k8s-reporter/templates/cronjob.yaml
@@ -38,7 +38,7 @@ spec:
           {{- end }}
           containers:
           - name: reporter
-            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             volumeMounts:
             - name: environments-config

--- a/charts/k8s-reporter/values.yaml
+++ b/charts/k8s-reporter/values.yaml
@@ -8,7 +8,7 @@ image:
   # -- the kosli reporter image pull policy
   pullPolicy: IfNotPresent
   # -- the kosli reporter image tag, overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "" # defaults to chart appVersion
 
 # -- overrides the name used for the created k8s resources. If `fullnameOverride` is provided, it has higher precedence than this one
 nameOverride: ""

--- a/charts/k8s-reporter/values.yaml
+++ b/charts/k8s-reporter/values.yaml
@@ -8,7 +8,7 @@ image:
   # -- the kosli reporter image pull policy
   pullPolicy: IfNotPresent
   # -- the kosli reporter image tag, overrides the image tag whose default is the chart appVersion.
-  tag: "v2.12.0"
+  tag: ""
 
 # -- overrides the name used for the created k8s resources. If `fullnameOverride` is provided, it has higher precedence than this one
 nameOverride: ""


### PR DESCRIPTION
Align behaviour with what we're saying in the comments and what the typical approach here is: use `appVersion` as default version for CLI and provide an option to override using values.