### PR TITLE
feat: improve version checking

### DIFF
--- a/cmd/kosli/main.go
+++ b/cmd/kosli/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	log "github.com/kosli-dev/cli/internal/logger"
@@ -49,7 +50,13 @@ func innerMain(cmd *cobra.Command, args []string) error {
 		// initialize() also never runs, so global.Debug is not set — check
 		// the flag and KOSLI_DEBUG env var directly.
 		if cmd.Root().Flags().Changed("version") {
-			debugEnabled := cmd.Root().Flags().Changed("debug") || os.Getenv("KOSLI_DEBUG") != ""
+			debugEnabled := cmd.Root().Flags().Changed("debug")
+			// match Viper internal bool env coercion
+			if !debugEnabled {
+				if v, err := strconv.ParseBool(os.Getenv("KOSLI_DEBUG")); err == nil {
+					debugEnabled = v
+				}
+			}
 			if !debugEnabled {
 				notice, _ := version.CheckForUpdate(version.GetVersion())
 				if notice != "" {

--- a/cmd/kosli/main.go
+++ b/cmd/kosli/main.go
@@ -46,10 +46,15 @@ func innerMain(cmd *cobra.Command, args []string) error {
 	if err == nil {
 		// Cobra handles --version internally and bypasses all hooks, so we print
 		// the update notice here after the fact.
+		// initialize() also never runs, so global.Debug is not set — check
+		// the flag and KOSLI_DEBUG env var directly.
 		if cmd.Root().Flags().Changed("version") {
-			notice, _ := version.CheckForUpdate(version.GetVersion())
-			if notice != "" {
-				_, _ = fmt.Fprint(logger.ErrOut, notice)
+			debugEnabled := cmd.Root().Flags().Changed("debug") || os.Getenv("KOSLI_DEBUG") != ""
+			if !debugEnabled {
+				notice, _ := version.CheckForUpdate(version.GetVersion())
+				if notice != "" {
+					_, _ = fmt.Fprint(logger.ErrOut, notice)
+				}
 			}
 		}
 

--- a/cmd/kosli/main.go
+++ b/cmd/kosli/main.go
@@ -7,6 +7,7 @@ import (
 
 	log "github.com/kosli-dev/cli/internal/logger"
 	"github.com/kosli-dev/cli/internal/requests"
+	"github.com/kosli-dev/cli/internal/version"
 	"github.com/spf13/cobra"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
@@ -43,6 +44,15 @@ func main() {
 func innerMain(cmd *cobra.Command, args []string) error {
 	err := cmd.Execute()
 	if err == nil {
+		// Cobra handles --version internally and bypasses all hooks, so we print
+		// the update notice here after the fact.
+		if cmd.Root().Flags().Changed("version") {
+			notice, _ := version.CheckForUpdate(version.GetVersion())
+			if notice != "" {
+				_, _ = fmt.Fprint(logger.ErrOut, notice)
+			}
+		}
+
 		return nil
 	}
 

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -334,7 +334,7 @@ func newRootCmd(out, errOut io.Writer, args []string) (*cobra.Command, error) {
 			if cmd.Name() != "version" && !strings.HasPrefix(cmd.Name(), "__") {
 				f := cmd.Flags().Lookup("output")
 				// skip version checks if using JSON output (programmatic usage)
-				if f == nil || f.Value.String() != "json" {
+				if f == nil || f.Value.String() == "table" {
 					go func() {
 						notice, _ := version.CheckForUpdate(version.GetVersion())
 						updateNoticeCh <- notice

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -332,8 +332,7 @@ func newRootCmd(out, errOut io.Writer, args []string) (*cobra.Command, error) {
 			// Note: --version is handled by Cobra before any hooks run, so it never
 			// reaches this point; innerMain handles the notice for that case.
 			if cmd.Name() != "version" && !strings.HasPrefix(cmd.Name(), "__") {
-				f := cmd.Flags().Lookup("output")
-				// skip version checks if using JSON output (programmatic usage)
+				// skip version checks if not using table output (programmatic usage)
 				if f == nil || f.Value.String() == "table" {
 					go func() {
 						notice, _ := version.CheckForUpdate(version.GetVersion())

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -332,6 +332,7 @@ func newRootCmd(out, errOut io.Writer, args []string) (*cobra.Command, error) {
 			// Note: --version is handled by Cobra before any hooks run, so it never
 			// reaches this point; innerMain handles the notice for that case.
 			if cmd.Name() != "version" && !strings.HasPrefix(cmd.Name(), "__") {
+				f := cmd.Flags().Lookup("output")
 				// skip version checks if not using table output (programmatic usage)
 				if f == nil || f.Value.String() == "table" {
 					go func() {

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -329,9 +329,10 @@ func newRootCmd(out, errOut io.Writer, args []string) (*cobra.Command, error) {
 			// Skip when:
 			//   - "version" subcommand: runs the check synchronously itself
 			//   - "__complete*": Cobra shell-completion commands fire on every Tab press
+			//   - debug mode: noisy HTTP traffic is undesirable when debugging
 			// Note: --version is handled by Cobra before any hooks run, so it never
 			// reaches this point; innerMain handles the notice for that case.
-			if cmd.Name() != "version" && !strings.HasPrefix(cmd.Name(), "__") {
+			if cmd.Name() != "version" && !strings.HasPrefix(cmd.Name(), "__") && !global.Debug {
 				f := cmd.Flags().Lookup("output")
 				// skip version checks if not using table output (programmatic usage)
 				if f == nil || f.Value.String() == "table" {

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -329,13 +329,17 @@ func newRootCmd(out, errOut io.Writer, args []string) (*cobra.Command, error) {
 			// Skip when:
 			//   - "version" subcommand: runs the check synchronously itself
 			//   - "__complete*": Cobra shell-completion commands fire on every Tab press
-			//   - --version flag: Cobra handles it internally and skips PersistentPostRun,
-			//     so the goroutine result would always be silently discarded
-			if cmd.Name() != "version" && !strings.HasPrefix(cmd.Name(), "__") && !cmd.Root().Flags().Changed("version") {
-				go func() {
-					notice, _ := version.CheckForUpdate(version.GetVersion())
-					updateNoticeCh <- notice
-				}()
+			// Note: --version is handled by Cobra before any hooks run, so it never
+			// reaches this point; innerMain handles the notice for that case.
+			if cmd.Name() != "version" && !strings.HasPrefix(cmd.Name(), "__") {
+				f := cmd.Flags().Lookup("output")
+				// skip version checks if using JSON output (programmatic usage)
+				if f == nil || f.Value.String() != "json" {
+					go func() {
+						notice, _ := version.CheckForUpdate(version.GetVersion())
+						updateNoticeCh <- notice
+					}()
+				}
 			}
 
 			if global.ApiToken == "DRY_RUN" {

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -334,7 +334,7 @@ func newRootCmd(out, errOut io.Writer, args []string) (*cobra.Command, error) {
 			// reaches this point; innerMain handles the notice for that case.
 			if cmd.Name() != "version" && !strings.HasPrefix(cmd.Name(), "__") && !global.Debug {
 				f := cmd.Flags().Lookup("output")
-				// skip version checks if not using table output (programmatic usage)
+				// skip version checks for programmatic output (avoid polluting JSON in CI pipelines)
 				if f == nil || f.Value.String() == "table" {
 					go func() {
 						notice, _ := version.CheckForUpdate(version.GetVersion())

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -62,6 +62,7 @@ func (suite *UpdateNoticeTestSuite) TestVersionFlagPrintsNotice() {
 	cmd, err := newRootCmd(io.Discard, &errBuf, []string{"--version"})
 	suite.Require().NoError(err)
 
+	cmd.SetArgs([]string{"--version"})
 	suite.NoError(innerMain(cmd, []string{"kosli", "--version"}))
 	suite.Contains(errBuf.String(), "A new version")
 }

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -62,8 +62,15 @@ func (suite *UpdateNoticeTestSuite) TestVersionFlagPrintsNotice() {
 	cmd, err := newRootCmd(io.Discard, &errBuf, []string{"--version"})
 	suite.Require().NoError(err)
 
+	var called bool
+	defer version.SetCheckForUpdateOverride(func(string) (string, error) {
+		called = true
+		return fakeNotice, nil
+	})()
+
 	cmd.SetArgs([]string{"--version"})
 	suite.NoError(innerMain(cmd, []string{"kosli", "--version"}))
+	suite.True(called, "expected CheckForUpdate override to be called for --version")
 	suite.Contains(errBuf.String(), "A new version")
 }
 

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -52,7 +52,6 @@ func (suite *UpdateNoticeTestSuite) SetupTest() {
 
 func (suite *UpdateNoticeTestSuite) TestVersionFlagPrintsNotice() {
 	const fakeNotice = "\nA new version of the Kosli CLI is available: v9.99.0 (you have v0.0.1)\nUpgrade: https://docs.kosli.com/getting_started/install/\n"
-	defer version.SetCheckForUpdateOverride(func(string) (string, error) { return fakeNotice, nil })()
 
 	var errBuf bytes.Buffer
 	origErrOut := logger.ErrOut

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/kosli-dev/cli/internal/version"
@@ -46,6 +48,22 @@ func (suite *UpdateNoticeTestSuite) SetupTest() {
 	}
 	suite.defaultKosliArguments = fmt.Sprintf("--host %s --org %s --api-token %s",
 		global.Host, global.Org, global.ApiToken)
+}
+
+func (suite *UpdateNoticeTestSuite) TestVersionFlagPrintsNotice() {
+	const fakeNotice = "\nA new version of the Kosli CLI is available: v9.99.0 (you have v0.0.1)\nUpgrade: https://docs.kosli.com/getting_started/install/\n"
+	defer version.SetCheckForUpdateOverride(func(string) (string, error) { return fakeNotice, nil })()
+
+	var errBuf bytes.Buffer
+	origErrOut := logger.ErrOut
+	logger.ErrOut = &errBuf
+	defer func() { logger.ErrOut = origErrOut }()
+
+	cmd, err := newRootCmd(io.Discard, &errBuf, []string{"--version"})
+	suite.Require().NoError(err)
+
+	suite.NoError(innerMain(cmd, []string{"kosli", "--version"}))
+	suite.Contains(errBuf.String(), "A new version")
 }
 
 func (suite *UpdateNoticeTestSuite) TestVersionNoticeSkippedForJSON() {

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -39,6 +39,11 @@ type UpdateNoticeTestSuite struct {
 }
 
 func (suite *UpdateNoticeTestSuite) SetupTest() {
+	global = &GlobalOpts{
+		ApiToken: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6ImNkNzg4OTg5In0.e8i_lA_QrEhFncb05Xw6E_tkCHU9QfcY4OLTVUCHffY",
+		Org:      "docs-cmd-test-user",
+		Host:     "http://localhost:8001",
+	}
 	suite.defaultKosliArguments = fmt.Sprintf("--host %s --org %s --api-token %s",
 		global.Host, global.Org, global.ApiToken)
 }
@@ -46,9 +51,7 @@ func (suite *UpdateNoticeTestSuite) SetupTest() {
 func (suite *UpdateNoticeTestSuite) TestVersionNoticeSkippedForJSON() {
 	const fakeNotice = "\nA new version of the Kosli CLI is available: v9.99.0 (you have v0.0.1)\nUpgrade: https://docs.kosli.com/getting_started/install/\n"
 
-	orig := version.OverrideCheckForUpdate
-	version.OverrideCheckForUpdate = func(string) (string, error) { return fakeNotice, nil }
-	defer func() { version.OverrideCheckForUpdate = orig }()
+	defer version.SetCheckForUpdateOverride(func(string) (string, error) { return fakeNotice, nil })()
 
 	// with --output json: no notice in stderr
 	_, _, _, stderr, err := executeCommandC(

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/kosli-dev/cli/internal/version"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -29,4 +31,38 @@ func (suite *RootCommandTestSuite) TestConfigProcessing() {
 // a normal test function and pass our suite to suite.Run
 func TestRootCommandTestSuite(t *testing.T) {
 	suite.Run(t, new(RootCommandTestSuite))
+}
+
+type UpdateNoticeTestSuite struct {
+	suite.Suite
+	defaultKosliArguments string
+}
+
+func (suite *UpdateNoticeTestSuite) SetupTest() {
+	suite.defaultKosliArguments = fmt.Sprintf("--host %s --org %s --api-token %s",
+		global.Host, global.Org, global.ApiToken)
+}
+
+func (suite *UpdateNoticeTestSuite) TestVersionNoticeSkippedForJSON() {
+	const fakeNotice = "\nA new version of the Kosli CLI is available: v9.99.0 (you have v0.0.1)\nUpgrade: https://docs.kosli.com/getting_started/install/\n"
+
+	orig := version.OverrideCheckForUpdate
+	version.OverrideCheckForUpdate = func(string) (string, error) { return fakeNotice, nil }
+	defer func() { version.OverrideCheckForUpdate = orig }()
+
+	// with --output json: no notice in stderr
+	_, _, _, stderr, err := executeCommandC(
+		fmt.Sprintf("list flows --output json %s", suite.defaultKosliArguments))
+	suite.NoError(err)
+	suite.Empty(stderr)
+
+	// with --output table: notice IS in stderr
+	_, _, _, stderr, err = executeCommandC(
+		fmt.Sprintf("list flows --output table %s", suite.defaultKosliArguments))
+	suite.NoError(err)
+	suite.Contains(stderr, "A new version")
+}
+
+func TestUpdateNoticeTestSuite(t *testing.T) {
+	suite.Run(t, new(UpdateNoticeTestSuite))
 }

--- a/cmd/kosli/version.go
+++ b/cmd/kosli/version.go
@@ -47,7 +47,7 @@ func (o *versionOptions) run(out, errOut io.Writer) {
 
 	// Synchronous check — version command always shows the update notice,
 	// unlike other commands where the check may be skipped if slower than the command.
-	// Skip wehn in debug mode
+	// Skip when in debug mode
 	if !global.Debug {
 		notice, _ := version.CheckForUpdate(version.GetVersion())
 		if notice != "" {

--- a/cmd/kosli/version.go
+++ b/cmd/kosli/version.go
@@ -47,9 +47,12 @@ func (o *versionOptions) run(out, errOut io.Writer) {
 
 	// Synchronous check — version command always shows the update notice,
 	// unlike other commands where the check may be skipped if slower than the command.
-	notice, _ := version.CheckForUpdate(version.GetVersion())
-	if notice != "" {
-		_, _ = fmt.Fprint(errOut, notice) // stderr — doesn't pollute piped stdout
+	// Skip wehn in debug mode
+	if !global.Debug {
+		notice, _ := version.CheckForUpdate(version.GetVersion())
+		if notice != "" {
+			_, _ = fmt.Fprint(errOut, notice) // stderr — doesn't pollute piped stdout
+		}
 	}
 }
 

--- a/cmd/kosli/version_test.go
+++ b/cmd/kosli/version_test.go
@@ -20,11 +20,11 @@ func (suite *VersionTestSuite) TestVersionCmd() {
 		{
 			name:   "default",
 			cmd:    "version",
-			golden: fmt.Sprintf("version.BuildInfo{Version:\"main\", GitCommit:\"\", GitTreeState:\"\", GoVersion:\"%s\"}\n", runtime.Version()),
+			golden: fmt.Sprintf("version.BuildInfo{Version:\"dev\", GitCommit:\"\", GitTreeState:\"\", GoVersion:\"%s\"}\n", runtime.Version()),
 		}, {
 			name:   "short",
 			cmd:    "version --short",
-			golden: "main\n",
+			golden: "dev\n",
 		},
 	}
 	runTestCmd(suite.T(), tests)

--- a/internal/version/update_check.go
+++ b/internal/version/update_check.go
@@ -39,7 +39,7 @@ func CheckForUpdate(currentVersion string) (string, error) {
 // so it never blocks or fails a command.
 // Set KOSLI_NO_UPDATE_CHECK=1 to skip entirely.
 func checkForUpdateWithURL(currentVersion string, apiURL string) (string, error) {
-	// checks disabled -skip
+	// checks disabled — skip
 	if os.Getenv("KOSLI_NO_UPDATE_CHECK") != "" {
 		return "", nil
 	}

--- a/internal/version/update_check.go
+++ b/internal/version/update_check.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	semver "github.com/Masterminds/semver/v3"

--- a/internal/version/update_check.go
+++ b/internal/version/update_check.go
@@ -23,20 +23,32 @@ type githubRelease struct {
 
 // overrideCheckForUpdate may be set by tests (via SetCheckForUpdateOverride)
 // to replace the real HTTP check.
-var overrideCheckForUpdate func(currentVersion string) (string, error)
+var (
+	overrideMu             sync.RWMutex
+	overrideCheckForUpdate func(currentVersion string) (string, error)
+)
 
 // SetCheckForUpdateOverride replaces the implementation used by CheckForUpdate
 // with fn and returns a function that restores the previous value. Tests only.
 func SetCheckForUpdateOverride(fn func(currentVersion string) (string, error)) func() {
+	overrideMu.Lock()
 	old := overrideCheckForUpdate
 	overrideCheckForUpdate = fn
-	return func() { overrideCheckForUpdate = old }
+	overrideMu.Unlock()
+	return func() {
+		overrideMu.Lock()
+		overrideCheckForUpdate = old
+		overrideMu.Unlock()
+	}
 }
 
 // CheckForUpdate is the public entry point — uses the real GitHub URL
 func CheckForUpdate(currentVersion string) (string, error) {
-	if overrideCheckForUpdate != nil {
-		return overrideCheckForUpdate(currentVersion)
+	overrideMu.RLock()
+	fn := overrideCheckForUpdate
+	overrideMu.RUnlock()
+	if fn != nil {
+		return fn(currentVersion)
 	}
 	return checkForUpdateWithURL(currentVersion, githubLatestReleaseURL)
 }

--- a/internal/version/update_check.go
+++ b/internal/version/update_check.go
@@ -14,15 +14,21 @@ import (
 
 const (
 	githubLatestReleaseURL = "https://api.github.com/repos/kosli-dev/cli/releases/latest"
-	updateCheckTimeout     = 2 * time.Second
+	updateCheckTimeout     = 1 * time.Second // max timeout when checking version
 )
 
 type githubRelease struct {
 	TagName string `json:"tag_name"`
 }
 
+// OverrideCheckForUpdate may be set in tests to replace the real HTTP check.
+var OverrideCheckForUpdate func(currentVersion string) (string, error)
+
 // CheckForUpdate is the public entry point — uses the real GitHub URL
 func CheckForUpdate(currentVersion string) (string, error) {
+	if OverrideCheckForUpdate != nil {
+		return OverrideCheckForUpdate(currentVersion)
+	}
 	return checkForUpdateWithURL(currentVersion, githubLatestReleaseURL)
 }
 
@@ -33,11 +39,13 @@ func CheckForUpdate(currentVersion string) (string, error) {
 // so it never blocks or fails a command.
 // Set KOSLI_NO_UPDATE_CHECK=1 to skip entirely.
 func checkForUpdateWithURL(currentVersion string, apiURL string) (string, error) {
+	// checks disabled -skip
 	if os.Getenv("KOSLI_NO_UPDATE_CHECK") != "" {
 		return "", nil
 	}
-	if currentVersion == "" || strings.HasPrefix(currentVersion, "main") || strings.Contains(currentVersion, "+unreleased") {
-		return "", nil // dev build — skip
+	// dev build — skip
+	if currentVersion == "" || strings.HasPrefix(currentVersion, "dev") {
+		return "", nil
 	}
 
 	// context provides the timeout and not http.Client

--- a/internal/version/update_check.go
+++ b/internal/version/update_check.go
@@ -21,13 +21,22 @@ type githubRelease struct {
 	TagName string `json:"tag_name"`
 }
 
-// OverrideCheckForUpdate may be set in tests to replace the real HTTP check.
-var OverrideCheckForUpdate func(currentVersion string) (string, error)
+// overrideCheckForUpdate may be set by tests (via SetCheckForUpdateOverride)
+// to replace the real HTTP check.
+var overrideCheckForUpdate func(currentVersion string) (string, error)
+
+// SetCheckForUpdateOverride replaces the implementation used by CheckForUpdate
+// with fn and returns a function that restores the previous value. Tests only.
+func SetCheckForUpdateOverride(fn func(currentVersion string) (string, error)) func() {
+	old := overrideCheckForUpdate
+	overrideCheckForUpdate = fn
+	return func() { overrideCheckForUpdate = old }
+}
 
 // CheckForUpdate is the public entry point — uses the real GitHub URL
 func CheckForUpdate(currentVersion string) (string, error) {
-	if OverrideCheckForUpdate != nil {
-		return OverrideCheckForUpdate(currentVersion)
+	if overrideCheckForUpdate != nil {
+		return overrideCheckForUpdate(currentVersion)
 	}
 	return checkForUpdateWithURL(currentVersion, githubLatestReleaseURL)
 }

--- a/internal/version/update_check_test.go
+++ b/internal/version/update_check_test.go
@@ -61,7 +61,7 @@ func TestCheckForUpdate_DevBuild(t *testing.T) {
 }
 
 func TestCheckForUpdate_UnreleasedBuild(t *testing.T) {
-	notice, err := checkForUpdateWithURL("v1.0.0+unreleased", "http://should-not-be-called")
+	notice, err := checkForUpdateWithURL("dev+unreleased", "http://should-not-be-called")
 	assert.NoError(t, err)
 	assert.Empty(t, notice)
 }

--- a/internal/version/update_check_test.go
+++ b/internal/version/update_check_test.go
@@ -102,6 +102,7 @@ func TestCheckForUpdate_Non200(t *testing.T) {
 }
 
 func TestSetCheckForUpdateOverride_Race(t *testing.T) {
+	t.Setenv("KOSLI_NO_UPDATE_CHECK", "1") // prevent real HTTP calls when override is momentarily nil
 	fake := func(string) (string, error) { return "notice", nil }
 	var wg sync.WaitGroup
 	for i := 0; i < 50; i++ {

--- a/internal/version/update_check_test.go
+++ b/internal/version/update_check_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -92,4 +93,25 @@ func TestCheckForUpdate_Non200(t *testing.T) {
 	notice, err := checkForUpdateWithURL("v0.1.0", srv.URL)
 	assert.NoError(t, err)
 	assert.Empty(t, notice)
+}
+
+func TestSetCheckForUpdateOverride_Race(t *testing.T) {
+	fake := func(string) (string, error) { return "notice", nil }
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = CheckForUpdate("v1.2.3")
+		}()
+	}
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			restore := SetCheckForUpdateOverride(fake)
+			restore()
+		}()
+	}
+	wg.Wait()
 }

--- a/internal/version/update_check_test.go
+++ b/internal/version/update_check_test.go
@@ -55,7 +55,7 @@ func TestCheckForUpdate_OptOut(t *testing.T) {
 
 func TestCheckForUpdate_DevBuild(t *testing.T) {
 	// dev builds should be skipped without any HTTP call
-	notice, err := checkForUpdateWithURL("main", "http://should-not-be-called")
+	notice, err := checkForUpdateWithURL("dev", "http://should-not-be-called")
 	assert.NoError(t, err)
 	assert.Empty(t, notice)
 }

--- a/internal/version/update_check_test.go
+++ b/internal/version/update_check_test.go
@@ -54,6 +54,12 @@ func TestCheckForUpdate_OptOut(t *testing.T) {
 	assert.Empty(t, notice)
 }
 
+func TestCheckForUpdate_EmptyVersion(t *testing.T) {
+	notice, err := checkForUpdateWithURL("", "http://should-not-be-called")
+	assert.NoError(t, err)
+	assert.Empty(t, notice)
+}
+
 func TestCheckForUpdate_DevBuild(t *testing.T) {
 	// dev builds should be skipped without any HTTP call
 	notice, err := checkForUpdateWithURL("dev", "http://should-not-be-called")

--- a/internal/version/update_check_test.go
+++ b/internal/version/update_check_test.go
@@ -60,7 +60,7 @@ func TestCheckForUpdate_DevBuild(t *testing.T) {
 	assert.Empty(t, notice)
 }
 
-func TestCheckForUpdate_UnreleasedBuild(t *testing.T) {
+func TestCheckForUpdate_DevBuildWithMetadata(t *testing.T) {
 	notice, err := checkForUpdateWithURL("dev+unreleased", "http://should-not-be-called")
 	assert.NoError(t, err)
 	assert.Empty(t, notice)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,7 +11,7 @@ var (
 	//
 	// Increment major number for new feature additions and behavioral changes.
 	// Increment minor number for bug fixes and performance enhancements.
-	version = "main" // this is overwritten with a release tag in the makefile
+	version = "dev" // this is overwritten with a release tag in the makefile
 
 	// metadata is extra build time data
 	metadata = ""

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -18,7 +18,7 @@ type VersionTestSuite struct {
 
 // reset the variables before each test
 func (suite *VersionTestSuite) SetupTest() {
-	version = "main"
+	version = "dev"
 	metadata = ""
 	gitCommit = ""
 	gitTreeState = ""
@@ -37,18 +37,18 @@ func (suite *VersionTestSuite) TestGetVersion() {
 		want string
 	}{
 		{
-			name: "version is main when metadata is empty.",
+			name: "version is dev when metadata is empty.",
 			args: args{
 				metadata: "",
 			},
-			want: "main",
+			want: "dev",
 		},
 		{
 			name: "version is suffixed with metadat when metadata is not empty.",
 			args: args{
 				metadata: "bla",
 			},
-			want: "main+bla",
+			want: "dev+bla",
 		},
 		{
 			name: "default version is overwritten when provided and there is metadata.",


### PR DESCRIPTION
* properly handle sync version checking when using `--version`
* don't check latest version when using JSON output (avoid polluting outputs in GHA pipelines)
* add testing for JSON output scenario 
* lower the async timeout to 1 sec (prevent long waits on slower connections)
* local builds use `dev` as version
* disable version check in debug mode