### PR TITLE
ci: run AWS Lambda contract tests nightly

### DIFF
--- a/.github/workflows/daily-cli-tests.yml
+++ b/.github/workflows/daily-cli-tests.yml
@@ -54,6 +54,39 @@ jobs:
       kosli_querying_api_token: ${{ secrets.KOSLI_API_TOKEN_PROD }}
       sonarqube_token: ${{ secrets.KOSLI_SONARQUBE_TOKEN }}
 
+  aws-contract-tests:
+    name: AWS Contract Tests
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: '.go-version'
+          check-latest: true
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::772819027869:role/cli
+          aws-region: eu-central-1
+          role-duration-seconds: 2400
+          role-session-name: ${{ github.event.repository.name }}
+
+      - name: Run AWS contract tests
+        run: make test_smoke_aws
+
   slack-notification-on-failure:
     runs-on: ubuntu-24.04
     permissions:
@@ -63,6 +96,7 @@ jobs:
       [
         set-trail-name,
         test,
+        aws-contract-tests,
       ]
     if: ${{ always() && contains(join(needs.*.result, ','), 'failure') && github.ref == 'refs/heads/main' }}
     steps:

--- a/.github/workflows/daily-cli-tests.yml
+++ b/.github/workflows/daily-cli-tests.yml
@@ -73,9 +73,6 @@ jobs:
           go-version-file: '.go-version'
           check-latest: true
 
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@latest
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ test_integration_restart_server: test_setup_restart_server
 test_integration_single: test_setup
 	@export KOSLI_TESTS=true $(FAKE_CI_ENV) && $(GOTESTSUM) -- -p=1 ./... -run "${TARGET}"
 
-test_smoke_aws: ## Run AWS contract and smoke tests against real AWS (requires AWS creds)
+test_smoke_aws: ensure_gotestsum ## Run AWS contract and smoke tests against real AWS (requires AWS creds)
 	@echo "Running AWS contract and smoke tests against real AWS..."
 	@echo "Requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY to be set"
 	@$(GOTESTSUM) -- -v -p=1 -run "LambdaContract_RealAWS|AWSTestSuite/TestGetLambdaPackageData|AWSTestSuite/TestGetEcsTasksData|AWSTestSuite/TestGetS3Data" ./internal/aws/


### PR DESCRIPTION
Add an aws-contract-tests job to the daily workflow that runs
make test_smoke_aws against real AWS using OIDC credentials.
Failure triggers the existing Slack notification.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
