### PR TITLE
fix: suppress npm always-auth deprecation warning by upgrading to setup-node@v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
           check-latest: true
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary

- Upgrades `actions/setup-node` from `@v4` to `@v6` in the release workflow
- Eliminates the `npm warn Unknown user config "always-auth"` deprecation warning that appears in release builds
- No behavioral change: the workflow uses npm with no `packageManager` field in any `package.json`, so v6's auto-caching restrictions don't apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)