### PR TITLE
Allow Claude Code to push feature branches

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,10 +28,18 @@
       "Bash(xargs *)",
       "Bash(git checkout -b *)",
       "Bash(git add *)",
-      "Bash(git commit *)"
+      "Bash(git commit *)",
+      "Bash(git push *)",
+      "Bash(git push --force-with-lease *)",
+      "Bash(git push --force-with-lease=*)"
     ],
     "deny": [
-      "Bash(git push *)",
+      "Bash(git push * main)",
+      "Bash(git push * main *)",
+      "Bash(git push * main:*)",
+      "Bash(git push * *:main)",
+      "Bash(git push --force *)",
+      "Bash(git push -f *)",
       "Bash(rm -rf *)",
       "Bash(curl *)",
       "Bash(wget *)"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,6 +40,10 @@
       "Bash(git push * *:main)",
       "Bash(git push --force *)",
       "Bash(git push -f *)",
+      "Bash(git push * --force)",
+      "Bash(git push * --force *)",
+      "Bash(git push * -f)",
+      "Bash(git push * -f *)",
       "Bash(rm -rf *)",
       "Bash(curl *)",
       "Bash(wget *)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Workflow Preferences
 
-- Claude **may** run `git checkout -b`, `git add`, and `git commit` as part of the TDD and slice workflow described below.
-- **NEVER** run `git push` or `git push --force`. The user handles all pushing themselves.
+- Claude **may** run `git checkout -b`, `git add`, `git commit`, and `git push` on feature branches as part of the TDD and slice workflow described below. `git push --force-with-lease` is permitted on feature branches for rebase workflows.
+- **NEVER** push to `main` and **NEVER** use `git push --force` / `git push -f` — use `--force-with-lease` instead, and only on feature branches.
 
 ## Project Overview
 


### PR DESCRIPTION
## Summary

- Update `.claude/settings.json` to allow `git push` on feature branches, including `git push --force-with-lease` for rebase workflows. Pushes touching `main`, plain `--force`, and `-f` remain denied.
- Update `CLAUDE.md` workflow preferences to match the new policy.

## Test plan

- [x] Confirm Claude can `git push` a feature branch without prompting
- [x] Confirm `git push origin main` (and variants) is still denied
- [x] Confirm `git push --force` / `git push -f` is still denied
- [x] Confirm `git push --force-with-lease` works on a feature branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)