### PR TITLE
fix: bump Go from 1.25.9 to 1.25.10 to resolve Snyk vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kosli-dev/cli
 
-go 1.25.9
+go 1.25.10
 
 require (
 	cloud.google.com/go/run v1.20.0


### PR DESCRIPTION
## Summary
- Bump Go version in `go.mod` from 1.25.9 to 1.25.10
- Fixes 6 CVEs in Go stdlib (`std/html/template`, `std/net`, `std/net/http`) that cause the Snyk Dependency Test CI job to fail

CVEs resolved: CVE-2026-27142, CVE-2026-33811, CVE-2026-33814, CVE-2026-39823, CVE-2026-39826, CVE-2026-39836

## Test plan
- [x] Snyk Dependency Test CI job passes
- [x] All other CI jobs pass (build, lint, tests)