### PR TITLE
Debug: expose Authorization, proxy, and response on errors

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -60,17 +60,30 @@ func extractRepoName(fullRepositoryName string) string {
 // NewGithubClientFromToken returns Github client with a token and context.
 // When debug is true the underlying transport is wrapped so every HTTP
 // request and response (REST and GraphQL) is dumped to stderr.
+//
+// debugTransport is installed as oauth2.Transport.Base (not as a wrapper
+// around it) so the Authorization header that oauth2 attaches is visible
+// in the dump — otherwise debug logs the request before oauth2 adds the
+// header and we lose the ability to verify it was actually sent.
 func NewGithubClientFromToken(ctx context.Context, ghToken string, baseURL string, debug bool) (*gh.Client, error) {
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: ghToken},
 	)
 	tc := oauth2.NewClient(ctx, ts)
 	if debug {
-		base := tc.Transport
-		if base == nil {
-			base = http.DefaultTransport
+		if t, ok := tc.Transport.(*oauth2.Transport); ok {
+			base := t.Base
+			if base == nil {
+				base = http.DefaultTransport
+			}
+			t.Base = &debugTransport{base: base, out: os.Stderr}
+		} else {
+			base := tc.Transport
+			if base == nil {
+				base = http.DefaultTransport
+			}
+			tc.Transport = &debugTransport{base: base, out: os.Stderr}
 		}
-		tc.Transport = &debugTransport{base: base, out: os.Stderr}
 	}
 	if baseURL != "" {
 		client, err := gh.NewEnterpriseClient(baseURL, baseURL, tc)
@@ -88,6 +101,10 @@ func NewGithubClientFromToken(ctx context.Context, ghToken string, baseURL strin
 type debugTransport struct {
 	base http.RoundTripper
 	out  io.Writer
+	// proxyFunc resolves the proxy URL for a request. Override in tests;
+	// nil means use http.ProxyFromEnvironment, whose cache makes it
+	// effectively impossible to set via t.Setenv after process start.
+	proxyFunc func(*http.Request) (*url.URL, error)
 }
 
 // logf writes debug output and intentionally ignores write errors —
@@ -98,6 +115,13 @@ func (d *debugTransport) logf(format string, args ...any) {
 
 func (d *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	d.logf("[debug-github] --> %s %s\n", req.Method, req.URL)
+	proxyFunc := d.proxyFunc
+	if proxyFunc == nil {
+		proxyFunc = http.ProxyFromEnvironment
+	}
+	if proxyURL, _ := proxyFunc(req); proxyURL != nil {
+		d.logf("[debug-github]     <via proxy %s>\n", proxyURL.Redacted())
+	}
 	for k, vs := range req.Header {
 		for _, v := range vs {
 			d.logf("[debug-github]     %s: %s\n", k, redactSensitiveHeader(k, v))
@@ -119,8 +143,14 @@ func (d *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := d.base.RoundTrip(req)
 	if err != nil {
 		d.logf("[debug-github] <-- transport error: %v\n", err)
-		return resp, err
 	}
+	if resp != nil {
+		d.logResponse(resp, req)
+	}
+	return resp, err
+}
+
+func (d *debugTransport) logResponse(resp *http.Response, req *http.Request) {
 	d.logf("[debug-github] <-- %d %s (%s %s)\n", resp.StatusCode, resp.Status, req.Method, req.URL)
 	for k, vs := range resp.Header {
 		for _, v := range vs {
@@ -140,7 +170,6 @@ func (d *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			resp.Body = io.NopCloser(bytes.NewReader(respBytes))
 		}
 	}
-	return resp, nil
 }
 
 // redactSensitiveHeader hides credentials in headers that commonly carry

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -119,7 +119,9 @@ func (d *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if proxyFunc == nil {
 		proxyFunc = http.ProxyFromEnvironment
 	}
-	if proxyURL, _ := proxyFunc(req); proxyURL != nil {
+	if proxyURL, proxyErr := proxyFunc(req); proxyErr != nil {
+		d.logf("[debug-github]     <proxy lookup error: %v>\n", proxyErr)
+	} else if proxyURL != nil {
 		d.logf("[debug-github]     <via proxy %s>\n", proxyURL.Redacted())
 	}
 	for k, vs := range req.Header {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -71,19 +71,12 @@ func NewGithubClientFromToken(ctx context.Context, ghToken string, baseURL strin
 	)
 	tc := oauth2.NewClient(ctx, ts)
 	if debug {
-		if t, ok := tc.Transport.(*oauth2.Transport); ok {
-			base := t.Base
-			if base == nil {
-				base = http.DefaultTransport
-			}
-			t.Base = &debugTransport{base: base, out: os.Stderr}
-		} else {
-			base := tc.Transport
-			if base == nil {
-				base = http.DefaultTransport
-			}
-			tc.Transport = &debugTransport{base: base, out: os.Stderr}
+		t := tc.Transport.(*oauth2.Transport)
+		base := t.Base
+		if base == nil {
+			base = http.DefaultTransport
 		}
+		t.Base = &debugTransport{base: base, out: os.Stderr}
 	}
 	if baseURL != "" {
 		client, err := gh.NewEnterpriseClient(baseURL, baseURL, tc)

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -1,15 +1,21 @@
 package github
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/oauth2"
 )
 
 type GithubTestSuite struct {
@@ -171,6 +177,125 @@ func TestRedactAuthHeader(t *testing.T) {
 			require.Equal(t, tc.want, redactAuthHeader(tc.in))
 		})
 	}
+}
+
+// fakeRoundTripper lets us inject an arbitrary response/error pair into
+// debugTransport without needing a real network. Used to assert behaviour
+// on transport-level errors, including the case where some middleboxes
+// return both a non-nil response and an error.
+type fakeRoundTripper struct {
+	resp *http.Response
+	err  error
+}
+
+func (f *fakeRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return f.resp, f.err
+}
+
+// TestNewGithubClientFromTokenDebugChain pins the transport chain shape
+// when debug=true: oauth2.Transport must be at the top and debugTransport
+// must be its Base. If this order is reversed, the Authorization header
+// added by oauth2 won't appear in the debug dump — which is the whole
+// reason customers turn debug on for auth failures.
+func TestNewGithubClientFromTokenDebugChain(t *testing.T) {
+	client, err := NewGithubClientFromToken(context.Background(), "fake-token", "", true)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	httpClient := client.Client()
+	require.NotNil(t, httpClient.Transport)
+
+	oauth2Tr, ok := httpClient.Transport.(*oauth2.Transport)
+	require.True(t, ok, "expected *oauth2.Transport at top of chain so it adds Authorization before debug logs")
+
+	_, ok = oauth2Tr.Base.(*debugTransport)
+	require.True(t, ok, "expected *debugTransport as oauth2.Transport.Base when debug=true")
+}
+
+// TestDebugTransport_LogsResponseOnTransportError covers the case where a
+// middlebox (corporate proxy, HTTP/2 layer) returns an error AND a non-nil
+// response. Before this fix the response — which carries the actual
+// diagnostic body — was silently dropped.
+func TestDebugTransport_LogsResponseOnTransportError(t *testing.T) {
+	var buf bytes.Buffer
+	resp := &http.Response{
+		StatusCode: 407,
+		Status:     "407 Proxy Authentication Required",
+		Header:     http.Header{"Proxy-Authenticate": []string{"Basic realm=\"corp\""}},
+		Body:       io.NopCloser(strings.NewReader("authentication required by proxy")),
+	}
+	tr := &debugTransport{
+		base: &fakeRoundTripper{resp: resp, err: errors.New("authenticationrequired")},
+		out:  &buf,
+	}
+	req, err := http.NewRequest("POST", "https://api.github.com/graphql", strings.NewReader(`{"query":"x"}`))
+	require.NoError(t, err)
+
+	gotResp, gotErr := tr.RoundTrip(req)
+	require.Error(t, gotErr)
+	require.NotNil(t, gotResp)
+
+	out := buf.String()
+	require.Contains(t, out, "transport error: authenticationrequired")
+	require.Contains(t, out, "407 Proxy Authentication Required")
+	require.Contains(t, out, "authentication required by proxy")
+}
+
+// TestDebugTransport_LogsProxyWhenSet verifies that when a proxy is
+// configured for the request, the proxy URL is logged on the request
+// line. This is a strong diagnostic for the customer's case where curl
+// works but the CLI gets a transport-level rejection.
+func TestDebugTransport_LogsProxyWhenSet(t *testing.T) {
+	proxyURL, err := url.Parse("http://corp-proxy.example.com:3128")
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	tr := &debugTransport{
+		base: &fakeRoundTripper{resp: &http.Response{
+			StatusCode: 200,
+			Status:     "200 OK",
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("{}")),
+		}},
+		out:       &buf,
+		proxyFunc: func(*http.Request) (*url.URL, error) { return proxyURL, nil },
+	}
+	req, err := http.NewRequest("POST", "https://api.github.com/graphql", nil)
+	require.NoError(t, err)
+
+	_, err = tr.RoundTrip(req)
+	require.NoError(t, err)
+
+	require.Contains(t, buf.String(), "<via proxy http://corp-proxy.example.com:3128>")
+}
+
+// TestDebugTransport_RedactsProxyUserinfo ensures credentials embedded in
+// the proxy URL (e.g. http://user:pass@proxy) are not leaked into debug
+// output. url.URL.Redacted() replaces the password with "xxxxx".
+func TestDebugTransport_RedactsProxyUserinfo(t *testing.T) {
+	proxyURL, err := url.Parse("http://user:secret@corp-proxy.example.com:3128")
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	tr := &debugTransport{
+		base: &fakeRoundTripper{resp: &http.Response{
+			StatusCode: 200,
+			Status:     "200 OK",
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("{}")),
+		}},
+		out:       &buf,
+		proxyFunc: func(*http.Request) (*url.URL, error) { return proxyURL, nil },
+	}
+	req, err := http.NewRequest("POST", "https://api.github.com/graphql", nil)
+	require.NoError(t, err)
+
+	_, err = tr.RoundTrip(req)
+	require.NoError(t, err)
+
+	out := buf.String()
+	require.NotContains(t, out, "secret")
+	require.Contains(t, out, "user:xxxxx@corp-proxy.example.com")
 }
 
 func TestRedactSensitiveHeader(t *testing.T) {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -269,6 +269,33 @@ func TestDebugTransport_LogsProxyWhenSet(t *testing.T) {
 	require.Contains(t, buf.String(), "<via proxy http://corp-proxy.example.com:3128>")
 }
 
+// TestDebugTransport_LogsProxyLookupError verifies that when proxyFunc
+// itself fails (e.g. malformed HTTP_PROXY env var) we surface the error
+// in the dump rather than silently swallowing it. This is the debug
+// transport — logging more is its job.
+func TestDebugTransport_LogsProxyLookupError(t *testing.T) {
+	var buf bytes.Buffer
+	tr := &debugTransport{
+		base: &fakeRoundTripper{resp: &http.Response{
+			StatusCode: 200,
+			Status:     "200 OK",
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("{}")),
+		}},
+		out: &buf,
+		proxyFunc: func(*http.Request) (*url.URL, error) {
+			return nil, errors.New("invalid proxy URL: missing scheme")
+		},
+	}
+	req, err := http.NewRequest("POST", "https://api.github.com/graphql", nil)
+	require.NoError(t, err)
+
+	_, err = tr.RoundTrip(req)
+	require.NoError(t, err)
+
+	require.Contains(t, buf.String(), "<proxy lookup error: invalid proxy URL: missing scheme>")
+}
+
 // TestDebugTransport_RedactsProxyUserinfo ensures credentials embedded in
 // the proxy URL (e.g. http://user:pass@proxy) are not leaked into debug
 // output. url.URL.Redacted() replaces the password with "xxxxx".


### PR DESCRIPTION
Three changes to make the GitHub debug dump actually diagnostic when
the request is rejected at the transport layer (e.g. corporate proxy,
edge filter):

- Install debugTransport as oauth2.Transport.Base instead of wrapping
  it. The Authorization header oauth2 attaches is now visible in the
  dump (redacted to last 4 chars), so we can verify the header was sent
  and matches the form curl uses.
- Log the resolved proxy URL on the request line via ProxyFromEnvironment
  (or an injected proxyFunc in tests, since the env-based lookup is
  sync.Once-cached and untestable post-init). Userinfo is redacted via
  url.URL.Redacted().
- Dump the response even when RoundTrip returns an error. Some
  middleboxes return both a non-nil response and an error; that response
  body is often where the actual reason lives, and we were silently
  dropping it.

Tests pin the chain shape (oauth2 on top, debug below) and cover the
three new behaviours.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
