### PR TITLE
docs: add Mintlify helm-docs template for k8s-reporter

### DIFF
--- a/charts/k8s-reporter/MINTLIFY.md.gotmpl
+++ b/charts/k8s-reporter/MINTLIFY.md.gotmpl
@@ -1,0 +1,27 @@
+---
+title: Kubernetes Reporter Helm Chart
+description: A Helm chart for installing the Kosli K8S reporter as a cronjob.
+---
+
+{{ template "chart.header" . }}
+
+{{ template "mintlify.versionInfo" . }}
+
+{{ template "chart.description" . }}
+{{ template "extra.longdescription" . }}
+
+{{ template "extra.prerequisites" . }}
+
+{{ template "extra.install" . }}
+
+{{ template "extra.upgrade" . }}
+
+{{ template "extra.uninstall" . }}
+
+{{ template "extra.customCA" . }}
+
+{{ template "mintlify.configurations" . }}
+
+---
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/k8s-reporter/_mintlify_templates.gotmpl
+++ b/charts/k8s-reporter/_mintlify_templates.gotmpl
@@ -1,0 +1,104 @@
+{{ define "mintlify.versionInfo" -}}
+<Info>
+This reference applies to **chart version {{ .Version }}**, which defaults to CLI **{{ .AppVersion }}** via `appVersion`. Override with `image.tag`.
+</Info>
+{{- end }}
+
+{{ define "mintlify.configurations" -}}
+## Configurations
+
+### General
+
+{{ range .Values -}}
+{{ if not (or (hasPrefix "image." .Key) (hasPrefix "reporterConfig." .Key) (hasPrefix "kosliApiToken." .Key) (hasPrefix "customCA" .Key) (hasPrefix "resources." .Key) (hasPrefix "serviceAccount." .Key) (eq "env" .Key) (eq "extraEnvVars" .Key) (eq "extraVolumes" .Key) (eq "extraVolumeMounts" .Key)) -}}
+{{ template "mintlify.paramField" . }}
+
+{{ end -}}
+{{ end -}}
+
+### Image
+
+{{ range .Values -}}
+{{ if hasPrefix "image." .Key -}}
+{{ template "mintlify.paramField" . }}
+
+{{ end -}}
+{{ end -}}
+
+### Reporter configuration
+
+{{ range .Values -}}
+{{ if hasPrefix "reporterConfig." .Key -}}
+{{ template "mintlify.paramField" . }}
+
+{{ end -}}
+{{ end -}}
+
+### Kosli API token
+
+{{ range .Values -}}
+{{ if hasPrefix "kosliApiToken." .Key -}}
+{{ template "mintlify.paramField" . }}
+
+{{ end -}}
+{{ end -}}
+
+### Environment variables
+
+{{ range .Values -}}
+{{ if or (eq "env" .Key) (eq "extraEnvVars" .Key) -}}
+{{ template "mintlify.paramField" . }}
+
+{{ end -}}
+{{ end -}}
+
+### Volumes
+
+{{ range .Values -}}
+{{ if or (eq "extraVolumes" .Key) (eq "extraVolumeMounts" .Key) -}}
+{{ template "mintlify.paramField" . }}
+
+{{ end -}}
+{{ end -}}
+
+### Custom CA
+
+{{ range .Values -}}
+{{ if hasPrefix "customCA" .Key -}}
+{{ template "mintlify.paramField" . }}
+
+{{ end -}}
+{{ end -}}
+
+### Resources
+
+{{ range .Values -}}
+{{ if hasPrefix "resources." .Key -}}
+{{ template "mintlify.paramField" . }}
+
+{{ end -}}
+{{ end -}}
+
+### Service account
+
+{{ range .Values -}}
+{{ if hasPrefix "serviceAccount." .Key -}}
+{{ template "mintlify.paramField" . }}
+
+{{ end -}}
+{{ end -}}
+{{- end }}
+
+{{ define "mintlify.paramField" -}}
+{{- $d := .Default | trimPrefix "`" | trimSuffix "`" -}}
+{{- $desc := or .Description .AutoDescription -}}
+{{- if or (and (eq .Type "object") (ne $d "{}")) (and (eq .Type "list") (ne $d "[]")) }}
+<ParamField path="{{ .Key }}" type="{{ .Type }}">
+  {{ $desc }}
+</ParamField>
+{{- else }}
+<ParamField path="{{ .Key }}" type="{{ .Type }}" default="{{ $d | trimPrefix "\"" | trimSuffix "\"" }}">
+  {{ $desc }}
+</ParamField>
+{{- end }}
+{{- end }}

--- a/charts/k8s-reporter/_templates.gotmpl
+++ b/charts/k8s-reporter/_templates.gotmpl
@@ -23,12 +23,12 @@ Version 2.0.0 removes the previous single-environment mode (`kosliEnvironmentNam
 To install this chart via the Helm chart repository:
 
 1. Add the Kosli helm repo
-```shell {.command}
+```shell
 helm repo add kosli https://charts.kosli.com/ && helm repo update
 ```
 
 2. Create a secret for the Kosli API token
-```shell {.command}
+```shell
 kubectl create secret generic kosli-api-token --from-literal=key=<your-api-key>
 ```
 
@@ -70,7 +70,7 @@ reporterConfig:
       excludeNamespaces: [prod-ns1, prod-ns2, default]
 ```
 
-```shell {.command}
+```shell
 helm install kosli-reporter kosli/k8s-reporter -f values.yaml
 ```
 
@@ -85,7 +85,7 @@ helm install kosli-reporter kosli/k8s-reporter -f values.yaml
 
 If upgrading from v1.x to v2.0.0, migrate your values to the **environments** list format (see above). Then:
 
-```shell {.command}
+```shell
 helm upgrade kosli-reporter kosli/k8s-reporter -f values.yaml
 ```
 {{- end }}
@@ -93,7 +93,7 @@ helm upgrade kosli-reporter kosli/k8s-reporter -f values.yaml
 {{ define "extra.uninstall" -}}
 ## Uninstalling chart
 
-```shell {.command}
+```shell
 helm uninstall kosli-reporter
 ```
 {{- end }}
@@ -109,7 +109,7 @@ The chart offers two ways to do this. Use whichever fits your deployment flow.
 
 1. Create a Secret containing the corporate CA certificate (PEM format, single cert or bundle):
 
-```shell {.command}
+```shell
 kubectl create secret generic corporate-ca-bundle --from-file=ca.crt=/path/to/corporate-ca.crt
 ```
 

--- a/charts/k8s-reporter/values.yaml
+++ b/charts/k8s-reporter/values.yaml
@@ -92,7 +92,7 @@ reporterConfig:
     runAsUser: 1000
 
 # -- map of plain environment variables to inject into the reporter container.
-# For a single-tenant Kosli instance, set KOSLI_HOST to https://<instance_name>.kosli.com.
+# For a single-tenant Kosli instance, set `KOSLI_HOST` to `https://<instance_name>.kosli.com`.
 env: {}
 
 # -- additional environment variables to inject into the reporter container.


### PR DESCRIPTION
## Summary

- Add a second helm-docs template set (`MINTLIFY.md.gotmpl` + `_mintlify_templates.gotmpl`) that generates Mintlify-compatible output with `<ParamField>` components and an `<Info>` version callout
- Share all prose sections (install, upgrade, customCA, etc.) with the existing README template via `_templates.gotmpl` to avoid duplication
- Remove `{.command}` Hugo attribute from shell code fences (Mintlify doesn't support it; GitHub ignores it)
- Wrap `<instance_name>` in backticks in `values.yaml` so MDX parser won't treat it as an HTML tag

## How it works

The docs repo workflow runs helm-docs twice with different template sets:
```bash
# GitHub README (existing):
helm-docs --template-files README.md.gotmpl,_templates.gotmpl

# Mintlify docs (new):
helm-docs --template-files MINTLIFY.md.gotmpl,_templates.gotmpl,_mintlify_templates.gotmpl --output-file k8s_reporter.md
```

Once this lands and a chart version is released, the hand-crafted `helm/k8s_reporter.mdx` in the docs repo can be deleted.

## Test plan

- [ ] Run `helm-docs --template-files README.md.gotmpl,_templates.gotmpl --dry-run` and verify README output is unchanged except `{.command}` removal
- [ ] Run `helm-docs --template-files MINTLIFY.md.gotmpl,_templates.gotmpl,_mintlify_templates.gotmpl --dry-run` and verify Mintlify output has `<ParamField>` components with correct descriptions and defaults
- [ ] Verify `<instance_name>` is wrapped in backticks in both outputs

Closes #853