### PR TITLE
fix: remove version checks on all commands

### DIFF
--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -315,8 +315,6 @@ func getConfigFileFlagDefault() string {
 func newRootCmd(out, errOut io.Writer, args []string) (*cobra.Command, error) {
 	global = new(GlobalOpts)
 
-	var updateNoticeCh = make(chan string, 1) // buffered — goroutine never blocks
-
 	cmd := &cobra.Command{
 		Use:              "kosli",
 		Short:            "The Kosli CLI.",
@@ -330,24 +328,6 @@ func newRootCmd(out, errOut io.Writer, args []string) (*cobra.Command, error) {
 			err := initialize(cmd, out, errOut)
 			if err != nil {
 				return err
-			}
-
-			// Fire update check in background — result collected in PostRun.
-			// Skip when:
-			//   - "version" subcommand: runs the check synchronously itself
-			//   - "__complete*": Cobra shell-completion commands fire on every Tab press
-			//   - debug mode: noisy HTTP traffic is undesirable when debugging
-			// Note: --version is handled by Cobra before any hooks run, so it never
-			// reaches this point; innerMain handles the notice for that case.
-			if cmd.Name() != "version" && !strings.HasPrefix(cmd.Name(), "__") && !global.Debug {
-				f := cmd.Flags().Lookup("output")
-				// skip version checks for programmatic output (avoid polluting JSON in CI pipelines)
-				if f == nil || f.Value.String() == "table" {
-					go func() {
-						notice, _ := version.CheckForUpdate(version.GetVersion())
-						updateNoticeCh <- notice
-					}()
-				}
 			}
 
 			if global.ApiToken == "DRY_RUN" {
@@ -371,16 +351,6 @@ func newRootCmd(out, errOut io.Writer, args []string) (*cobra.Command, error) {
 			})
 
 			return flagError
-		},
-		PersistentPostRun: func(cmd *cobra.Command, args []string) {
-			select {
-			case notice := <-updateNoticeCh:
-				if notice != "" {
-					_, _ = fmt.Fprint(errOut, notice) // stderr — doesn't pollute piped stdout
-				}
-			default:
-				// goroutine not done yet (took > command duration) — skip silently
-			}
 		},
 	}
 	cmd.SetVersionTemplate("{{.Version}}\n")

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -73,22 +73,20 @@ func (suite *UpdateNoticeTestSuite) TestVersionFlagPrintsNotice() {
 	suite.Contains(errBuf.String(), "A new version")
 }
 
-func (suite *UpdateNoticeTestSuite) TestVersionNoticeSkippedForJSON() {
+func (suite *UpdateNoticeTestSuite) TestVersionNoticeNotShownOnRegularCommands() {
 	const fakeNotice = "\nA new version of the Kosli CLI is available: v9.99.0 (you have v0.0.1)\nUpgrade: https://docs.kosli.com/getting_started/install/\n"
 
 	defer version.SetCheckForUpdateOverride(func(string) (string, error) { return fakeNotice, nil })()
 
-	// with --output json: no notice in stderr
-	_, _, _, stderr, err := executeCommandC(
-		fmt.Sprintf("list flows --output json %s", suite.defaultKosliArguments))
-	suite.NoError(err)
-	suite.Empty(stderr)
-
-	// with --output table: notice IS in stderr
-	_, _, _, stderr, err = executeCommandC(
-		fmt.Sprintf("list flows --output table %s", suite.defaultKosliArguments))
-	suite.NoError(err)
-	suite.Contains(stderr, "A new version")
+	// The update check only runs for the `version` subcommand and the
+	// `--version` flag — regular commands must not print the notice,
+	// regardless of output format.
+	for _, format := range []string{"json", "table"} {
+		_, _, _, stderr, err := executeCommandC(
+			fmt.Sprintf("list flows --output %s %s", format, suite.defaultKosliArguments))
+		suite.NoError(err)
+		suite.NotContains(stderr, "A new version", "no update notice expected for --output %s", format)
+	}
 }
 
 func TestUpdateNoticeTestSuite(t *testing.T) {


### PR DESCRIPTION
Some CI systems (like GHA) were multiplexing stdErr/stdOut and polluting output when piping or using output from CLI. This removes checking for version on all commands and only does it when explicitly running `--version`