### PR TITLE
Makefile: fixed setup_test_to_use_xxx to only clean up the cli containers and not all containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ setup_test_to_use_local_image:
 
 setup_test_to_use_staging_server_image:
 	@rm /tmp/server-image.txt
-	@docker ps -aq | xargs -r docker rm -fv
+	@docker compose down -v
 	@echo "Now run make test_integration"
 	@echo "To look at the logs from kosli server run: make follow_integration_test_server"
 

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ test_setup_restart_server: ensure_gotestsum
 
 setup_test_to_use_local_image:
 	@echo merkely > /tmp/server-image.txt
-	@docker ps -aq | xargs -r docker rm -fv
+	@docker compose down -v
 	@echo "Run make build in the server repo you want to use"
 	@echo "Then run make test_integration"
 	@echo "To look at the logs from local kosli server run: make follow_integration_test_server"


### PR DESCRIPTION
- **fix(make): scope setup_test_to_use_local_image cleanup to the compose stack**
- **fix(make): scope setup_test_to_use_staging_server_image cleanup to the compose stack**
