### PR TITLE
fix: use json.Marshal instead of json.MarshalIndent for multipart data_json

### DIFF
--- a/internal/requests/requests.go
+++ b/internal/requests/requests.go
@@ -176,7 +176,7 @@ func createMultipartRequestBody(items []FormItem) (string, *bytes.Buffer, map[st
 			}
 
 			// Marshal the JSON field and add it to the multipart writer
-			jsonBytes, err := json.MarshalIndent(item.Content, "", "    ")
+			jsonBytes, err := json.Marshal(item.Content)
 			if err != nil {
 				return "", body, nil, err
 			}

--- a/internal/requests/requests.go
+++ b/internal/requests/requests.go
@@ -303,7 +303,12 @@ func (c *Client) PayloadOutput(req *http.Request, jsonFields map[string]any, mes
 		// Log only the JSON fields for multipart/form-data
 		c.Logger.Info(message)
 		for key, value := range jsonFields {
-			c.Logger.Info("Field: %s, Value: %+v", key, string(value.([]byte)))
+			var prettyJSON bytes.Buffer
+			if err := json.Indent(&prettyJSON, value.([]byte), "", "    "); err == nil {
+				c.Logger.Info("Field: %s, Value: %+v", key, prettyJSON.String())
+			} else {
+				c.Logger.Info("Field: %s, Value: %+v", key, string(value.([]byte)))
+			}
 		}
 	} else if req.Body != nil {
 		// For non-multipart requests, log the full JSON body

--- a/internal/requests/requests_test.go
+++ b/internal/requests/requests_test.go
@@ -549,14 +549,17 @@ func (suite *RequestsTestSuite) TestMultipartFieldJSON_IsCompact() {
 			Content:   map[string]interface{}{"key": "value", "nested": map[string]interface{}{"a": 1}},
 		},
 	}
-	_, body, _, err := createMultipartRequestBody(formItems)
+	_, body, jsonFields, err := createMultipartRequestBody(formItems)
 	require.NoError(suite.T(), err)
 
 	bodyStr := body.String()
 
-	// The JSON must not contain newlines or indentation
-	// (a compact marshal produces a single line like {"key":"value","nested":{"a":1}})
+	// The JSON in the multipart body must not contain indentation
 	require.NotContains(suite.T(), bodyStr, "    ", "multipart JSON field should not contain indentation")
+
+	// The raw JSON bytes stored for logging must be compact (single line, no newlines)
+	rawJSON := string(jsonFields["data_json"].([]byte))
+	require.NotContains(suite.T(), rawJSON, "\n", "multipart JSON field should be on a single line")
 }
 
 // In order for 'go test' to run this suite, we need to create

--- a/internal/requests/requests_test.go
+++ b/internal/requests/requests_test.go
@@ -541,6 +541,24 @@ func (suite *RequestsTestSuite) TestCreateMultipartRequestBody() {
 	}
 }
 
+func (suite *RequestsTestSuite) TestMultipartFieldJSON_IsCompact() {
+	formItems := []FormItem{
+		{
+			Type:      "field",
+			FieldName: "data_json",
+			Content:   map[string]interface{}{"key": "value", "nested": map[string]interface{}{"a": 1}},
+		},
+	}
+	_, body, _, err := createMultipartRequestBody(formItems)
+	require.NoError(suite.T(), err)
+
+	bodyStr := body.String()
+
+	// The JSON must not contain newlines or indentation
+	// (a compact marshal produces a single line like {"key":"value","nested":{"a":1}})
+	require.NotContains(suite.T(), bodyStr, "    ", "multipart JSON field should not contain indentation")
+}
+
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run
 func TestRequestsTestSuite(t *testing.T) {

--- a/internal/requests/requests_test.go
+++ b/internal/requests/requests_test.go
@@ -541,6 +541,34 @@ func (suite *RequestsTestSuite) TestCreateMultipartRequestBody() {
 	}
 }
 
+func (suite *RequestsTestSuite) TestMultipartDryRunOutput_IsPrettyPrinted() {
+	buf := new(bytes.Buffer)
+	client, err := NewKosliClient("", 1, false, logger.NewLogger(buf, buf, false))
+	require.NoError(suite.T(), err)
+
+	params := &RequestParams{
+		Method: http.MethodPut,
+		URL:    "http://localhost:8001/api/v2/attestations/test",
+		DryRun: true,
+		Token:  "test-token",
+		Form: []FormItem{
+			{
+				Type:      "field",
+				FieldName: "data_json",
+				Content:   map[string]any{"key": "value", "nested": map[string]any{"a": 1}},
+			},
+		},
+	}
+
+	_, err = client.Do(params)
+	require.NoError(suite.T(), err)
+
+	output := buf.String()
+	// Dry-run output should contain pretty-printed JSON with indentation
+	require.Contains(suite.T(), output, "    \"key\": \"value\"", "dry-run output should pretty-print JSON fields")
+	require.Contains(suite.T(), output, "    \"nested\": {", "dry-run output should pretty-print nested JSON")
+}
+
 func (suite *RequestsTestSuite) TestMultipartFieldJSON_IsCompact() {
 	formItems := []FormItem{
 		{


### PR DESCRIPTION
## Summary
- Replace `json.MarshalIndent` with `json.Marshal` for multipart form `data_json` fields
- Pretty-printing inflated payloads ~2x, causing `--attestation-data` and `--user-data` to hit the server's 1024 KB per-part limit at ~400-500 KB instead of ~1 MB
- Add test asserting multipart JSON fields contain no indentation

Closes #822

## Test plan
- [x] New test `TestMultipartFieldJSON_IsCompact` verifies compact JSON in multipart fields
- [x] All existing requests tests pass