### PR TITLE
fix: npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,7 +165,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GORELEASER_KEY: ${{ secrets.KOSLI_GORELEASERPRO }}
 
       - name: Copy npm packages into dist for provenance

--- a/npm/README.md
+++ b/npm/README.md
@@ -4,7 +4,7 @@ This directory contains the npm package structure for distributing the Kosli CLI
 
 ## Structure
 
-```
+```text
 npm/
 ├── wrapper/              # @kosli/cli — the package users install
 │   ├── bin/kosli         # JS shim that detects the platform and runs the binary
@@ -96,6 +96,8 @@ before:
 ## Publishing
 
 Packages are published to the [npm public registry](https://registry.npmjs.org). Platform packages must be published before the wrapper, since the wrapper's `optionalDependencies` references them by version. After a goreleaser build has populated the `bin/` directories:
+
+The package publishing expects the package is configured for [Trusted publishing](https://docs.npmjs.com/trusted-publishers) - so if more platforms are added you must configure the new packages accordingly.
 
 ```sh
 # Publish platform packages first

--- a/npm/README.md
+++ b/npm/README.md
@@ -97,8 +97,6 @@ before:
 
 Packages are published to the [npm public registry](https://registry.npmjs.org). Platform packages must be published before the wrapper, since the wrapper's `optionalDependencies` references them by version. After a goreleaser build has populated the `bin/` directories:
 
-The package publishing expects the package is configured for [Trusted publishing](https://docs.npmjs.com/trusted-publishers) - so if more platforms are added you must configure the new packages accordingly.
-
 ```sh
 # Publish platform packages first
 (cd npm/cli-linux-x64    && npm publish)
@@ -113,11 +111,7 @@ The package publishing expects the package is configured for [Trusted publishing
 (cd npm/wrapper && npm publish)
 ```
 
-Each package directory contains an `.npmrc` that sets the auth token:
-
-```text
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
-```
+The package publishing expects the package is configured for [Trusted publishing](https://docs.npmjs.com/trusted-publishers) - so if more platforms are added you must configure the new packages accordingly.
 
 ## Automated Publishing with npm-publish.sh
 

--- a/npm/cli-darwin-arm64/.npmrc
+++ b/npm/cli-darwin-arm64/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/npm/cli-darwin-x64/.npmrc
+++ b/npm/cli-darwin-x64/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/npm/cli-linux-arm/.npmrc
+++ b/npm/cli-linux-arm/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/npm/cli-linux-arm64/.npmrc
+++ b/npm/cli-linux-arm64/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/npm/cli-linux-x64/.npmrc
+++ b/npm/cli-linux-x64/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/npm/cli-win32-arm64/.npmrc
+++ b/npm/cli-win32-arm64/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/npm/cli-win32-x64/.npmrc
+++ b/npm/cli-win32-x64/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/npm/wrapper/.npmrc
+++ b/npm/wrapper/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
- All 8 packages have updated publishing settings including "Require two-factor authentication and disallow tokens (recommended)" as per npm recommandations.
- the secret `NPM_TOKEN` have been deleted

fix: #828 
