### PR TITLE
chore: remove live-docs generation from CLI doc command

### DIFF
--- a/cmd/kosli/docs.go
+++ b/cmd/kosli/docs.go
@@ -1,11 +1,7 @@
 package main
 
 import (
-	"encoding/json"
 	"io"
-	"net/http"
-	neturl "net/url"
-	"strings"
 
 	"github.com/kosli-dev/cli/internal/docgen"
 	"github.com/spf13/cobra"
@@ -64,94 +60,8 @@ func (o *docsOptions) run() error {
 			}
 		}
 
-		return docgen.GenMarkdownTree(o.topCmd, o.dest, formatter, metaFn, &kosliLiveDocProvider{})
+		return docgen.GenMarkdownTree(o.topCmd, o.dest, formatter, metaFn)
 	}
 	return doc.GenMarkdownTree(o.topCmd, o.dest)
 }
 
-// kosliLiveDocProvider implements docgen.LiveDocProvider using HTTP calls
-// to the Kosli live docs API.
-type kosliLiveDocProvider struct{}
-
-const baseURL = "https://app.kosli.com/api/v2/livedocs/cyber-dojo"
-
-func buildDocURL(base, path, ci, command string) string {
-	u, err := neturl.JoinPath(base, path)
-	if err != nil {
-		return ""
-	}
-	q := neturl.Values{}
-	q.Set("ci", strings.ToLower(ci))
-	q.Set("command", command)
-	return u + "?" + q.Encode()
-}
-
-func buildCLIDocURL(base, path, command string) string {
-	u, err := neturl.JoinPath(base, path)
-	if err != nil {
-		return ""
-	}
-	q := neturl.Values{}
-	q.Set("command", command)
-	return u + "?" + q.Encode()
-}
-
-func (p *kosliLiveDocProvider) YamlDocExists(ci, command string) bool {
-	return liveDocExists(buildDocURL(baseURL, "yaml_exists", ci, command))
-}
-
-func (p *kosliLiveDocProvider) EventDocExists(ci, command string) bool {
-	return liveDocExists(buildDocURL(baseURL, "event_exists", ci, command))
-}
-
-func (p *kosliLiveDocProvider) YamlURL(ci, command string) string {
-	return buildDocURL(baseURL, "yaml", ci, command)
-}
-
-func (p *kosliLiveDocProvider) EventURL(ci, command string) string {
-	return buildDocURL(baseURL, "event", ci, command)
-}
-
-func (p *kosliLiveDocProvider) CLIDocExists(command string) (string, string, bool) {
-	fullCommand, ok := liveCliMap[command]
-	if ok {
-		plussed := strings.ReplaceAll(fullCommand, " ", "+")
-		existsURL := buildCLIDocURL(baseURL, "cli_exists", plussed)
-		url := buildCLIDocURL(baseURL, "cli", plussed)
-		return fullCommand, url, liveDocExists(existsURL)
-	}
-	return "", "", false
-}
-
-func liveDocExists(url string) bool {
-	response, err := http.Get(url) //nolint:gosec
-	if err != nil {
-		return false
-	}
-	defer func() {
-		if err := response.Body.Close(); err != nil {
-			logger.Warn("failed to close response body: %v", err)
-		}
-	}()
-	decoder := json.NewDecoder(response.Body)
-	var exists bool
-	err = decoder.Decode(&exists)
-	if err != nil {
-		return false
-	}
-	return exists
-}
-
-var liveCliMap = map[string]string{
-	"kosli list environments": "kosli list environments --output=json",
-	"kosli get environment":   "kosli get environment aws-prod --output=json",
-	"kosli log environment":   "kosli log environment aws-prod --output=json",
-	"kosli list snapshots":    "kosli list snapshots aws-prod --output=json",
-	"kosli get snapshot":      "kosli get snapshot aws-prod --output=json",
-	"kosli diff snapshots":    "kosli diff snapshots aws-beta aws-prod --output=json",
-	"kosli list flows":        "kosli list flows --output=json",
-	"kosli get flow":          "kosli get flow dashboard-ci --output=json",
-	//"kosli list trails":       "kosli list trails dashboard-ci --output=json",  // Produces too much output
-	"kosli get trail":       "kosli get trail dashboard-ci 1159a6f1193150681b8484545150334e89de6c1c --output=json",
-	"kosli get attestation": "kosli get attestation snyk-container-scan --flow=differ-ci --fingerprint=0cbbe3a6e73e733e8ca4b8813738d68e824badad0508ff20842832b5143b48c0 --output=json",
-}

--- a/internal/docgen/formatter.go
+++ b/internal/docgen/formatter.go
@@ -15,21 +15,6 @@ type CommandMeta struct {
 	Example    string
 }
 
-// CIExample holds data for a single CI system's live example.
-type CIExample struct {
-	CI       string
-	YamlURL  string
-	EventURL string
-}
-
-// LiveExampleData holds all live example data for a command.
-type LiveExampleData struct {
-	CIExamples []CIExample
-	CLICommand string
-	CLIURL     string
-	CLIExists  bool
-}
-
 // Formatter defines the interface for generating doc output in different formats.
 type Formatter interface {
 	Title(name string) string
@@ -38,8 +23,6 @@ type Formatter interface {
 	DeprecatedWarning(name, message string) string
 	Synopsis(meta CommandMeta) string
 	FlagsSection(flags, inherited string) string
-	LiveCIExamples(examples []CIExample, commandName string) string
-	LiveCLIExample(commandName, fullCommand, url string) string
 	ExampleUseCases(commandName, example string) string
 	LinkHandler(name string) string
 }
@@ -48,21 +31,3 @@ type Formatter interface {
 // It bridges the cmd/kosli package (which knows about isBeta/isDeprecated)
 // with the docgen package.
 type CommandMetaFunc func(cmd *cobra.Command) CommandMeta
-
-// LiveDocProvider abstracts the HTTP calls to check for live documentation.
-type LiveDocProvider interface {
-	YamlDocExists(ci, command string) bool
-	EventDocExists(ci, command string) bool
-	YamlURL(ci, command string) string
-	EventURL(ci, command string) string
-	CLIDocExists(command string) (fullCommand, url string, exists bool)
-}
-
-// NullLiveDocProvider is a no-op implementation for testing.
-type NullLiveDocProvider struct{}
-
-func (NullLiveDocProvider) YamlDocExists(ci, command string) bool              { return false }
-func (NullLiveDocProvider) EventDocExists(ci, command string) bool             { return false }
-func (NullLiveDocProvider) YamlURL(ci, command string) string                  { return "" }
-func (NullLiveDocProvider) EventURL(ci, command string) string                 { return "" }
-func (NullLiveDocProvider) CLIDocExists(command string) (string, string, bool) { return "", "", false }

--- a/internal/docgen/formatter_test.go
+++ b/internal/docgen/formatter_test.go
@@ -1,27 +1,4 @@
 package docgen
 
-import "testing"
-
-// Compile-time interface satisfaction checks.
+// Compile-time interface satisfaction check.
 var _ Formatter = (*MintlifyFormatter)(nil)
-var _ LiveDocProvider = (*NullLiveDocProvider)(nil)
-
-func TestNullLiveDocProvider(t *testing.T) {
-	p := NullLiveDocProvider{}
-	if p.YamlDocExists("GitHub", "cmd") {
-		t.Error("expected false")
-	}
-	if p.EventDocExists("GitHub", "cmd") {
-		t.Error("expected false")
-	}
-	if p.YamlURL("GitHub", "cmd") != "" {
-		t.Error("expected empty string")
-	}
-	if p.EventURL("GitHub", "cmd") != "" {
-		t.Error("expected empty string")
-	}
-	fc, u, exists := p.CLIDocExists("cmd")
-	if fc != "" || u != "" || exists {
-		t.Error("expected empty/false")
-	}
-}

--- a/internal/docgen/generate.go
+++ b/internal/docgen/generate.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,13 +13,13 @@ import (
 
 // GenMarkdownTree walks the cobra command tree and generates a doc file for each
 // leaf command using the provided Formatter.
-func GenMarkdownTree(cmd *cobra.Command, dir string, formatter Formatter, metaFn CommandMetaFunc, liveDocs LiveDocProvider) error {
+func GenMarkdownTree(cmd *cobra.Command, dir string, formatter Formatter, metaFn CommandMetaFunc) error {
 	for _, c := range cmd.Commands() {
 		// skip all unavailable commands except deprecated ones
 		if (!c.IsAvailableCommand() || c.IsAdditionalHelpTopicCommand()) && c.Deprecated == "" {
 			continue
 		}
-		if err := GenMarkdownTree(c, dir, formatter, metaFn, liveDocs); err != nil {
+		if err := GenMarkdownTree(c, dir, formatter, metaFn); err != nil {
 			return err
 		}
 	}
@@ -39,14 +38,14 @@ func GenMarkdownTree(cmd *cobra.Command, dir string, formatter Formatter, metaFn
 			}
 		}()
 
-		if err := genMarkdownCustom(cmd, f, formatter, metaFn, liveDocs); err != nil {
+		if err := genMarkdownCustom(cmd, f, formatter, metaFn); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func genMarkdownCustom(cmd *cobra.Command, w io.Writer, formatter Formatter, metaFn CommandMetaFunc, liveDocs LiveDocProvider) error {
+func genMarkdownCustom(cmd *cobra.Command, w io.Writer, formatter Formatter, metaFn CommandMetaFunc) error {
 	cmd.InitDefaultHelpCmd()
 	cmd.InitDefaultHelpFlag()
 
@@ -77,29 +76,6 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, formatter Formatter, met
 	// Flags
 	flags, inherited := RenderFlagsTables(cmd)
 	buf.WriteString(formatter.FlagsSection(flags, inherited))
-
-	// Live CI examples
-	urlSafeName := url.QueryEscape(name)
-	var ciExamples []CIExample
-	for _, ci := range []string{"GitHub", "GitLab"} {
-		if liveDocs.YamlDocExists(ci, urlSafeName) {
-			ex := CIExample{
-				CI:      ci,
-				YamlURL: liveDocs.YamlURL(ci, urlSafeName),
-			}
-			if liveDocs.EventDocExists(ci, urlSafeName) {
-				ex.EventURL = liveDocs.EventURL(ci, urlSafeName)
-			}
-			ciExamples = append(ciExamples, ex)
-		}
-	}
-	buf.WriteString(formatter.LiveCIExamples(ciExamples, name))
-
-	// Live CLI example
-	fullCommand, cliURL, cliExists := liveDocs.CLIDocExists(name)
-	if cliExists {
-		buf.WriteString(formatter.LiveCLIExample(name, fullCommand, cliURL))
-	}
 
 	// Example use cases
 	if len(meta.Example) > 0 {

--- a/internal/docgen/generate_test.go
+++ b/internal/docgen/generate_test.go
@@ -32,7 +32,7 @@ func TestGenMarkdownTreeCreatesFiles(t *testing.T) {
 		}
 	}
 
-	err := GenMarkdownTree(root, dir, MintlifyFormatter{}, metaFn, NullLiveDocProvider{})
+	err := GenMarkdownTree(root, dir, MintlifyFormatter{}, metaFn)
 	if err != nil {
 		t.Fatalf("GenMarkdownTree error: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestGenMarkdownTreeSkipsHiddenCommands(t *testing.T) {
 		return CommandMeta{Name: cmd.CommandPath()}
 	}
 
-	err := GenMarkdownTree(root, dir, MintlifyFormatter{}, metaFn, NullLiveDocProvider{})
+	err := GenMarkdownTree(root, dir, MintlifyFormatter{}, metaFn)
 	if err != nil {
 		t.Fatalf("GenMarkdownTree error: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestGenMarkdownTreeIncludesDeprecatedCommands(t *testing.T) {
 		}
 	}
 
-	err := GenMarkdownTree(root, dir, MintlifyFormatter{}, metaFn, NullLiveDocProvider{})
+	err := GenMarkdownTree(root, dir, MintlifyFormatter{}, metaFn)
 	if err != nil {
 		t.Fatalf("GenMarkdownTree error: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestGenMarkdownTreeWithMintlifyFormatter(t *testing.T) {
 		}
 	}
 
-	err := GenMarkdownTree(root, dir, MintlifyFormatter{}, metaFn, NullLiveDocProvider{})
+	err := GenMarkdownTree(root, dir, MintlifyFormatter{}, metaFn)
 	if err != nil {
 		t.Fatalf("GenMarkdownTree error: %v", err)
 	}

--- a/internal/docgen/mintlify.go
+++ b/internal/docgen/mintlify.go
@@ -78,38 +78,6 @@ func (MintlifyFormatter) FlagsSection(flags, inherited string) string {
 	return b.String()
 }
 
-func (MintlifyFormatter) LiveCIExamples(examples []CIExample, commandName string) string {
-	if len(examples) == 0 {
-		return ""
-	}
-	var b strings.Builder
-	b.WriteString("## Live Examples in different CI systems\n\n")
-	b.WriteString("<Tabs>\n")
-	for _, ex := range examples {
-		fmt.Fprintf(&b, "\t<Tab title=\"%v\">\n", ex.CI)
-		fmt.Fprintf(&b, "\tView an example of the `%s` command in %s.\n\n", commandName, ex.CI)
-		fmt.Fprintf(&b, "\tIn [this YAML file](%v)", ex.YamlURL)
-		if ex.EventURL != "" {
-			fmt.Fprintf(&b, ", which created [this Kosli Event](%v).", ex.EventURL)
-		}
-		b.WriteString("\n\t</Tab>\n")
-	}
-	b.WriteString("</Tabs>\n\n")
-	return b.String()
-}
-
-func (MintlifyFormatter) LiveCLIExample(commandName, fullCommand, url string) string {
-	var b strings.Builder
-	b.WriteString("## Live Example\n\n")
-	fmt.Fprintf(&b, "To view a live example of '%s' you can run the commands below (for the <a href=\"https://app.kosli.com/cyber-dojo/environments/aws-prod/snapshots/\">cyber-dojo</a> demo organization).<br/><a href=\"%s\">Run the commands below and view the output.</a>", commandName, url)
-	b.WriteString("<pre>")
-	b.WriteString("export KOSLI_ORG=cyber-dojo\n")
-	b.WriteString("export KOSLI_API_TOKEN=Pj_XT2deaVA6V1qrTlthuaWsmjVt4eaHQwqnwqjRO3A  # read-only\n")
-	b.WriteString(fullCommand)
-	b.WriteString("</pre>\n\n")
-	return b.String()
-}
-
 func (MintlifyFormatter) ExampleUseCases(commandName, example string) string {
 	var b strings.Builder
 	b.WriteString("## Examples Use Cases\n\n")

--- a/internal/docgen/mintlify_test.go
+++ b/internal/docgen/mintlify_test.go
@@ -77,39 +77,6 @@ func TestMintlifySynopsis(t *testing.T) {
 	}
 }
 
-func TestMintlifyLiveCIExamples(t *testing.T) {
-	f := MintlifyFormatter{}
-	examples := []CIExample{
-		{CI: "GitHub", YamlURL: "http://yaml", EventURL: "http://event"},
-		{CI: "GitLab", YamlURL: "http://yaml2"},
-	}
-	got := f.LiveCIExamples(examples, "kosli attest snyk")
-	if !strings.Contains(got, "<Tabs>") {
-		t.Error("expected Tabs component")
-	}
-	if !strings.Contains(got, `<Tab title="GitHub">`) {
-		t.Error("expected GitHub tab")
-	}
-	if !strings.Contains(got, `<Tab title="GitLab">`) {
-		t.Error("expected GitLab tab")
-	}
-	if !strings.Contains(got, "</Tabs>") {
-		t.Error("expected closing Tabs")
-	}
-}
-
-func TestMintlifyLiveCLIExample(t *testing.T) {
-	f := MintlifyFormatter{}
-	got := f.LiveCLIExample("kosli list environments", "kosli list environments --output=json", "http://example.com")
-	// Should NOT contain Hugo shortcode wrappers
-	if strings.Contains(got, "{{< raw-html >}}") {
-		t.Error("should not contain Hugo shortcode")
-	}
-	if !strings.Contains(got, "<pre>") {
-		t.Error("expected raw HTML pre tag")
-	}
-}
-
 func TestMintlifyExampleUseCases(t *testing.T) {
 	f := MintlifyFormatter{}
 	example := "# report a snyk attestation\nkosli attest snyk foo"


### PR DESCRIPTION
The docs repo now resolves and embeds live-docs links (yamlURLs, eventURLs, CLI examples) at deployment time via add_livedocs.py. The CLI no longer needs to call the live-docs API or generate those sections - it produces a static skeleton that the docs pipeline fills in.