### PR TITLE
perf: use json.Marshal instead of json.MarshalIndent for non-multipart request bodies

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -79,6 +79,15 @@
 - [x] Inject fake in `assertPRGithub_test.go`
 - [x] Inject fake in `attestPRGithub_test.go`
 
+## perf: compact JSON for non-multipart request bodies (#825)
+
+### Slice 1: Switch MarshalIndent → Marshal and verify
+
+- [x] Test: non-multipart JSON request body is compact (no indentation)
+- [x] Fix: change `json.MarshalIndent` → `json.Marshal` on line 122 of requests.go
+- [x] Fix: update `PayloadOutput` to pretty-print non-multipart body for debug/dry-run logging
+- [x] Verify: all request tests pass
+
 ## Fakes & contract tests for cloud provider integrations (#758)
 
 ### Lambda (done — this PR)

--- a/internal/requests/requests.go
+++ b/internal/requests/requests.go
@@ -119,7 +119,7 @@ func (p *RequestParams) newHTTPRequest() (*http.Request, map[string]any, error) 
 	} else {
 		// JSON payload handling
 		if p.Method != http.MethodGet {
-			jsonBytes, err := json.MarshalIndent(p.Payload, "", "    ")
+			jsonBytes, err := json.Marshal(p.Payload)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -319,7 +319,13 @@ func (c *Client) PayloadOutput(req *http.Request, jsonFields map[string]any, mes
 		}
 		// Restore the body for the actual request
 		req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
-		c.Logger.Info("%s \n %+v", message, string(bodyBytes))
+		// Pretty-print the JSON for human-readable output
+		var prettyJSON bytes.Buffer
+		if err := json.Indent(&prettyJSON, bodyBytes, "", "    "); err == nil {
+			c.Logger.Info("%s \n %+v", message, prettyJSON.String())
+		} else {
+			c.Logger.Info("%s \n %+v", message, string(bodyBytes))
+		}
 	}
 	return nil
 }

--- a/internal/requests/requests_test.go
+++ b/internal/requests/requests_test.go
@@ -3,6 +3,7 @@ package requests
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -588,6 +589,28 @@ func (suite *RequestsTestSuite) TestMultipartFieldJSON_IsCompact() {
 	// The raw JSON bytes stored for logging must be compact (single line, no newlines)
 	rawJSON := string(jsonFields["data_json"].([]byte))
 	require.NotContains(suite.T(), rawJSON, "\n", "multipart JSON field should be on a single line")
+}
+
+func (suite *RequestsTestSuite) TestNonMultipartJSON_IsCompact() {
+	params := &RequestParams{
+		Method: http.MethodPut,
+		URL:    "https://example.com/api/v2/test",
+		Token:  "test-token",
+		Payload: map[string]interface{}{
+			"key":    "value",
+			"nested": map[string]interface{}{"a": 1},
+		},
+	}
+	req, _, err := params.newHTTPRequest()
+	require.NoError(suite.T(), err)
+
+	bodyBytes, err := io.ReadAll(req.Body)
+	require.NoError(suite.T(), err)
+	bodyStr := string(bodyBytes)
+
+	// The JSON body must not contain indentation or newlines
+	require.NotContains(suite.T(), bodyStr, "    ", "non-multipart JSON body should not contain indentation")
+	require.NotContains(suite.T(), bodyStr, "\n", "non-multipart JSON body should be on a single line")
 }
 
 // In order for 'go test' to run this suite, we need to create


### PR DESCRIPTION
## Summary

- Switch `json.MarshalIndent` → `json.Marshal` for non-multipart JSON request bodies, eliminating ~30–55% payload inflation on every API call
- Update `PayloadOutput` to pretty-print via `json.Indent` at the logging site, preserving human-readable `--debug` and `--dry-run` output
- Add `TestNonMultipartJSON_IsCompact` test (mirrors `TestMultipartFieldJSON_IsCompact` from #822)

Closes #825

## Test plan

- [x] `TestNonMultipartJSON_IsCompact` asserts no indentation or newlines in wire-format body
- [x] All existing `requests` package tests pass (excluding `TestDebugPayloadOutput` which requires local server)
- [x] `golangci-lint` clean