### PR TITLE
feat: add quiet flag to logger

### DIFF
--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -95,7 +95,8 @@ The ^.kosli_ignore^ will be treated as part of the artifact like any other file,
 	dryRunFlag                      = "[optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors."
 	maxAPIRetryFlag                 = "[defaulted] How many times should API calls be retried when the API host is not reachable."
 	configFileFlag                  = "[optional] The Kosli config file path."
-	debugFlag                       = "[optional] Print debug logs to stdout. A boolean flag https://docs.kosli.com/faq/#boolean-flags (default false)"
+	debugFlag                       = "[optional] Print debug logs to stdout."
+	quietFlag                       = "[optional] Suppress non-critical warning messages. Errors and normal output are not affected. If both --quiet and --debug are set, --debug wins."
 	artifactTypeFlag                = "The type of the artifact to calculate its SHA256 fingerprint. One of: [oci, docker, file, dir]. Only required if you want Kosli to calculate the fingerprint for you (i.e. when you don't specify '--fingerprint' on commands that allow it)."
 	flowNameFlag                    = "The Kosli flow name."
 	flowNameFlagOptional            = "[optional] The Kosli flow name."
@@ -283,6 +284,7 @@ type GlobalOpts struct {
 	MaxAPIRetries int
 	ConfigFile    string
 	Debug         bool
+	Quiet         bool
 }
 
 // ConfigGetter defines an interface for getting the default config file path
@@ -368,6 +370,7 @@ func newRootCmd(out, errOut io.Writer, args []string) (*cobra.Command, error) {
 	cmd.PersistentFlags().IntVarP(&global.MaxAPIRetries, "max-api-retries", "r", defaultMaxAPIRetries, maxAPIRetryFlag)
 	cmd.PersistentFlags().StringVarP(&global.ConfigFile, "config-file", "c", getConfigFileFlagDefault(), configFileFlag)
 	cmd.PersistentFlags().BoolVar(&global.Debug, "debug", false, debugFlag)
+	cmd.PersistentFlags().BoolVarP(&global.Quiet, "quiet", "q", false, quietFlag)
 
 	// Add subcommands
 	cmd.AddCommand(
@@ -419,6 +422,7 @@ func initialize(cmd *cobra.Command, out, errOut io.Writer) error {
 	// assign debug value early here to enable debug logs during config file and env var binding
 	// if --debug is used. The value is re-assigned later after binding config file and env vars
 	logger.DebugEnabled = global.Debug
+	logger.QuietEnabled = global.Quiet && !global.Debug
 
 	// If provided, extract the custom config file dir and name
 
@@ -473,6 +477,10 @@ func initialize(cmd *cobra.Command, out, errOut io.Writer) error {
 	// re-assign debug after binding flags to config or env vars as it may have
 	// a different value now
 	logger.DebugEnabled = global.Debug
+	logger.QuietEnabled = global.Quiet && !global.Debug
+	if global.Quiet && global.Debug {
+		logger.Debug("--quiet is ignored because --debug is set")
+	}
 
 	var err error
 	kosliClient, err = requests.NewKosliClient(global.HttpProxy, global.MaxAPIRetries, global.Debug, logger)

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -29,6 +29,24 @@ func (suite *RootCommandTestSuite) TestConfigProcessing() {
 	runTestCmd(suite.T(), tests)
 }
 
+func (suite *RootCommandTestSuite) TestQuietFlagSuppressesWarnings() {
+	_, _, _, stderr, err := executeCommandC(
+		"version --config-file testdata/config/plain-text-token.yaml --quiet")
+	suite.NoError(err)
+	suite.NotContains(stderr, "[warning]",
+		"--quiet should suppress warning output, got: %q", stderr)
+}
+
+func (suite *RootCommandTestSuite) TestDebugWinsOverQuiet() {
+	_, _, _, stderr, err := executeCommandC(
+		"version --config-file testdata/config/plain-text-token.yaml --quiet --debug")
+	suite.NoError(err)
+	suite.Contains(stderr, "[warning]",
+		"--debug should override --quiet, expected warnings in stderr, got: %q", stderr)
+	suite.Contains(stderr, "[debug] --quiet is ignored because --debug is set",
+		"expected debug notice that --quiet was overridden, got: %q", stderr)
+}
+
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run
 func TestRootCommandTestSuite(t *testing.T) {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -9,6 +9,7 @@ import (
 
 type Logger struct {
 	DebugEnabled bool
+	QuietEnabled bool
 	Out          io.Writer
 	ErrOut       io.Writer
 	warnLog      *log.Logger
@@ -53,6 +54,9 @@ func (l *Logger) Debug(format string, v ...interface{}) {
 }
 
 func (l *Logger) Warn(format string, v ...interface{}) {
+	if l.QuietEnabled {
+		return
+	}
 	format = fmt.Sprintf("[warning] %s\n", format)
 	l.warnLog.Printf(format, v...)
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,9 +1,54 @@
 package logger_test
 
-import "testing"
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kosli-dev/cli/internal/logger"
+)
 
 func TestPlaceholder(t *testing.T) {
 	// We use the tool cover for coverage, but if there is no _test.go file, then
 	// Go use the tool covdata. At the same time, they removed covdata as a precompiled
 	// binary in the distribution. This made the coverage calculation fail for some of us.
+}
+
+func TestWarnSuppressedWhenQuietEnabled(t *testing.T) {
+	var out, errOut bytes.Buffer
+	l := logger.NewLogger(&out, &errOut, false)
+	l.QuietEnabled = true
+
+	l.Warn("something happened")
+
+	if errOut.Len() != 0 {
+		t.Fatalf("expected no stderr output when quiet, got %q", errOut.String())
+	}
+}
+
+func TestWarnEmittedWhenQuietDisabled(t *testing.T) {
+	var out, errOut bytes.Buffer
+	l := logger.NewLogger(&out, &errOut, false)
+
+	l.Warn("something happened")
+
+	if !strings.Contains(errOut.String(), "[warning] something happened") {
+		t.Fatalf("expected warning on stderr, got %q", errOut.String())
+	}
+}
+
+func TestQuietDoesNotSuppressInfoOrDebug(t *testing.T) {
+	var out, errOut bytes.Buffer
+	l := logger.NewLogger(&out, &errOut, true)
+	l.QuietEnabled = true
+
+	l.Info("hello")
+	l.Debug("debug-line")
+
+	if !strings.Contains(out.String(), "hello") {
+		t.Fatalf("expected info preserved, got %q", out.String())
+	}
+	if !strings.Contains(errOut.String(), "[debug] debug-line") {
+		t.Fatalf("expected debug preserved, got %q", errOut.String())
+	}
 }


### PR DESCRIPTION
Adds a global --quiet/-q boolean flag (KOSLI_QUIET) that suppresses non-critical [warning] messages emitted by logger.Warn while leaving errors, debug, and stdout output unaffected.

If both --quiet and --debug are supplied, --debug wins so the user keeps full diagnostic visibility.

Fixes: #864