### PR TITLE
Sonar qube pr test now uses the lastest sonar-qube-pr scan and not a hard coded value server/#5354

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,6 +164,7 @@ jobs:
         INTEGRATION_TEST_AZURE_CLIENT_ID: ${{ secrets.azure_client_id }}
         KOSLI_SONAR_API_TOKEN: ${{ secrets.sonarqube_token }}
         KOSLI_API_TOKEN_PROD: ${{ secrets.kosli_querying_api_token }}
+        GH_TOKEN: ${{ secrets.github_access_token }}  # sonar tests download artifacts from cyber-dojo/differ
       run: |
         # some tests use git operations, therefore the git author on the CI VM needs to be set
         git config --global user.name "John Doe"

--- a/cmd/kosli/attestSonar_test.go
+++ b/cmd/kosli/attestSonar_test.go
@@ -1,7 +1,13 @@
 package main
 
 import (
+	"archive/zip"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/kosli-dev/cli/internal/testHelpers"
@@ -31,6 +37,7 @@ type AttestSonarCommandTestSuite struct {
 	flowName            string
 	trailName           string
 	artifactFingerprint string
+	prScannerWorkDir    string
 	suite.Suite
 	defaultKosliArguments string
 }
@@ -59,6 +66,8 @@ func (suite *AttestSonarCommandTestSuite) SetupTest() {
 	CreateFlowWithTemplate(suite.flowName, "testdata/valid_template.yml", suite.T())
 	BeginTrail(suite.trailName, suite.flowName, "", suite.T())
 	CreateArtifactOnTrail(suite.flowName, suite.trailName, "cli", suite.artifactFingerprint, "file1", suite.T())
+
+	suite.prScannerWorkDir = createPRScannerWorkDir(suite.T())
 }
 
 func (suite *AttestSonarQubeCommandTestSuite) SetupTest() {
@@ -191,7 +200,7 @@ func (suite *AttestSonarCommandTestSuite) TestAttestSonarCmd() {
 		},
 		{
 			name:   "21 can attest sonar for a pull request scan using report-task.txt without --pull-request flag",
-			cmd:    fmt.Sprintf("attest sonar --name cli.foo --commit HEAD --origin-url http://www.example.com --sonar-working-dir testdata/sonar/sonarcloud/.scannerwork-pr %s", suite.defaultKosliArguments),
+			cmd:    fmt.Sprintf("attest sonar --name cli.foo --commit HEAD --origin-url http://www.example.com --sonar-working-dir %s %s", suite.prScannerWorkDir, suite.defaultKosliArguments),
 			golden: "sonar attestation 'foo' is reported to trail: test-123\n",
 		},
 		{
@@ -343,6 +352,122 @@ func (suite *AttestSonarQubeCommandTestSuite) TestAttestSonarQubeCmd() {
 	}
 
 	runTestCmd(suite.T(), tests)
+}
+
+// createPRScannerWorkDir downloads the report-task.txt from the latest
+// SonarCloud PR scan of cyber-dojo_differ. The file is uploaded as a GitHub
+// Actions artifact by the sonar-pr-trigger workflow in that repo.
+func createPRScannerWorkDir(t *testing.T) string {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	httpClient := &http.Client{}
+
+	// GitHub token is required to download workflow artifacts.
+	// Check GH_TOKEN (gh CLI), GITHUB_TOKEN (CI), in that order.
+	ghToken := os.Getenv("GH_TOKEN")
+	if ghToken == "" {
+		ghToken = os.Getenv("GITHUB_TOKEN")
+	}
+	if ghToken == "" {
+		t.Fatalf("GH_TOKEN or GITHUB_TOKEN must be set to download artifacts from GitHub")
+	}
+
+	// Find the artifact ID via GitHub API
+	req, err := http.NewRequest("GET",
+		"https://api.github.com/repos/cyber-dojo/differ/actions/artifacts?name=sonar-pr-report-task&per_page=1", nil)
+	if err != nil {
+		t.Fatalf("failed to create artifact list request: %v", err)
+	}
+	req.Header.Add("Authorization", "Bearer "+ghToken)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("failed to list artifacts from GitHub: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GitHub artifacts API returned status %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Artifacts []struct {
+			ID      int    `json:"id"`
+			Expired bool   `json:"expired"`
+			Name    string `json:"name"`
+		} `json:"artifacts"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode artifacts response: %v", err)
+	}
+	if len(result.Artifacts) == 0 {
+		t.Fatalf("no sonar-pr-report-task artifact found in cyber-dojo/differ")
+	}
+	if result.Artifacts[0].Expired {
+		t.Fatalf("sonar-pr-report-task artifact has expired")
+	}
+
+	// Download the artifact zip
+	downloadURL := fmt.Sprintf("https://api.github.com/repos/cyber-dojo/differ/actions/artifacts/%d/zip", result.Artifacts[0].ID)
+	dlReq, err := http.NewRequest("GET", downloadURL, nil)
+	if err != nil {
+		t.Fatalf("failed to create artifact download request: %v", err)
+	}
+	dlReq.Header.Add("Authorization", "Bearer "+ghToken)
+
+	dlResp, err := httpClient.Do(dlReq)
+	if err != nil {
+		t.Fatalf("failed to download artifact: %v", err)
+	}
+	defer func() { _ = dlResp.Body.Close() }()
+
+	if dlResp.StatusCode != http.StatusOK {
+		t.Fatalf("artifact download returned status %d", dlResp.StatusCode)
+	}
+
+	// Save zip to temp file, then extract report-task.txt
+	zipPath := filepath.Join(tmpDir, "artifact.zip")
+	zipFile, err := os.Create(zipPath)
+	if err != nil {
+		t.Fatalf("failed to create temp zip file: %v", err)
+	}
+	if _, err := io.Copy(zipFile, dlResp.Body); err != nil {
+		_ = zipFile.Close()
+		t.Fatalf("failed to write artifact zip: %v", err)
+	}
+	_ = zipFile.Close()
+
+	zipReader, err := zip.OpenReader(zipPath)
+	if err != nil {
+		t.Fatalf("failed to open artifact zip: %v", err)
+	}
+	defer func() { _ = zipReader.Close() }()
+
+	for _, f := range zipReader.File {
+		if f.Name == "report-task.txt" {
+			rc, err := f.Open()
+			if err != nil {
+				t.Fatalf("failed to open report-task.txt in zip: %v", err)
+			}
+			outPath := filepath.Join(tmpDir, "report-task.txt")
+			outFile, err := os.Create(outPath)
+			if err != nil {
+				_ = rc.Close()
+				t.Fatalf("failed to create report-task.txt: %v", err)
+			}
+			_, err = io.Copy(outFile, rc)
+			_ = rc.Close()
+			_ = outFile.Close()
+			if err != nil {
+				t.Fatalf("failed to extract report-task.txt: %v", err)
+			}
+			return tmpDir
+		}
+	}
+
+	t.Fatalf("report-task.txt not found in artifact zip")
+	return ""
 }
 
 // In order for 'go test' to run this suite, we need to create

--- a/cmd/kosli/attestSonar_test.go
+++ b/cmd/kosli/attestSonar_test.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"archive/zip"
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kosli-dev/cli/internal/testHelpers"
@@ -38,6 +40,8 @@ type AttestSonarCommandTestSuite struct {
 	trailName           string
 	artifactFingerprint string
 	prScannerWorkDir    string
+	prKey               string
+	prCETaskURL         string
 	suite.Suite
 	defaultKosliArguments string
 }
@@ -67,7 +71,7 @@ func (suite *AttestSonarCommandTestSuite) SetupTest() {
 	BeginTrail(suite.trailName, suite.flowName, "", suite.T())
 	CreateArtifactOnTrail(suite.flowName, suite.trailName, "cli", suite.artifactFingerprint, "file1", suite.T())
 
-	suite.prScannerWorkDir = createPRScannerWorkDir(suite.T())
+	suite.prScannerWorkDir, suite.prKey, suite.prCETaskURL = downloadPRScanData(suite.T())
 }
 
 func (suite *AttestSonarQubeCommandTestSuite) SetupTest() {
@@ -184,7 +188,7 @@ func (suite *AttestSonarCommandTestSuite) TestAttestSonarCmd() {
 		},
 		{
 			name:   "18 can retrieve scan results using report-task.txt file and pull-request flag",
-			cmd:    fmt.Sprintf("attest sonar --name cli.foo --commit HEAD --origin-url http://www.example.com --sonar-working-dir testdata/sonar/sonarcloud/.scannerwork --pull-request 359 %s", suite.defaultKosliArguments),
+			cmd:    fmt.Sprintf("attest sonar --name cli.foo --commit HEAD --origin-url http://www.example.com --sonar-working-dir testdata/sonar/sonarcloud/.scannerwork --pull-request %s %s", suite.prKey, suite.defaultKosliArguments),
 			golden: "sonar attestation 'foo' is reported to trail: test-123\n",
 		},
 		{
@@ -195,7 +199,7 @@ func (suite *AttestSonarCommandTestSuite) TestAttestSonarCmd() {
 		},
 		{
 			name:   "20 can retrieve scan results using project key and pull-request flag",
-			cmd:    fmt.Sprintf("attest sonar --name cli.foo --commit HEAD --origin-url http://www.example.com --sonar-project-key cyber-dojo_differ --pull-request 359 %s", suite.defaultKosliArguments),
+			cmd:    fmt.Sprintf("attest sonar --name cli.foo --commit HEAD --origin-url http://www.example.com --sonar-project-key cyber-dojo_differ --pull-request %s %s", suite.prKey, suite.defaultKosliArguments),
 			golden: "sonar attestation 'foo' is reported to trail: test-123\n",
 		},
 		{
@@ -228,7 +232,7 @@ func (suite *AttestSonarCommandTestSuite) TestAttestSonarCmd() {
 		},
 		{
 			name:   "26 can attest sonar for a pull request scan using --sonar-ce-task-url",
-			cmd:    fmt.Sprintf("attest sonar --name cli.foo --commit HEAD --origin-url http://www.example.com --sonar-ce-task-url https://sonarcloud.io/api/ce/task?id=AZ2Qge89T7Y829rQbv87 %s", suite.defaultKosliArguments),
+			cmd:    fmt.Sprintf("attest sonar --name cli.foo --commit HEAD --origin-url http://www.example.com --sonar-ce-task-url %s %s", suite.prCETaskURL, suite.defaultKosliArguments),
 			golden: "sonar attestation 'foo' is reported to trail: test-123\n",
 		},
 		{
@@ -354,10 +358,11 @@ func (suite *AttestSonarQubeCommandTestSuite) TestAttestSonarQubeCmd() {
 	runTestCmd(suite.T(), tests)
 }
 
-// createPRScannerWorkDir downloads the report-task.txt from the latest
+// downloadPRScanData downloads the report-task.txt from the latest
 // SonarCloud PR scan of cyber-dojo_differ. The file is uploaded as a GitHub
 // Actions artifact by the sonar-pr-trigger workflow in that repo.
-func createPRScannerWorkDir(t *testing.T) string {
+// Returns the directory containing report-task.txt, the PR key, and the CE task URL.
+func downloadPRScanData(t *testing.T) (workDir, prKey, ceTaskURL string) {
 	t.Helper()
 
 	tmpDir := t.TempDir()
@@ -462,12 +467,47 @@ func createPRScannerWorkDir(t *testing.T) string {
 			if err != nil {
 				t.Fatalf("failed to extract report-task.txt: %v", err)
 			}
-			return tmpDir
+
+			prKey, ceTaskURL = parsePRReportTask(t, outPath)
+			return tmpDir, prKey, ceTaskURL
 		}
 	}
 
 	t.Fatalf("report-task.txt not found in artifact zip")
-	return ""
+	return "", "", ""
+}
+
+// parsePRReportTask extracts the PR key and CE task URL from a report-task.txt file.
+func parsePRReportTask(t *testing.T, path string) (prKey, ceTaskURL string) {
+	t.Helper()
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("failed to open %s: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "ceTaskUrl=") {
+			ceTaskURL = strings.TrimPrefix(line, "ceTaskUrl=")
+		}
+		if strings.HasPrefix(line, "dashboardUrl=") {
+			// dashboardUrl contains ...&pullRequest=<key>
+			if i := strings.Index(line, "pullRequest="); i != -1 {
+				prKey = line[i+len("pullRequest="):]
+			}
+		}
+	}
+
+	if prKey == "" {
+		t.Fatalf("pullRequest not found in %s", path)
+	}
+	if ceTaskURL == "" {
+		t.Fatalf("ceTaskUrl not found in %s", path)
+	}
+	return prKey, ceTaskURL
 }
 
 // In order for 'go test' to run this suite, we need to create


### PR DESCRIPTION
- **Dynamically fetch PR scan test data from GitHub artifact**
- **Use dynamic PR scan data for tests 18, 20, and 26**
- **Add GH_TOKEN to test workflow for sonar PR scan tests**
