### PR TITLE
4808 fix attestation name check

### DIFF
--- a/cmd/kosli/attestCustom_test.go
+++ b/cmd/kosli/attestCustom_test.go
@@ -158,6 +158,12 @@ func (suite *AttestCustomCommandTestSuite) TestAttestCustomCmd() {
 			cmd:       fmt.Sprintf("attest custom --name bar --annotate foo.baz=bar %s", suite.defaultKosliArguments),
 			golden:    "Error: --annotate flag should be in the format key=value. Invalid key: 'foo.baz'. Key can only contain [A-Za-z0-9_]\n",
 		},
+		{
+			wantError: true,
+			name:      "fails when --name has invalid dot format",
+			cmd:       fmt.Sprintf("attest custom --name .foo %s", suite.defaultKosliArguments),
+			golden:    "Error: failed to parse attestation name: invalid attestation name format: .foo\n",
+		},
 	}
 
 	runTestCmd(suite.T(), tests)

--- a/cmd/kosli/attestGeneric_test.go
+++ b/cmd/kosli/attestGeneric_test.go
@@ -190,6 +190,12 @@ func (suite *AttestGenericCommandTestSuite) TestAttestGenericCmd() {
 			cmd:    fmt.Sprintf("attest generic --name foo --fingerprint 7509e5bda0c762d2bac7f90d758b5b2263fa01ccbc542ab5e3df163be08e6ca9 --repo-id test-repo-id --repository test-repo-name --repo-url https://github.com/org/repo --repo-provider github %s", suite.defaultKosliArguments),
 			golden: "generic attestation 'foo' is reported to trail: test-123\n",
 		},
+		{
+			wantError: true,
+			name:      "fails when --name has invalid dot format",
+			cmd:       fmt.Sprintf("attest generic --name .foo %s", suite.defaultKosliArguments),
+			golden:    "Error: failed to parse attestation name: invalid attestation name format: .foo\n",
+		},
 	}
 
 	runTestCmd(suite.T(), tests)

--- a/cmd/kosli/attestJira_test.go
+++ b/cmd/kosli/attestJira_test.go
@@ -325,6 +325,12 @@ func (suite *AttestJiraCommandTestSuite) TestAttestJiraCmd() {
 				commitMessage: "SAMI-1 test commit",
 			},
 		},
+		{
+			wantError: true,
+			name:      "26 fails when --name has invalid dot format",
+			cmd:       fmt.Sprintf("attest jira --name .foo --commit HEAD --jira-base-url https://kosli-test.atlassian.net %s", suite.defaultKosliArguments),
+			golden:    "Error: failed to parse attestation name: invalid attestation name format: .foo\n",
+		},
 	}
 
 	for _, test := range tests {

--- a/cmd/kosli/attestJunit_test.go
+++ b/cmd/kosli/attestJunit_test.go
@@ -122,6 +122,12 @@ func (suite *AttestJunitCommandTestSuite) TestAttestJunitCmd() {
 					       --annotate foo.bar=bar %s`, suite.defaultKosliArguments),
 			golden: "Error: --annotate flag should be in the format key=value. Invalid key: 'foo.bar'. Key can only contain [A-Za-z0-9_]\n",
 		},
+		{
+			wantError: true,
+			name:      "fails when --name has invalid dot format",
+			cmd:       fmt.Sprintf("attest junit --name .foo %s", suite.defaultKosliArguments),
+			golden:    "Error: failed to parse attestation name: invalid attestation name format: .foo\n",
+		},
 	}
 
 	runTestCmd(suite.T(), tests)

--- a/cmd/kosli/attestPRAzure_test.go
+++ b/cmd/kosli/attestPRAzure_test.go
@@ -131,6 +131,12 @@ func (suite *AttestAzurePRCommandTestSuite) TestAttestAzurePRCmd() {
 			cmd:       fmt.Sprintf("attest pullrequest azure --name foo --commit HEAD --azure-token fake --azure-org-url https://dev.azure.com/myorg --project myproject --repository myrepo --repo-provider jenkins %s", suite.defaultKosliArguments),
 			golden:    "Error: --repo-provider 'jenkins' is not allowed. Must be one of: github, gitlab, bitbucket, azure-devops\n",
 		},
+		{
+			wantError: true,
+			name:      "16 fails when --name has invalid dot format",
+			cmd:       fmt.Sprintf("attest pullrequest azure --name .foo --commit HEAD --azure-org-url https://dev.azure.com/myorg --project myproject --repository myrepo %s", suite.defaultKosliArguments),
+			golden:    "Error: failed to parse attestation name: invalid attestation name format: .foo\n",
+		},
 	}
 
 	runTestCmd(suite.T(), tests)

--- a/cmd/kosli/attestPRBitbucket_test.go
+++ b/cmd/kosli/attestPRBitbucket_test.go
@@ -170,6 +170,12 @@ func (suite *AttestBitbucketPRCommandTestSuite) TestAttestBitbucketPRCmd() {
 			cmd:       fmt.Sprintf("attest pullrequest bitbucket --name foo --commit %s --bitbucket-access-token fake --bitbucket-workspace myworkspace --repository myrepo --repo-provider jenkins %s", suite.commitWithPR, suite.defaultKosliArguments),
 			golden:    "Error: --repo-provider 'jenkins' is not allowed. Must be one of: github, gitlab, bitbucket, azure-devops\n",
 		},
+		{
+			wantError: true,
+			name:      "19 fails when --name has invalid dot format",
+			cmd:       fmt.Sprintf("attest pullrequest bitbucket --name .foo --bitbucket-workspace myworkspace --repository myrepo %s", suite.defaultKosliArguments),
+			golden:    "Error: failed to parse attestation name: invalid attestation name format: .foo\n",
+		},
 	}
 
 	runTestCmd(suite.T(), tests)

--- a/cmd/kosli/attestPRBitbucket_test.go
+++ b/cmd/kosli/attestPRBitbucket_test.go
@@ -173,7 +173,7 @@ func (suite *AttestBitbucketPRCommandTestSuite) TestAttestBitbucketPRCmd() {
 		{
 			wantError: true,
 			name:      "19 fails when --name has invalid dot format",
-			cmd:       fmt.Sprintf("attest pullrequest bitbucket --name .foo --bitbucket-workspace myworkspace --repository myrepo %s", suite.defaultKosliArguments),
+			cmd:       fmt.Sprintf("attest pullrequest bitbucket --name .foo --bitbucket-workspace myworkspace --commit %s --bitbucket-access-token fake --repository myrepo %s", suite.commitWithPR, suite.defaultKosliArguments),
 			golden:    "Error: failed to parse attestation name: invalid attestation name format: .foo\n",
 		},
 	}

--- a/cmd/kosli/attestPRGithub_test.go
+++ b/cmd/kosli/attestPRGithub_test.go
@@ -161,6 +161,12 @@ func (suite *AttestGithubPRCommandTestSuite) TestAttestGithubPRCmd() {
 			cmd:       fmt.Sprintf("attest pullrequest github --name foo --commit %s --github-token fake --github-org myorg --repository myrepo --repo-provider jenkins %s", suite.commitWithPR, suite.defaultKosliArguments),
 			golden:    "Error: --repo-provider 'jenkins' is not allowed. Must be one of: github, gitlab, bitbucket, azure-devops\n",
 		},
+		{
+			wantError: true,
+			name:      "20 fails when --name has invalid dot format",
+			cmd:       fmt.Sprintf("attest pullrequest github --name .foo --github-org myorg --repository myrepo %s", suite.defaultKosliArguments),
+			golden:    "Error: failed to parse attestation name: invalid attestation name format: .foo\n",
+		},
 	}
 
 	runTestCmd(suite.T(), tests)

--- a/cmd/kosli/attestPRGithub_test.go
+++ b/cmd/kosli/attestPRGithub_test.go
@@ -164,7 +164,7 @@ func (suite *AttestGithubPRCommandTestSuite) TestAttestGithubPRCmd() {
 		{
 			wantError: true,
 			name:      "20 fails when --name has invalid dot format",
-			cmd:       fmt.Sprintf("attest pullrequest github --name .foo --github-org myorg --repository myrepo %s", suite.defaultKosliArguments),
+			cmd:       fmt.Sprintf("attest pullrequest github --name .foo --github-org myorg --commit %s --github-token fake --repository myrepo %s", suite.commitWithPR, suite.defaultKosliArguments),
 			golden:    "Error: failed to parse attestation name: invalid attestation name format: .foo\n",
 		},
 	}

--- a/cmd/kosli/attestPRGitlab_test.go
+++ b/cmd/kosli/attestPRGitlab_test.go
@@ -163,6 +163,12 @@ func (suite *AttestGitlabPRCommandTestSuite) TestAttestGitlabPRCmd() {
 			cmd:       fmt.Sprintf("attest pullrequest gitlab --name foo --commit %s --gitlab-token fake --gitlab-org myorg --repository myrepo --repo-provider jenkins %s", suite.commitWithPR, suite.defaultKosliArguments),
 			golden:    "Error: --repo-provider 'jenkins' is not allowed. Must be one of: github, gitlab, bitbucket, azure-devops\n",
 		},
+		{
+			wantError: true,
+			name:      "18 fails when --name has invalid dot format",
+			cmd:       fmt.Sprintf("attest pullrequest gitlab --name .foo --gitlab-org myorg --repository myrepo %s", suite.defaultKosliArguments),
+			golden:    "Error: failed to parse attestation name: invalid attestation name format: .foo\n",
+		},
 	}
 
 	runTestCmd(suite.T(), tests)

--- a/cmd/kosli/attestPRGitlab_test.go
+++ b/cmd/kosli/attestPRGitlab_test.go
@@ -166,7 +166,7 @@ func (suite *AttestGitlabPRCommandTestSuite) TestAttestGitlabPRCmd() {
 		{
 			wantError: true,
 			name:      "18 fails when --name has invalid dot format",
-			cmd:       fmt.Sprintf("attest pullrequest gitlab --name .foo --gitlab-org myorg --repository myrepo %s", suite.defaultKosliArguments),
+			cmd:       fmt.Sprintf("attest pullrequest gitlab --name .foo --gitlab-org myorg --commit %s --gitlab-token fake --repository myrepo %s", suite.commitWithPR, suite.defaultKosliArguments),
 			golden:    "Error: failed to parse attestation name: invalid attestation name format: .foo\n",
 		},
 	}

--- a/cmd/kosli/attestSnyk_test.go
+++ b/cmd/kosli/attestSnyk_test.go
@@ -124,6 +124,12 @@ func (suite *AttestSnykCommandTestSuite) TestAttestSnykCmd() {
 				--scan-results testdata/snyk_sarif.json %s`, suite.defaultKosliArguments),
 			golden: "Error: --annotate flag should be in the format key=value. Invalid key: 'foo.baz'. Key can only contain [A-Za-z0-9_]\n",
 		},
+		{
+			wantError: true,
+			name:      "fails when --name has invalid dot format",
+			cmd:       fmt.Sprintf("attest snyk --name .foo --scan-results testdata/snyk_sarif.json %s", suite.defaultKosliArguments),
+			golden:    "Error: failed to parse attestation name: invalid attestation name format: .foo\n",
+		},
 	}
 
 	runTestCmd(suite.T(), tests)

--- a/cmd/kosli/attestSonar_test.go
+++ b/cmd/kosli/attestSonar_test.go
@@ -247,6 +247,12 @@ func (suite *AttestSonarCommandTestSuite) TestAttestSonarCmd() {
 			cmd:       fmt.Sprintf("attest sonar --name cli.foo --commit HEAD --origin-url http://www.example.com --sonar-ce-task-url https://sonarcloud.io/api/ce/task?id=AZERk4uWpzGpahwkB9ac %s", suite.defaultKosliArguments),
 			golden:    "Error: No activity found for task 'AZERk4uWpzGpahwkB9ac' on https://sonarcloud.io. \nSonarQube may be experiencing problems, please check https://status.sonarqube.com/ and try again later. \nOtherwise if you are attesting an older scan, the snapshot may have been deleted by SonarQube\n",
 		},
+		{
+			wantError: true,
+			name:      "29 fails when --name has invalid dot format",
+			cmd:       fmt.Sprintf("attest sonar --name .foo %s", suite.defaultKosliArguments),
+			golden:    "Error: failed to parse attestation name: invalid attestation name format: .foo\n",
+		},
 	}
 
 	runTestCmd(suite.T(), tests)
@@ -352,6 +358,12 @@ func (suite *AttestSonarQubeCommandTestSuite) TestAttestSonarQubeCmd() {
 			name:   "can retrieve scan results using report-task.txt file and pull-request flag",
 			cmd:    fmt.Sprintf("attest sonar --name cli.foo --commit HEAD --origin-url http://www.example.com --sonar-working-dir testdata/sonar/sonarqube/.scannerwork --pull-request 359 --sonar-server-url http://example.com %s", suite.defaultKosliArguments),
 			golden: "sonar attestation 'foo' is reported to trail: test-123\n",
+		},
+		{
+			wantError: true,
+			name:      "fails when --name has invalid dot format",
+			cmd:       fmt.Sprintf("attest sonar --name .foo %s", suite.defaultKosliArguments),
+			golden:    "Error: failed to parse attestation name: invalid attestation name format: .foo\n",
 		},
 	}
 

--- a/cmd/kosli/attestation.go
+++ b/cmd/kosli/attestation.go
@@ -195,14 +195,16 @@ func prepareAttestationForm(payload interface{}, evidencePaths []string) ([]requ
 }
 
 func parseAttestationNameTemplate(template string) (string, string, error) {
-	parts := strings.Split(template, ".")
-	if len(parts) == 1 {
-		return parts[0], "", nil
-	} else if len(parts) == 2 {
-		return parts[0], parts[1], nil
-	} else {
+	p1, p2, found := strings.Cut(template, ".")
+	// No dot: treat the whole string as the attestation name
+	if !found {
+		return template, "", nil
+	}
+	// Reject empty sides (e.g. ".foo", "foo.") or multiple dots (e.g. "foo.bar.baz")
+	if p1 == "" || p2 == "" || strings.Contains(p2, ".") {
 		return "", "", fmt.Errorf("invalid attestation name format: %s", template)
 	}
+	return p1, p2, nil
 }
 
 // newAttestationForm constructs a list of FormItems for an attestation

--- a/cmd/kosli/attestation_test.go
+++ b/cmd/kosli/attestation_test.go
@@ -116,3 +116,54 @@ func TestMergeGitRepoInfo(t *testing.T) {
 		})
 	}
 }
+
+func TestParseAttestationNameTemplate(t *testing.T) {
+	tests := []struct {
+		name      string
+		template  string
+		wantP1    string
+		wantP2    string
+		wantError bool
+	}{
+		{
+			name:     "no dot returns whole string as p1",
+			template: "myattestation",
+			wantP1:   "myattestation",
+			wantP2:   "",
+		},
+		{
+			name:     "dot separates flow and attestation name",
+			template: "myflow.myattestation",
+			wantP1:   "myflow",
+			wantP2:   "myattestation",
+		},
+		{
+			name:      "leading dot is invalid",
+			template:  ".myattestation",
+			wantError: true,
+		},
+		{
+			name:      "trailing dot is invalid",
+			template:  "myflow.",
+			wantError: true,
+		},
+		{
+			name:      "multiple dots are invalid",
+			template:  "myflow.myattestation.extra",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p1, p2, err := parseAttestationNameTemplate(tt.template)
+			if tt.wantError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantP1, p1)
+			assert.Equal(t, tt.wantP2, p2)
+		})
+	}
+}


### PR DESCRIPTION
This PR updates the checking of an attestation name so that if there is a leading or trailing dot (e.g. ".foo" or "foo.") this will raise an error.