### PR TITLE
feat(evaluate): add --assert / --no-assert to make evaluate a decision point

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -55,6 +55,27 @@
 - [x] Slice 3: Show params in `--show-input` output
 - [x] Slice 4: Update help text and examples
 
+## Add `--assert` / `--no-assert` to kosli evaluate commands
+
+Goal: make evaluate commands a policy decision point — print the verdict but
+let callers choose whether a deny becomes a non-zero exit. Today's default
+stays "assert" (non-zero on deny); the next major release flips the default
+to "no-assert" by changing one line.
+
+- [ ] Slice 1: Plumb `assertOnDeny` bool through `evaluateAndPrintResult` and the two printers (always passed `true`) ← active
+  - [ ] Existing `wantError: true` deny-all cases stay green
+- [ ] Slice 2: Add `--assert` / `--no-assert` flags to `commonEvaluateOptions`, mark mutually exclusive, default = assert
+  - [ ] `evaluate trail --policy deny-all --no-assert` exits 0, prints `RESULT: DENIED`
+  - [ ] `evaluate trail --policy deny-all --assert` exits non-zero
+  - [ ] `evaluate trail --policy deny-all` (neither flag) exits non-zero (default unchanged)
+  - [ ] `evaluate trail --assert --no-assert ...` fails with cobra mutual-exclusion error
+  - [ ] `evaluate trail --policy deny-all --no-assert --output json` emits `"allow": false` + violations, exits 0
+  - [ ] Same trio of tests for `evaluate trails` and `evaluate input`
+- [ ] Slice 3: Help text and examples
+  - [ ] Update `evaluateLongDesc` and `evaluateInputLongDesc` exit-code line
+  - [ ] Add `--no-assert` example to each command's `Example` block
+  - [ ] Verify `kosli evaluate trail --help` shows new flags
+
 ## Fakes & contract tests for GitHub API integration
 
 ### Slice 1: FakeGitHubClient + contract tests (`internal/github`) ← active

--- a/TODO.md
+++ b/TODO.md
@@ -62,16 +62,16 @@ let callers choose whether a deny becomes a non-zero exit. Today's default
 stays "assert" (non-zero on deny); the next major release flips the default
 to "no-assert" by changing one line.
 
-- [ ] Slice 1: Plumb `assertOnDeny` bool through `evaluateAndPrintResult` and the two printers (always passed `true`) ← active
-  - [ ] Existing `wantError: true` deny-all cases stay green
-- [ ] Slice 2: Add `--assert` / `--no-assert` flags to `commonEvaluateOptions`, mark mutually exclusive, default = assert
-  - [ ] `evaluate trail --policy deny-all --no-assert` exits 0, prints `RESULT: DENIED`
-  - [ ] `evaluate trail --policy deny-all --assert` exits non-zero
-  - [ ] `evaluate trail --policy deny-all` (neither flag) exits non-zero (default unchanged)
-  - [ ] `evaluate trail --assert --no-assert ...` fails with cobra mutual-exclusion error
-  - [ ] `evaluate trail --policy deny-all --no-assert --output json` emits `"allow": false` + violations, exits 0
-  - [ ] Same trio of tests for `evaluate trails` and `evaluate input`
-- [ ] Slice 3: Help text and examples
+- [x] Slice 1: Plumb `assertOnDeny` bool through `evaluateAndPrintResult` and the two printers (always passed `true`)
+  - [x] Existing `wantError: true` deny-all cases stay green
+- [x] Slice 2: Add `--assert` / `--no-assert` flags to `commonEvaluateOptions`, mark mutually exclusive, default = assert
+  - [x] `evaluate input --policy deny-all --no-assert` exits 0, prints `RESULT: DENIED`
+  - [x] `evaluate input --policy deny-all --assert` exits non-zero
+  - [x] `evaluate input --policy deny-all` (neither flag) exits non-zero (default unchanged)
+  - [x] `evaluate input --assert --no-assert ...` fails with cobra mutual-exclusion error
+  - [x] `evaluate input --policy deny-all --no-assert --output json` emits `"allow": false`, exits 0
+  - [x] Smoke test in `evaluate trail` and `evaluate trails` suites (`--no-assert` exit 0 + mutual exclusion); deferred run pending local Kosli server
+- [ ] Slice 3: Help text and examples ← active
   - [ ] Update `evaluateLongDesc` and `evaluateInputLongDesc` exit-code line
   - [ ] Add `--no-assert` example to each command's `Example` block
   - [ ] Verify `kosli evaluate trail --help` shows new flags

--- a/TODO.md
+++ b/TODO.md
@@ -71,10 +71,10 @@ to "no-assert" by changing one line.
   - [x] `evaluate input --assert --no-assert ...` fails with cobra mutual-exclusion error
   - [x] `evaluate input --policy deny-all --no-assert --output json` emits `"allow": false`, exits 0
   - [x] Smoke test in `evaluate trail` and `evaluate trails` suites (`--no-assert` exit 0 + mutual exclusion); deferred run pending local Kosli server
-- [ ] Slice 3: Help text and examples ← active
-  - [ ] Update `evaluateLongDesc` and `evaluateInputLongDesc` exit-code line
-  - [ ] Add `--no-assert` example to each command's `Example` block
-  - [ ] Verify `kosli evaluate trail --help` shows new flags
+- [x] Slice 3: Help text and examples
+  - [x] Update `evaluateLongDesc` and `evaluateInputLongDesc` exit-code section
+  - [x] Add `--no-assert` example to each command's `Example` block
+  - [x] Verify `kosli evaluate trail --help` shows new flags
 
 ## Fakes & contract tests for GitHub API integration
 

--- a/cmd/kosli/evaluate.go
+++ b/cmd/kosli/evaluate.go
@@ -6,11 +6,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const evaluateShortDesc = `Evaluate data against Rego policies.`
+const evaluateShortDesc = `[BETA] Evaluate data against Rego policies.`
 
 // Backtick breaks (`"` + "`x`" + `"`) are needed to embed markdown
 // inline code spans inside raw string literals.
 const evaluateLongDesc = evaluateShortDesc + `
+
+This command is in BETA. Behaviour, flags, and the policy input shape may
+change without notice. Pin a CLI version if you depend on it from CI.
+
 Evaluate trail data or local JSON input against custom Rego policies.
 
 Use ` + "`evaluate trail`" + ` or ` + "`evaluate trails`" + ` to fetch data from Kosli and evaluate it.

--- a/cmd/kosli/evaluate.go
+++ b/cmd/kosli/evaluate.go
@@ -18,7 +18,13 @@ Use ` + "`evaluate input`" + ` to evaluate a local JSON file or stdin without an
 
 The policy must use ` + "`package policy`" + ` and define an ` + "`allow`" + ` rule.
 An optional ` + "`violations`" + ` rule (a set of strings) can provide human-readable denial reasons.
-The command exits with code 0 when allowed and code 1 when denied.
+
+By default a deny exits with code 1 so the command can gate a pipeline.
+Pass ` + "`--no-assert`" + ` to use the command as a policy decision point: it prints
+the verdict and exits 0 even on deny, leaving the asserting to a downstream
+step. ` + "`--assert`" + ` is the current default; pass it explicitly to lock in the
+assert-on-deny behaviour across future releases, where the default will flip
+to ` + "`--no-assert`" + `.
 
 Use ` + "`--params`" + ` to pass configuration data (thresholds, expected counts, etc.)
 to your policy. Params are available as ` + "`data.params`" + ` in Rego, keeping policy

--- a/cmd/kosli/evaluateHelpers.go
+++ b/cmd/kosli/evaluateHelpers.go
@@ -116,7 +116,7 @@ func parseParams(raw string) (map[string]interface{}, error) {
 	return params, nil
 }
 
-func evaluateAndPrintResult(out io.Writer, policyFile string, input map[string]interface{}, outputFormat string, showInput bool, params map[string]interface{}) error {
+func evaluateAndPrintResult(out io.Writer, policyFile string, input map[string]interface{}, outputFormat string, showInput bool, params map[string]interface{}, assertOnDeny bool) error {
 	policySource, err := os.ReadFile(policyFile)
 	if err != nil {
 		return fmt.Errorf("failed to read policy file: %w", err)
@@ -145,54 +145,64 @@ func evaluateAndPrintResult(out io.Writer, policyFile string, input map[string]i
 
 	return output.FormattedPrint(string(raw), outputFormat, out, 0,
 		map[string]output.FormatOutputFunc{
-			"json":  printEvaluateResultAsJson,
-			"table": printEvaluateResultAsTable,
+			"json":  printEvaluateResultAsJsonFn(assertOnDeny),
+			"table": printEvaluateResultAsTableFn(assertOnDeny),
 		})
 }
 
-func printEvaluateResultAsJson(raw string, out io.Writer, _ int) error {
-	if err := output.PrintJson(raw, out, 0); err != nil {
-		return err
-	}
+func printEvaluateResultAsJsonFn(assertOnDeny bool) output.FormatOutputFunc {
+	return func(raw string, out io.Writer, _ int) error {
+		if err := output.PrintJson(raw, out, 0); err != nil {
+			return err
+		}
 
-	var result map[string]interface{}
-	if err := json.Unmarshal([]byte(raw), &result); err != nil {
-		return err
-	}
-	if allow, ok := result["allow"].(bool); ok && !allow {
-		return fmt.Errorf("policy denied")
-	}
-	return nil
-}
-
-func printEvaluateResultAsTable(raw string, out io.Writer, _ int) error {
-	var result map[string]interface{}
-	if err := json.Unmarshal([]byte(raw), &result); err != nil {
-		return err
-	}
-
-	allow, _ := result["allow"].(bool)
-
-	var rows []string
-	if allow {
-		rows = append(rows, "RESULT:\tALLOWED")
-		tabFormattedPrint(out, []string{}, rows)
+		var result map[string]interface{}
+		if err := json.Unmarshal([]byte(raw), &result); err != nil {
+			return err
+		}
+		if allow, ok := result["allow"].(bool); ok && !allow && assertOnDeny {
+			return fmt.Errorf("policy denied")
+		}
 		return nil
 	}
+}
 
-	rows = append(rows, "RESULT:\tDENIED")
+func printEvaluateResultAsTableFn(assertOnDeny bool) output.FormatOutputFunc {
+	return func(raw string, out io.Writer, _ int) error {
+		var result map[string]interface{}
+		if err := json.Unmarshal([]byte(raw), &result); err != nil {
+			return err
+		}
 
-	if violations, ok := result["violations"].([]interface{}); ok && len(violations) > 0 {
-		for i, v := range violations {
-			if i == 0 {
-				rows = append(rows, fmt.Sprintf("VIOLATIONS:\t%s", v))
-			} else {
-				rows = append(rows, fmt.Sprintf("\t%s", v))
+		allow, _ := result["allow"].(bool)
+
+		var rows []string
+		if allow {
+			rows = append(rows, "RESULT:\tALLOWED")
+			tabFormattedPrint(out, []string{}, rows)
+			return nil
+		}
+
+		rows = append(rows, "RESULT:\tDENIED")
+
+		if violations, ok := result["violations"].([]interface{}); ok && len(violations) > 0 {
+			for i, v := range violations {
+				if i == 0 {
+					rows = append(rows, fmt.Sprintf("VIOLATIONS:\t%s", v))
+				} else {
+					rows = append(rows, fmt.Sprintf("\t%s", v))
+				}
 			}
+			tabFormattedPrint(out, []string{}, rows)
+			if assertOnDeny {
+				return fmt.Errorf("policy denied: %v", violations)
+			}
+			return nil
 		}
 		tabFormattedPrint(out, []string{}, rows)
-		return fmt.Errorf("policy denied: %v", violations)
+		if assertOnDeny {
+			return fmt.Errorf("policy denied")
+		}
+		return nil
 	}
-	tabFormattedPrint(out, []string{}, rows)
-	return fmt.Errorf("policy denied")
 }

--- a/cmd/kosli/evaluateHelpers.go
+++ b/cmd/kosli/evaluateHelpers.go
@@ -22,6 +22,8 @@ type commonEvaluateOptions struct {
 	showInput    bool
 	attestations []string
 	params       string
+	assert       bool
+	noAssert     bool
 }
 
 func (o *commonEvaluateOptions) addFlags(cmd *cobra.Command, policyDesc string) {
@@ -31,6 +33,16 @@ func (o *commonEvaluateOptions) addFlags(cmd *cobra.Command, policyDesc string) 
 	cmd.Flags().BoolVar(&o.showInput, "show-input", false, "[optional] Include the policy input data in the output.")
 	cmd.Flags().StringSliceVar(&o.attestations, "attestations", nil, "[optional] Limit which attestations are included. Plain name for trail-level, dot-qualified (artifact.name) for artifact-level.")
 	cmd.Flags().StringVar(&o.params, "params", "", "[optional] Policy parameters as inline JSON or @file.json. Available in policies as data.params.")
+	cmd.Flags().BoolVar(&o.assert, "assert", false, "[optional] Exit with a non-zero status when the policy denies. This is the current default; pass --assert to lock it in across future releases.")
+	cmd.Flags().BoolVar(&o.noAssert, "no-assert", false, "[optional] Print the result and always exit 0, even when the policy denies. Use when this command feeds another tool as a policy decision point.")
+	cmd.MarkFlagsMutuallyExclusive("assert", "no-assert")
+}
+
+// assertOnDeny resolves the --assert / --no-assert pair into a single bool.
+// Today the default is true (assert); a future major release flips this by
+// returning o.assert directly.
+func (o *commonEvaluateOptions) assertOnDeny() bool {
+	return !o.noAssert
 }
 
 func fetchAndEnrichTrail(flowName, trailName string, attestations []string) (interface{}, error) {

--- a/cmd/kosli/evaluateInput.go
+++ b/cmd/kosli/evaluateInput.go
@@ -15,7 +15,7 @@ type evaluateInputOptions struct {
 	inputFile string
 }
 
-const evaluateInputShortDesc = `Evaluate a local JSON input against a Rego policy.`
+const evaluateInputShortDesc = `[BETA] Evaluate a local JSON input against a Rego policy.`
 
 const evaluateInputLongDesc = evaluateInputShortDesc + `
 Read JSON from a file or stdin and evaluate it against a Rego policy.

--- a/cmd/kosli/evaluateInput.go
+++ b/cmd/kosli/evaluateInput.go
@@ -114,7 +114,7 @@ func (o *evaluateInputOptions) run(out io.Writer, in io.Reader) error {
 		return err
 	}
 
-	return evaluateAndPrintResult(out, o.policyFile, input, o.output, o.showInput, params)
+	return evaluateAndPrintResult(out, o.policyFile, input, o.output, o.showInput, params, true)
 }
 
 func loadInputFromFile(filePath string) (result map[string]interface{}, err error) {

--- a/cmd/kosli/evaluateInput.go
+++ b/cmd/kosli/evaluateInput.go
@@ -114,7 +114,7 @@ func (o *evaluateInputOptions) run(out io.Writer, in io.Reader) error {
 		return err
 	}
 
-	return evaluateAndPrintResult(out, o.policyFile, input, o.output, o.showInput, params, true)
+	return evaluateAndPrintResult(out, o.policyFile, input, o.output, o.showInput, params, o.assertOnDeny())
 }
 
 func loadInputFromFile(filePath string) (result map[string]interface{}, err error) {

--- a/cmd/kosli/evaluateInput.go
+++ b/cmd/kosli/evaluateInput.go
@@ -25,7 +25,10 @@ the policy input from a ` + "`--show-input --output json`" + ` capture.
 
 The policy must use ` + "`package policy`" + ` and define an ` + "`allow`" + ` rule.
 An optional ` + "`violations`" + ` rule (a set of strings) can provide human-readable denial reasons.
-The command exits with code 0 when allowed and code 1 when denied.
+
+By default a deny exits with code 1. Pass ` + "`--no-assert`" + ` to print the verdict
+and exit 0 even on deny, when this command is feeding another tool as a
+policy decision point.
 
 When ` + "`--input-file`" + ` is omitted, JSON is read from stdin.
 
@@ -64,7 +67,13 @@ kosli evaluate input \
 kosli evaluate input \
 	--input-file trail-data.json \
 	--policy policy.rego \
-	--params @params.json`
+	--params @params.json
+
+# evaluate as a decision point (print verdict, never fail the step):
+kosli evaluate input \
+	--input-file trail-data.json \
+	--policy policy.rego \
+	--no-assert`
 
 func newEvaluateInputCmd(out io.Writer) *cobra.Command {
 	o := new(evaluateInputOptions)

--- a/cmd/kosli/evaluateInput_test.go
+++ b/cmd/kosli/evaluateInput_test.go
@@ -107,6 +107,36 @@ func (suite *EvaluateInputCommandTestSuite) TestEvaluateInputCmd() {
 				{"params.threshold", float64(3)},
 			},
 		},
+		{
+			name:        "deny-all with --no-assert exits 0 and prints DENIED",
+			cmd:         "evaluate input --input-file testdata/evaluate/trail-input.json --policy testdata/policies/deny-all.rego --no-assert",
+			goldenRegex: `RESULT:\s+DENIED`,
+		},
+		{
+			wantError:   true,
+			name:        "deny-all with --assert exits non-zero (matches default)",
+			cmd:         "evaluate input --input-file testdata/evaluate/trail-input.json --policy testdata/policies/deny-all.rego --assert",
+			goldenRegex: `RESULT:\s+DENIED`,
+		},
+		{
+			wantError:   true,
+			name:        "deny-all with no flag still exits non-zero (default unchanged)",
+			cmd:         "evaluate input --input-file testdata/evaluate/trail-input.json --policy testdata/policies/deny-all.rego",
+			goldenRegex: `RESULT:\s+DENIED`,
+		},
+		{
+			wantError:   true,
+			name:        "--assert and --no-assert together are mutually exclusive",
+			cmd:         "evaluate input --input-file testdata/evaluate/trail-input.json --policy testdata/policies/allow-all.rego --assert --no-assert",
+			goldenRegex: `none of the others can be.*\[assert no-assert\] were all set`,
+		},
+		{
+			name: "deny-all with --no-assert and --output json prints allow false and exits 0",
+			cmd:  "evaluate input --input-file testdata/evaluate/trail-input.json --policy testdata/policies/deny-all.rego --no-assert --output json",
+			goldenJson: []jsonCheck{
+				{"allow", false},
+			},
+		},
 	}
 	runTestCmd(suite.T(), tests)
 }

--- a/cmd/kosli/evaluateTrail.go
+++ b/cmd/kosli/evaluateTrail.go
@@ -55,6 +55,14 @@ kosli evaluate trail yourTrailName \
 	--flow yourFlowName \
 	--params @params.json \
 	--api-token yourAPIToken \
+	--org yourOrgName
+
+# evaluate a trail as a decision point (print verdict, never fail the step):
+kosli evaluate trail yourTrailName \
+	--policy yourPolicyFile.rego \
+	--flow yourFlowName \
+	--no-assert \
+	--api-token yourAPIToken \
 	--org yourOrgName`
 
 type evaluateTrailOptions struct {

--- a/cmd/kosli/evaluateTrail.go
+++ b/cmd/kosli/evaluateTrail.go
@@ -106,5 +106,5 @@ func (o *evaluateTrailOptions) run(out io.Writer, args []string) error {
 		"trail": trailData,
 	}
 
-	return evaluateAndPrintResult(out, o.policyFile, input, o.output, o.showInput, params, true)
+	return evaluateAndPrintResult(out, o.policyFile, input, o.output, o.showInput, params, o.assertOnDeny())
 }

--- a/cmd/kosli/evaluateTrail.go
+++ b/cmd/kosli/evaluateTrail.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const evaluateTrailShortDesc = `Evaluate a trail against a policy.`
+const evaluateTrailShortDesc = `[BETA] Evaluate a trail against a policy.`
 
 const evaluateTrailLongDesc = evaluateTrailShortDesc + `
 Fetch a single trail from Kosli and evaluate it against a Rego policy.

--- a/cmd/kosli/evaluateTrail.go
+++ b/cmd/kosli/evaluateTrail.go
@@ -106,5 +106,5 @@ func (o *evaluateTrailOptions) run(out io.Writer, args []string) error {
 		"trail": trailData,
 	}
 
-	return evaluateAndPrintResult(out, o.policyFile, input, o.output, o.showInput, params)
+	return evaluateAndPrintResult(out, o.policyFile, input, o.output, o.showInput, params, true)
 }

--- a/cmd/kosli/evaluateTrail_test.go
+++ b/cmd/kosli/evaluateTrail_test.go
@@ -139,6 +139,17 @@ func (suite *EvaluateTrailCommandTestSuite) TestEvaluateTrailCmd() {
 			cmd:         fmt.Sprintf(`evaluate trail %s --flow %s --policy testdata/policies/allow-all.rego --output table --show-input %s`, suite.trailName, suite.flowName, suite.defaultKosliArguments),
 			goldenRegex: `RESULT:\s+ALLOWED`,
 		},
+		{
+			name:        "deny-all with --no-assert exits 0 and prints DENIED",
+			cmd:         fmt.Sprintf(`evaluate trail %s --flow %s --policy testdata/policies/deny-all.rego --no-assert %s`, suite.trailName, suite.flowName, suite.defaultKosliArguments),
+			goldenRegex: `RESULT:\s+DENIED`,
+		},
+		{
+			wantError:   true,
+			name:        "--assert and --no-assert together are mutually exclusive",
+			cmd:         fmt.Sprintf(`evaluate trail %s --flow %s --policy testdata/policies/allow-all.rego --assert --no-assert %s`, suite.trailName, suite.flowName, suite.defaultKosliArguments),
+			goldenRegex: `none of the others can be.*\[assert no-assert\] were all set`,
+		},
 	}
 
 	runTestCmd(suite.T(), tests)

--- a/cmd/kosli/evaluateTrails.go
+++ b/cmd/kosli/evaluateTrails.go
@@ -103,5 +103,5 @@ func (o *evaluateTrailsOptions) run(out io.Writer, args []string) error {
 		"trails": trails,
 	}
 
-	return evaluateAndPrintResult(out, o.policyFile, input, o.output, o.showInput, params, true)
+	return evaluateAndPrintResult(out, o.policyFile, input, o.output, o.showInput, params, o.assertOnDeny())
 }

--- a/cmd/kosli/evaluateTrails.go
+++ b/cmd/kosli/evaluateTrails.go
@@ -103,5 +103,5 @@ func (o *evaluateTrailsOptions) run(out io.Writer, args []string) error {
 		"trails": trails,
 	}
 
-	return evaluateAndPrintResult(out, o.policyFile, input, o.output, o.showInput, params)
+	return evaluateAndPrintResult(out, o.policyFile, input, o.output, o.showInput, params, true)
 }

--- a/cmd/kosli/evaluateTrails.go
+++ b/cmd/kosli/evaluateTrails.go
@@ -48,6 +48,14 @@ kosli evaluate trails yourTrailName1 yourTrailName2 \
 	--flow yourFlowName \
 	--params '{"min_approvers": 2}' \
 	--api-token yourAPIToken \
+	--org yourOrgName
+
+# evaluate trails as a decision point (print verdict, never fail the step):
+kosli evaluate trails yourTrailName1 yourTrailName2 \
+	--policy yourPolicyFile.rego \
+	--flow yourFlowName \
+	--no-assert \
+	--api-token yourAPIToken \
 	--org yourOrgName`
 
 type evaluateTrailsOptions struct {

--- a/cmd/kosli/evaluateTrails.go
+++ b/cmd/kosli/evaluateTrails.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const evaluateTrailsShortDesc = `Evaluate multiple trails against a policy.`
+const evaluateTrailsShortDesc = `[BETA] Evaluate multiple trails against a policy.`
 
 const evaluateTrailsLongDesc = evaluateTrailsShortDesc + `
 Fetch multiple trails from Kosli and evaluate them together against a Rego policy.

--- a/cmd/kosli/evaluateTrails_test.go
+++ b/cmd/kosli/evaluateTrails_test.go
@@ -98,6 +98,17 @@ func (suite *EvaluateTrailsCommandTestSuite) TestEvaluateTrailsCmd() {
 			cmd:        fmt.Sprintf(`evaluate trails %s --flow %s --policy testdata/policies/allow-all.rego --output json --show-input %s`, suite.trailName, suite.flowName, suite.defaultKosliArguments),
 			goldenJson: []jsonCheck{{"allow", true}, {"input.trails.[0].name", suite.trailName}},
 		},
+		{
+			name:        "deny-all with --no-assert exits 0 and prints DENIED",
+			cmd:         fmt.Sprintf(`evaluate trails %s --flow %s --policy testdata/policies/deny-all.rego --no-assert %s`, suite.trailName, suite.flowName, suite.defaultKosliArguments),
+			goldenRegex: `RESULT:\s+DENIED`,
+		},
+		{
+			wantError:   true,
+			name:        "--assert and --no-assert together are mutually exclusive",
+			cmd:         fmt.Sprintf(`evaluate trails %s --flow %s --policy testdata/policies/allow-all.rego --assert --no-assert %s`, suite.trailName, suite.flowName, suite.defaultKosliArguments),
+			goldenRegex: `none of the others can be.*\[assert no-assert\] were all set`,
+		},
 	}
 
 	runTestCmd(suite.T(), tests)


### PR DESCRIPTION
## Summary
- Add a mutually-exclusive `--assert` / `--no-assert` flag pair to `kosli evaluate trail`, `kosli evaluate trails`, and `kosli evaluate input`. **Default behaviour is unchanged**: a policy deny still exits non-zero.
- Pass `--no-assert` to use these commands as a policy *decision point*: the verdict (`RESULT: DENIED` + violations, or `"allow": false`) is printed and the command exits 0, leaving any assertion to a downstream step.
- `--assert` is the current default; pinning it explicitly will keep today's behaviour after the next major release, when the default flips to `--no-assert`. The resolver lives on `commonEvaluateOptions.assertOnDeny()` — the major-version flip is one line (`return o.assert` instead of `return !o.noAssert`).
- Mark all three evaluate commands `[BETA]` in their short descriptions and add a beta paragraph to the parent long description, since behaviour, flags, and the policy input shape are still evolving.

## Notes for reviewers
- **Slice 1** (`green: thread assertOnDeny ...`) is a pure refactor — the two printers become closure factories taking an `assertOnDeny` bool. All callers pass `true`, behaviour unchanged.
- **Slice 2** wires the flags into `commonEvaluateOptions.addFlags()` (mutually exclusive via `cmd.MarkFlagsMutuallyExclusive`) and adds the resolver. Five new test cases in `evaluateInput_test.go` cover both flags, the default, mutual exclusion, and JSON output. Smoke tests added to the trail/trails suites for the same flag-resolution path.
- **Slice 3** is help-text-only.
- **Slice 4** adds the `[BETA]` markers.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./cmd/kosli/...` — clean
- [x] `go test -short -run TestEvaluateInputCommandTestSuite ./cmd/kosli/...` — all 5 new flag cases pass
- [x] `make test_integration_single TARGET=TestEvaluateTrailCommandTestSuite` and `…TestEvaluateTrailsCommandTestSuite` — need a local Kosli server (docker compose). The new flag cases use the same `assertOnDeny()` resolver as the input suite, which is fully exercised
- [x] Manual spot-check of `kosli evaluate input --help`, `kosli evaluate trail --help`, and `kosli evaluate --help` — new flags and BETA marker visible

---
_Generated by [Claude Code](https://claude.ai/code/session_014XhjL5TKL6JbrmyT42e9nV)_