### PR TITLE
docs: add make docs target for generating CLI reference docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ release_notes.md
 junit.xml
 junit-test-results/.
 .claude/settings.local.json
+client_reference/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build clean clean-cache deps fmt lint vet docker ldflags ensure_golangci-lint check_dirty add_test_tag build_release ensure_network ensure_gotestsum test_setup test_integration test_integration_full test_integration_single licenses upgrade-deps helm-lint helm-docs release suggest-version-ai
+.PHONY: help build clean clean-cache deps fmt lint vet docker ldflags ensure_golangci-lint check_dirty add_test_tag build_release ensure_network ensure_gotestsum test_setup test_integration test_integration_full test_integration_single licenses upgrade-deps helm-lint helm-docs docs release suggest-version-ai
 .DEFAULT: help
 .DEFAULT_GOAL := help
 .DELETE_ON_ERROR:
@@ -186,6 +186,11 @@ helm-lint: ## Lint Helm chart
 
 helm-docs: helm-lint ## Update Helm docs
 	@cd charts/k8s-reporter &&  docker run --rm --volume "$(PWD):/helm-docs" jnorwood/helm-docs:latest --template-files README.md.gotmpl,_templates.gotmpl --output-file README.md
+
+docs: build ## Generate CLI reference docs (use CMD="attest snyk" for one command)
+	@mkdir -p client_reference
+	@./kosli docs --dir client_reference $(CMD)
+	@echo "Docs written to client_reference/"
 
 # Suggest next semver and changelog using Claude.
 # Writes changelog to dist/release_notes.md for use with goreleaser --release-notes.

--- a/cmd/kosli/docs.go
+++ b/cmd/kosli/docs.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/kosli-dev/cli/internal/docgen"
@@ -12,6 +13,10 @@ const docsShortDesc = `Generate documentation files for Kosli CLI. `
 
 const docsLongDesc = docsShortDesc + `
 This command can generate documentation in the following formats: Markdown.
+
+When called with no arguments, docs are generated for all commands.
+When called with arguments, only the matching subcommand's docs are generated.
+For example: kosli docs attest snyk
 `
 
 type docsOptions struct {
@@ -28,9 +33,16 @@ func newDocsCmd(out io.Writer) *cobra.Command {
 		Short:  docsShortDesc,
 		Long:   docsLongDesc,
 		Hidden: true,
-		Args:   cobra.NoArgs,
+		Args:   cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			o.topCmd = cmd.Root()
+			if len(args) > 0 {
+				target, _, err := o.topCmd.Find(args)
+				if err != nil {
+					return fmt.Errorf("command %q not found: %w", args, err)
+				}
+				o.topCmd = target
+			}
 			return o.run()
 		},
 	}
@@ -64,4 +76,3 @@ func (o *docsOptions) run() error {
 	}
 	return doc.GenMarkdownTree(o.topCmd, o.dest)
 }
-

--- a/cmd/kosli/docs.go
+++ b/cmd/kosli/docs.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/kosli-dev/cli/internal/docgen"
 	"github.com/spf13/cobra"
@@ -37,9 +38,12 @@ func newDocsCmd(out io.Writer) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			o.topCmd = cmd.Root()
 			if len(args) > 0 {
-				target, _, err := o.topCmd.Find(args)
+				target, remainingArgs, err := o.topCmd.Find(args)
 				if err != nil {
-					return fmt.Errorf("command %q not found: %w", args, err)
+					return fmt.Errorf("command %q not found: %w", strings.Join(args, " "), err)
+				}
+				if len(remainingArgs) > 0 {
+					return fmt.Errorf("command %q not found", strings.Join(args, " "))
 				}
 				o.topCmd = target
 			}

--- a/cmd/kosli/docs_test.go
+++ b/cmd/kosli/docs_test.go
@@ -19,7 +19,11 @@ type DocsCommandTestSuite struct {
 func (suite *DocsCommandTestSuite) TestDocsArgsLookup() {
 	tempDirName, err := os.MkdirTemp("", "docsArgsLookup")
 	require.NoError(suite.T(), err)
-	defer os.RemoveAll(tempDirName)
+	defer func() {
+		if err := os.RemoveAll(tempDirName); err != nil {
+			require.NoError(suite.T(), err, "failed to remove temp dir %s", tempDirName)
+		}
+	}()
 
 	tests := []cmdTestCase{
 		{

--- a/cmd/kosli/docs_test.go
+++ b/cmd/kosli/docs_test.go
@@ -16,6 +16,31 @@ type DocsCommandTestSuite struct {
 	suite.Suite
 }
 
+func (suite *DocsCommandTestSuite) TestDocsArgsLookup() {
+	tempDirName, err := os.MkdirTemp("", "docsArgsLookup")
+	require.NoError(suite.T(), err)
+	defer os.RemoveAll(tempDirName)
+
+	tests := []cmdTestCase{
+		{
+			name:    "valid subcommand generates docs",
+			cmd:     "docs --dir " + tempDirName + " attest snyk",
+			golden:  "",
+		},
+		{
+			name:      "unknown command returns error",
+			cmd:       "docs --dir " + tempDirName + " nonexistent",
+			wantError: true,
+		},
+		{
+			name:      "partial match returns error",
+			cmd:       "docs --dir " + tempDirName + " attest nonexistent",
+			wantError: true,
+		},
+	}
+	runTestCmd(suite.T(), tests)
+}
+
 func (suite *DocsCommandTestSuite) TestDocsCmdSnyk() {
 	global = &GlobalOpts{}
 	tempDirName, err := os.MkdirTemp("", "generatedDocs")

--- a/dev-guide.md
+++ b/dev-guide.md
@@ -33,6 +33,14 @@ Windows will not allow building using the makefile, so we need to run the comman
 Then to run Kosli commands:  
 `./kosli.exe [COMMAND]` or `.\kosli.exe [COMMAND]`
 
+## Generating CLI reference docs
+
+To generate docs for all commands into `client_reference/`:
+`make docs`
+
+To generate docs for a specific command:
+`make docs CMD="attest snyk"`
+
 ## Running the tests
 
 To run the tests you need to set the env-var `KOSLI_API_TOKEN_PROD`


### PR DESCRIPTION
## Summary
- Add `make docs` target that generates CLI reference markdown into `client_reference/`
- Support generating docs for a single command via `CMD` variable (e.g. `make docs CMD="attest snyk"`)
- Update `kosli docs` to accept optional arguments for targeting a specific subcommand
- Add `client_reference/` to `.gitignore` and document the workflow in `dev-guide.md`

## Test plan
- [x] `make docs` generates all command docs into `client_reference/`
- [x] `make docs CMD="attest snyk"` generates only the targeted command doc
- [x] `make build && make lint` pass