### PR TITLE
fix(ci): wait for versions json upload before dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,7 +299,7 @@ jobs:
           client-payload: '{"kosli_cli_tag": "${{ needs.pre-build.outputs.tag }}"}'
 
   evidence-reporter-upload-package-and-deploy:
-    needs: [pre-build, goreleaser]
+    needs: [pre-build, goreleaser, environment-reporter-upload-layer]
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -316,7 +316,7 @@ jobs:
           client-payload: '{"kosli_cli_tag": "${{ needs.pre-build.outputs.tag }}"}'
 
   environment-reporter-upload-package-and-deploy:
-    needs: [pre-build, goreleaser]
+    needs: [pre-build, goreleaser, environment-reporter-upload-layer]
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner


### PR DESCRIPTION
The evidence-reporter-upload-package-and-deploy and environment-reporter-upload-package-and-deploy jobs fire repository_dispatch events into other Kosli repos. Those repos dispatch onward to further downstream repos, which read lambda_layer_versions.json from S3 -- the file written by environment-reporter-upload-layer in this workflow.

Until now, the two dispatching jobs only declared pre-build and goreleaser as needs, so they could run before
environment-reporter-upload-layer had finished uploading lambda_layer_versions.json. Jobs at the end of the dispatch chain were intermittently failing because the file was not yet in S3; manually re-running them succeeded, since by then the upload had completed -- a clear race-condition defect.

Add environment-reporter-upload-layer to the needs list for both jobs so the dispatches only fire once the file is in S3.