### PR TITLE
fix: wire up Node 24 + setup-node for npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,12 @@ jobs:
           go-version-file: '.go-version'
           check-latest: true
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
       # Use release notes from the tag body when present (set by interactive `make release` or `make release tag=vX.Y.Z` with dist/release_notes.md). Otherwise GoReleaser uses its default changelog.
       # Write to repo root so GoReleaser's --clean (which removes dist/) does not delete the file before it is read.
       - name: Get release notes from tag


### PR DESCRIPTION
## Summary

- Adds `actions/setup-node@v4` (Node 24) with `registry-url: https://registry.npmjs.org` to the `goreleaser` job
- This wires up the OIDC-based registry auth that npm trusted publishing requires, without needing `NPM_TOKEN` or per-package `.npmrc` files
- The `id-token: write` permission was already present on the job; the missing piece was `setup-node` to configure the registry endpoint

## Root cause

The previous commit (#843) correctly removed the `.npmrc` files and `NPM_TOKEN`, but npm trusted publishing requires Node ≥ 22.14.0, npm ≥ 11.5.1, **and** `actions/setup-node` with a `registry-url` to configure OIDC auth. Without `setup-node`, the runner had no registry config at all → `ENEEDAUTH` on every `npm publish` attempt.

## Test plan

- [ ] Trigger a release and verify npm packages publish successfully without `NPM_TOKEN`
- [ ] Confirm `--provenance` attestations are generated for each package

🤖 Generated with [Claude Code](https://claude.ai/claude-code)