### PR TITLE
fix: backtick http-proxy example URL to prevent broken doc links

### DIFF
--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -91,7 +91,7 @@ The ^.kosli_ignore^ will be treated as part of the artifact like any other file,
 	artifactDisplayName             = "[optional] Artifact display name, if different from file, image or directory name."
 	orgFlag                         = "The Kosli organization."
 	hostFlag                        = "[defaulted] The Kosli endpoint."
-	httpProxyFlag                   = "[optional] The HTTP proxy URL including protocol and port number. e.g. 'http://proxy-server-ip:proxy-port'"
+	httpProxyFlag                   = "[optional] The HTTP proxy URL including protocol and port number. e.g. `http://proxy-server-ip:proxy-port`"
 	dryRunFlag                      = "[optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors."
 	maxAPIRetryFlag                 = "[defaulted] How many times should API calls be retried when the API host is not reachable."
 	configFileFlag                  = "[optional] The Kosli config file path."


### PR DESCRIPTION
## Summary
- Wraps the example URL `http://proxy-server-ip:proxy-port` in the `--http-proxy` flag description with backticks instead of single quotes, so Mintlify renders it as inline code rather than a clickable (broken) link.
- Fixes 79 broken-link reports across `client_reference/` pages.

Closes kosli-dev/docs#105

## Test plan
- [x] Verify `kosli <any-command> --help` still shows the example URL correctly
- [ ] Regenerate docs and confirm the URL renders as inline code, not a link