### PR TITLE
Guard against lightweight tags in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,16 @@ jobs:
         id: tag
         uses: dawidd6/action-get-tag@v1
 
+      - name: Verify annotated tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG_TYPE=$(gh api repos/${{ github.repository }}/git/refs/tags/${{ steps.tag.outputs.tag }} --jq '.object.type')
+          if [ "$TAG_TYPE" != "tag" ]; then
+            echo "::error::Tag ${{ steps.tag.outputs.tag }} is lightweight, not annotated. Use 'make release' to cut releases."
+            exit 1
+          fi
+
       - name: Prepare
         id: prep
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,19 @@ All command tests in `cmd/kosli/` use the **testify suite** pattern:
 - Multi-platform releases via GoReleaser (darwin/linux/windows × amd64/arm64)
 - Semantic versioning; releases created with `make release tag=v<version>`
 
+## Releasing
+
+**NEVER use `gh release create` to cut a release.** It creates a lightweight tag and a premature GitHub Release, both of which break the release pipeline (never-alone-trail fails, GoReleaser conflicts with the pre-existing release).
+
+The release process is documented in [release-guide.md](/release-guide.md). The correct way to release:
+
+```bash
+make release              # Interactive: AI suggests version + changelog, you confirm
+make release tag=v2.x.y   # Fallback: explicit tag, no AI
+```
+
+Both paths create an **annotated tag** and push it. The `release.yml` workflow then runs GoReleaser, which creates the GitHub Release at the correct point in the pipeline. Do not create tags or releases via any other method.
+
 ## Working Style: TDD
 
 Follow a strict Red-Green-Refactor loop for every change:


### PR DESCRIPTION
## Summary

- Adds a **fail-fast check** in the `release.yml` workflow (`pre-build` job) that verifies the pushed tag is annotated, not lightweight. If a lightweight tag is detected, the workflow fails immediately with a clear error message directing the user to `make release`.
- Documents the correct release process in a new **"Releasing"** section in `CLAUDE.md`, explicitly prohibiting `gh release create` and pointing to `make release` / `release-guide.md`.

## Context

During the v2.16.0 release, `gh release create` was used instead of `make release`. This created a lightweight tag and a premature GitHub Release, which caused:
- **never-alone-trail** failures (lightweight tags don't carry the commit metadata the trail expects)
- **GoReleaser conflicts** with the pre-existing GitHub Release created by `gh release create`

The annotated tag guard catches this class of mistake at the earliest possible point in the pipeline, before any downstream jobs run.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | New "Verify annotated tag" step after "Get tag", before "Prepare" |
| `CLAUDE.md` | New "Releasing" section before "Working Style: TDD" |

## Test plan

- [ ] Verify the workflow YAML is valid (no syntax errors)
- [ ] Confirm the new step uses `gh api` to check the tag ref type and fails on `commit` (lightweight) vs `tag` (annotated)
- [ ] Confirm CLAUDE.md renders correctly with the new section