### PR TITLE
Cloud run: recover missing digests via registry lookup server/#4986

### DIFF
--- a/cmd/kosli/docs_test.go
+++ b/cmd/kosli/docs_test.go
@@ -27,9 +27,9 @@ func (suite *DocsCommandTestSuite) TestDocsArgsLookup() {
 
 	tests := []cmdTestCase{
 		{
-			name:    "valid subcommand generates docs",
-			cmd:     "docs --dir " + tempDirName + " attest snyk",
-			golden:  "",
+			name:   "valid subcommand generates docs",
+			cmd:    "docs --dir " + tempDirName + " attest snyk",
+			golden: "",
 		},
 		{
 			name:      "unknown command returns error",

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -182,6 +182,7 @@ The ^.kosli_ignore^ will be treated as part of the artifact like any other file,
 	ecsServicesRegexFlag            = "[optional] The comma-separated list of ECS service name regex patterns to snapshot. Can't be used together with --exclude-services or --exclude-services-regex."
 	ecsExcludeServicesFlag          = "[optional] The comma-separated list of ECS service names to exclude. Can't be used together with --services or --services-regex."
 	ecsExcludeServicesRegexFlag     = "[optional] The comma-separated list of ECS service name regex patterns to exclude. Can't be used together with --services or --services-regex."
+	cloudRunResolveNamesFlag        = "[optional] When set, resolve digest-pinned artifact names back to their deploy-time tags (commit SHA / version) via an Artifact Registry reverse-lookup. Requires roles/artifactregistry.reader. Default: artifacts keep whatever name the Cloud Run API returned (digest-pinned for Services, deploy-time form for Jobs)."
 	cloudRunIncludeFlag             = "[optional] The comma-separated list of Cloud Run service or job names to snapshot. Can't be used together with --exclude or --exclude-regex."
 	cloudRunIncludeRegexFlag        = "[optional] The comma-separated list of Cloud Run service or job name regex patterns to snapshot. Can't be used together with --exclude or --exclude-regex."
 	cloudRunExcludeFlag             = "[optional] The comma-separated list of Cloud Run service or job names to exclude. Can't be used together with --include or --include-regex."

--- a/cmd/kosli/snapshotCloudRun.go
+++ b/cmd/kosli/snapshotCloudRun.go
@@ -65,13 +65,14 @@ type cloudRunLister interface {
 	ListJobs(ctx context.Context, project, region string) ([]cloudrun.Job, error)
 }
 
-var newCloudRunClient = func(ctx context.Context) (cloudRunLister, error) {
-	return cloudrun.New(ctx, logger)
+var newCloudRunClient = func(ctx context.Context, resolveNames bool) (cloudRunLister, error) {
+	return cloudrun.New(ctx, logger, resolveNames)
 }
 
 type snapshotCloudRunOptions struct {
 	project        string
 	region         string
+	resolveNames   bool
 	resourceFilter *filters.ResourceFilterOptions
 }
 
@@ -108,6 +109,7 @@ func newSnapshotCloudRunCmd(out io.Writer) *cobra.Command {
 
 	cmd.Flags().StringVar(&o.project, "project", "", "[required] GCP project ID.")
 	cmd.Flags().StringVar(&o.region, "region", "", "[required] GCP region (e.g. europe-west1).")
+	cmd.Flags().BoolVar(&o.resolveNames, "resolve-names", false, cloudRunResolveNamesFlag)
 	cmd.Flags().StringSliceVar(&o.resourceFilter.IncludeNames, "include", []string{}, cloudRunIncludeFlag)
 	cmd.Flags().StringSliceVar(&o.resourceFilter.IncludeNamesRegex, "include-regex", []string{}, cloudRunIncludeRegexFlag)
 	cmd.Flags().StringSliceVar(&o.resourceFilter.ExcludeNames, "exclude", []string{}, cloudRunExcludeFlag)
@@ -129,7 +131,7 @@ func (o *snapshotCloudRunOptions) run(args []string) error {
 	}
 
 	ctx := context.Background()
-	client, err := newCloudRunClient(ctx)
+	client, err := newCloudRunClient(ctx, o.resolveNames)
 	if err != nil {
 		return err
 	}

--- a/cmd/kosli/snapshotCloudRun.go
+++ b/cmd/kosli/snapshotCloudRun.go
@@ -22,13 +22,24 @@ Idle Jobs (no currently-running Execution) are included.
 GCP authentication uses Application Default Credentials. On a developer
 machine, run ^gcloud auth application-default login^; in GCE/GKE/Cloud Run
 the metadata server / Workload Identity is used automatically. The caller
-needs at least ^roles/run.viewer^ on the target project.
+needs ^roles/run.viewer^ on the target project, plus
+^roles/artifactregistry.reader^ on the Artifact Registry repository (or the
+project) for digest and tag resolution on tag-pinned images. Missing the AR
+role is non-fatal — tag-pinned artifacts then surface with empty digests.
+
+Digest and tag resolution is scoped to Artifact Registry (^*-docker.pkg.dev^)
+and the legacy Container Registry (^*.gcr.io^). Images from other registries
+(Docker Hub, Quay, ECR, etc.) are reported as-is.
 
 Skip all filtering flags to report every service and every job in the given
 project + region. Use ^--include^ and/or ^--include-regex^ to snapshot only a
 subset, OR ^--exclude^ and/or ^--exclude-regex^ to omit a subset; include and
 exclude are mutually exclusive. Filters apply uniformly to both service and
 job names and are case-sensitive.
+
+Pass ^--resolve-names^ to rewrite digest-pinned Service artifact names back
+to their deploy-time tags (commit SHA / version) via an Artifact Registry
+reverse-lookup. Only supported for Artifact Registry hosts.
 
 Currently a hidden, in-development command. Use --dry-run to inspect the payload without sending it to Kosli.`
 

--- a/cmd/kosli/snapshotCloudRun.go
+++ b/cmd/kosli/snapshotCloudRun.go
@@ -66,7 +66,7 @@ type cloudRunLister interface {
 }
 
 var newCloudRunClient = func(ctx context.Context) (cloudRunLister, error) {
-	return cloudrun.New(ctx)
+	return cloudrun.New(ctx, logger)
 }
 
 type snapshotCloudRunOptions struct {

--- a/cmd/kosli/snapshotCloudRun_test.go
+++ b/cmd/kosli/snapshotCloudRun_test.go
@@ -92,7 +92,7 @@ func (suite *SnapshotCloudRunTestSuite) SetupTest() {
 	}
 	suite.defaultKosliArguments = fmt.Sprintf(" --host %s --org %s --api-token %s", global.Host, global.Org, global.ApiToken)
 
-	newCloudRunClient = func(_ context.Context) (cloudRunLister, error) {
+	newCloudRunClient = func(_ context.Context, _ bool) (cloudRunLister, error) {
 		return stubCloudRunLister{services: stubServices()}, nil
 	}
 
@@ -215,7 +215,7 @@ func (suite *SnapshotCloudRunTestSuite) TestSnapshotCloudRunCmd_HappyPathReports
 // Jobs surface in the snapshot payload alongside services, with the flat
 // kind=job / jobName shape.
 func (suite *SnapshotCloudRunTestSuite) TestSnapshotCloudRunCmd_DryRunIncludesJobs() {
-	newCloudRunClient = func(_ context.Context) (cloudRunLister, error) {
+	newCloudRunClient = func(_ context.Context, _ bool) (cloudRunLister, error) {
 		return stubCloudRunLister{services: stubServices(), jobs: stubJobs()}, nil
 	}
 
@@ -232,7 +232,7 @@ func (suite *SnapshotCloudRunTestSuite) TestSnapshotCloudRunCmd_DryRunIncludesJo
 // TestSnapshotCloudRunCmd_HappyPathReportsServicesAndJobs is the live-server
 // counterpart to the dry-run test above: 2 services + 1 job → 3 artifacts.
 func (suite *SnapshotCloudRunTestSuite) TestSnapshotCloudRunCmd_HappyPathReportsServicesAndJobs() {
-	newCloudRunClient = func(_ context.Context) (cloudRunLister, error) {
+	newCloudRunClient = func(_ context.Context, _ bool) (cloudRunLister, error) {
 		return stubCloudRunLister{services: stubServices(), jobs: stubJobs()}, nil
 	}
 
@@ -246,7 +246,7 @@ func (suite *SnapshotCloudRunTestSuite) TestSnapshotCloudRunCmd_HappyPathReports
 // TestSnapshotCloudRunFilter_AppliesToJobs verifies that the same name filter
 // applies uniformly to job names — excluding by name removes the matching job.
 func (suite *SnapshotCloudRunTestSuite) TestSnapshotCloudRunFilter_AppliesToJobs() {
-	newCloudRunClient = func(_ context.Context) (cloudRunLister, error) {
+	newCloudRunClient = func(_ context.Context, _ bool) (cloudRunLister, error) {
 		return stubCloudRunLister{services: stubServices(), jobs: stubJobs()}, nil
 	}
 
@@ -259,7 +259,7 @@ func (suite *SnapshotCloudRunTestSuite) TestSnapshotCloudRunFilter_AppliesToJobs
 // gRPC Unauthenticated error from GCP surfaces as the actionable ADC message
 // rather than a raw SDK string.
 func (suite *SnapshotCloudRunTestSuite) TestSnapshotCloudRunCmd_UnauthenticatedReturnsFriendlyError() {
-	newCloudRunClient = func(_ context.Context) (cloudRunLister, error) {
+	newCloudRunClient = func(_ context.Context, _ bool) (cloudRunLister, error) {
 		return stubCloudRunLister{err: status.Error(codes.Unauthenticated, "token expired")}, nil
 	}
 

--- a/cmd/kosli/snapshotCloudRun_test.go
+++ b/cmd/kosli/snapshotCloudRun_test.go
@@ -255,6 +255,47 @@ func (suite *SnapshotCloudRunTestSuite) TestSnapshotCloudRunFilter_AppliesToJobs
 	require.NotContains(suite.T(), out, `"jobName": "sandman-job"`, "the named job must be filtered out")
 }
 
+// TestSnapshotCloudRunCmd_ResolveNamesFlag verifies that --resolve-names
+// reaches the client constructor. Two cases:
+//   - flag present → constructor called with true
+//   - flag absent  → constructor called with false (default unchanged)
+//
+// Without this test, a future refactor could silently break the flag
+// plumbing (e.g. by binding a different variable, or by forgetting to
+// forward the bool through newCloudRunClient).
+func (suite *SnapshotCloudRunTestSuite) TestSnapshotCloudRunCmd_ResolveNamesFlag() {
+	type capture struct {
+		called       bool
+		resolveNames bool
+	}
+	for _, tc := range []struct {
+		name string
+		args string
+		want bool
+	}{
+		{name: "flag present", args: "--resolve-names", want: true},
+		{name: "flag absent", args: "", want: false},
+	} {
+		suite.Run(tc.name, func() {
+			var got capture
+			newCloudRunClient = func(_ context.Context, resolveNames bool) (cloudRunLister, error) {
+				got.called = true
+				got.resolveNames = resolveNames
+				return stubCloudRunLister{services: stubServices()}, nil
+			}
+
+			cmd := fmt.Sprintf(`snapshot cloud-run %s --project p --region r --dry-run %s %s`,
+				suite.envName, tc.args, suite.defaultKosliArguments)
+			_, combined, _, _, err := executeCommandC(cmd)
+
+			require.NoError(suite.T(), err, "command failed: %s", combined)
+			require.True(suite.T(), got.called, "newCloudRunClient must be invoked")
+			require.Equal(suite.T(), tc.want, got.resolveNames,
+				"--resolve-names should reach the client constructor")
+		})
+	}
+}
+
 // TestSnapshotCloudRunCmd_UnauthenticatedReturnsFriendlyError verifies that a
 // gRPC Unauthenticated error from GCP surfaces as the actionable ADC message
 // rather than a raw SDK string.

--- a/internal/cloudrun/cloudrun.go
+++ b/internal/cloudrun/cloudrun.go
@@ -199,9 +199,10 @@ func (c *Client) ListJobs(ctx context.Context, project, region string) ([]Job, e
 // resolveTagPinnedDigests walks the digests map and, for each entry whose
 // value is empty (i.e., the image string was not digest-pinned), asks the
 // resolver to look up the digest in the hosting registry. On success the
-// tag-pinned key is replaced with a digest-pinned key (image@sha256:<hex>)
-// and the value carries the bare hex. Failures are logged at debug level
-// and leave the entry untouched — never fatal.
+// resolved hex is filled in as the value; the tag-pinned key is left in
+// place so the artifact keeps its recognizable deploy-time name (e.g.
+// "…/ghost-job:c85b06b0…" rather than "…/ghost-job@sha256:…"). Failures
+// are logged at debug level and leave the entry untouched — never fatal.
 //
 // No-op when the Client was constructed without a resolver (test paths,
 // or when ADC token-source construction failed).
@@ -213,13 +214,12 @@ func (c *Client) resolveTagPinnedDigests(digests map[string]string) {
 		if hex != "" {
 			continue
 		}
-		resolvedRef, resolvedHex, err := c.resolver.Resolve(image)
+		resolvedHex, err := c.resolver.Resolve(image)
 		if err != nil {
 			c.log.Debug("registry digest resolution failed for %q: %v", image, err)
 			continue
 		}
-		delete(digests, image)
-		digests[resolvedRef] = resolvedHex
+		digests[image] = resolvedHex
 	}
 }
 

--- a/internal/cloudrun/cloudrun.go
+++ b/internal/cloudrun/cloudrun.go
@@ -13,6 +13,7 @@ import (
 
 	run "cloud.google.com/go/run/apiv2"
 	"cloud.google.com/go/run/apiv2/runpb"
+	"github.com/kosli-dev/cli/internal/logger"
 	"google.golang.org/api/iterator"
 )
 
@@ -53,9 +54,16 @@ type apiClient interface {
 	listJobs(ctx context.Context, project, region string) ([]*runpb.Job, error)
 }
 
-// Client fetches Cloud Run data from GCP.
+// Client fetches Cloud Run data from GCP. The optional resolver, when set,
+// is consulted for any tag-pinned image whose digest cannot be parsed from
+// the image string alone — it queries the OCI Distribution endpoint of the
+// hosting registry to look up the current sha256. Resolver failures are
+// non-fatal: the original tag-pinned reference stays in place with an empty
+// digest, mirroring today's tag-pinned ECS / Service container fallback.
 type Client struct {
-	api apiClient
+	api      apiClient
+	resolver digestResolver
+	log      *logger.Logger
 }
 
 // New returns a Client backed by the real Cloud Run Admin API v2 using
@@ -63,7 +71,12 @@ type Client struct {
 // cluster cron job, since the metadata server provides credentials) are
 // wrapped with a generic "GCP client setup failed" prefix; the SDK's own
 // message is preserved via %w for diagnosis. Callers should defer Close().
-func New(ctx context.Context) (*Client, error) {
+//
+// The returned Client is wired with a registry-lookup resolver for tag-
+// pinned images using the same ADC token source. If the resolver cannot be
+// constructed (rare), it is left nil and the Client behaves as before:
+// tag-pinned images report empty digests.
+func New(ctx context.Context, log *logger.Logger) (*Client, error) {
 	services, err := run.NewServicesClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("GCP client setup failed: %w", err)
@@ -79,7 +92,16 @@ func New(ctx context.Context) (*Client, error) {
 		_ = revisions.Close()
 		return nil, fmt.Errorf("GCP client setup failed: %w", err)
 	}
-	return &Client{api: &gcpAPI{services: services, revisions: revisions, jobs: jobs}}, nil
+	resolver, err := newGCPRegistryResolver(ctx, log)
+	if err != nil {
+		log.Debug("registry digest resolution disabled: %v", err)
+		resolver = nil
+	}
+	return &Client{
+		api:      &gcpAPI{services: services, revisions: revisions, jobs: jobs},
+		resolver: resolver,
+		log:      log,
+	}, nil
 }
 
 // Close releases the underlying gRPC connections. Safe to call on a Client
@@ -125,7 +147,9 @@ func (c *Client) toService(ctx context.Context, raw *runpb.Service) (Service, er
 		if err != nil {
 			return Service{}, fmt.Errorf("getting revision %s: %w", fullName, err)
 		}
-		svc.Revisions = append(svc.Revisions, toRevision(rev))
+		revision := toRevision(rev)
+		c.resolveTagPinnedDigests(revision.Digests)
+		svc.Revisions = append(svc.Revisions, revision)
 	}
 	return svc, nil
 }
@@ -165,9 +189,38 @@ func (c *Client) ListJobs(ctx context.Context, project, region string) ([]Job, e
 	}
 	out := make([]Job, 0, len(rawJobs))
 	for _, raw := range rawJobs {
-		out = append(out, toJob(raw))
+		job := toJob(raw)
+		c.resolveTagPinnedDigests(job.Digests)
+		out = append(out, job)
 	}
 	return out, nil
+}
+
+// resolveTagPinnedDigests walks the digests map and, for each entry whose
+// value is empty (i.e., the image string was not digest-pinned), asks the
+// resolver to look up the digest in the hosting registry. On success the
+// tag-pinned key is replaced with a digest-pinned key (image@sha256:<hex>)
+// and the value carries the bare hex. Failures are logged at debug level
+// and leave the entry untouched — never fatal.
+//
+// No-op when the Client was constructed without a resolver (test paths,
+// or when ADC token-source construction failed).
+func (c *Client) resolveTagPinnedDigests(digests map[string]string) {
+	if c.resolver == nil {
+		return
+	}
+	for image, hex := range digests {
+		if hex != "" {
+			continue
+		}
+		resolvedRef, resolvedHex, err := c.resolver.Resolve(image)
+		if err != nil {
+			c.log.Debug("registry digest resolution failed for %q: %v", image, err)
+			continue
+		}
+		delete(digests, image)
+		digests[resolvedRef] = resolvedHex
+	}
 }
 
 func toJob(j *runpb.Job) Job {

--- a/internal/cloudrun/cloudrun.go
+++ b/internal/cloudrun/cloudrun.go
@@ -14,6 +14,7 @@ import (
 	run "cloud.google.com/go/run/apiv2"
 	"cloud.google.com/go/run/apiv2/runpb"
 	"github.com/kosli-dev/cli/internal/logger"
+	"github.com/kosli-dev/cli/internal/requests"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/iterator"
 )
@@ -104,13 +105,23 @@ func New(ctx context.Context, log *logger.Logger, resolveNames bool) (*Client, e
 
 	var digestRes digestResolver
 	var tagRes tagResolver
-	if src, terr := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform"); terr == nil {
-		digestRes = &gcpRegistryResolver{tokens: src, log: log}
-		if resolveNames {
-			tagRes = &gcpArtifactRegistryTagResolver{tokens: src, log: log}
-		}
-	} else {
+	src, terr := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	switch {
+	case terr != nil:
 		log.Debug("ADC token source unavailable; registry resolution disabled: %v", terr)
+	default:
+		// One HTTP client shared by both resolvers so that hundreds of
+		// per-artifact registry calls reuse a single connection pool
+		// (TCP + TLS handshakes amortise across the snapshot).
+		kosliClient, cerr := requests.NewKosliClient("", 1, log.DebugEnabled, log)
+		if cerr != nil {
+			log.Debug("registry HTTP client unavailable; registry resolution disabled: %v", cerr)
+			break
+		}
+		digestRes = &gcpRegistryResolver{tokens: src, client: kosliClient, log: log}
+		if resolveNames {
+			tagRes = &gcpArtifactRegistryTagResolver{tokens: src, client: kosliClient, log: log}
+		}
 	}
 
 	return &Client{

--- a/internal/cloudrun/cloudrun.go
+++ b/internal/cloudrun/cloudrun.go
@@ -14,6 +14,7 @@ import (
 	run "cloud.google.com/go/run/apiv2"
 	"cloud.google.com/go/run/apiv2/runpb"
 	"github.com/kosli-dev/cli/internal/logger"
+	"golang.org/x/oauth2/google"
 	"google.golang.org/api/iterator"
 )
 
@@ -57,13 +58,17 @@ type apiClient interface {
 // Client fetches Cloud Run data from GCP. The optional resolver, when set,
 // is consulted for any tag-pinned image whose digest cannot be parsed from
 // the image string alone — it queries the OCI Distribution endpoint of the
-// hosting registry to look up the current sha256. Resolver failures are
-// non-fatal: the original tag-pinned reference stays in place with an empty
-// digest, mirroring today's tag-pinned ECS / Service container fallback.
+// hosting registry to look up the current sha256. The optional tagResolver,
+// when set (via the --resolve-names flag at construction time), is consulted
+// for any digest-pinned image to recover a tag pointing at the same digest,
+// so the artifact's display name surfaces the deploy-time tag (commit SHA
+// or version) instead of the opaque sha256. Both resolvers fail open: the
+// original key/value stays in place if the lookup fails.
 type Client struct {
-	api      apiClient
-	resolver digestResolver
-	log      *logger.Logger
+	api         apiClient
+	resolver    digestResolver
+	tagResolver tagResolver
+	log         *logger.Logger
 }
 
 // New returns a Client backed by the real Cloud Run Admin API v2 using
@@ -73,10 +78,14 @@ type Client struct {
 // message is preserved via %w for diagnosis. Callers should defer Close().
 //
 // The returned Client is wired with a registry-lookup resolver for tag-
-// pinned images using the same ADC token source. If the resolver cannot be
-// constructed (rare), it is left nil and the Client behaves as before:
-// tag-pinned images report empty digests.
-func New(ctx context.Context, log *logger.Logger) (*Client, error) {
+// pinned images using ADC. When resolveNames is true, it is also wired with
+// a reverse tag resolver against Artifact Registry, so digest-pinned
+// artifact names (e.g. for Service revisions) are rewritten to their
+// tag-pinned equivalents (commit SHA, version) for display. If ADC is
+// unavailable both resolvers are left nil and the Client falls back to the
+// pre-resolution behaviour: tag-pinned images report empty digests and
+// digest-pinned names stay digest-pinned.
+func New(ctx context.Context, log *logger.Logger, resolveNames bool) (*Client, error) {
 	services, err := run.NewServicesClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("GCP client setup failed: %w", err)
@@ -92,15 +101,23 @@ func New(ctx context.Context, log *logger.Logger) (*Client, error) {
 		_ = revisions.Close()
 		return nil, fmt.Errorf("GCP client setup failed: %w", err)
 	}
-	resolver, err := newGCPRegistryResolver(ctx, log)
-	if err != nil {
-		log.Debug("registry digest resolution disabled: %v", err)
-		resolver = nil
+
+	var digestRes digestResolver
+	var tagRes tagResolver
+	if src, terr := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform"); terr == nil {
+		digestRes = &gcpRegistryResolver{tokens: src, log: log}
+		if resolveNames {
+			tagRes = &gcpArtifactRegistryTagResolver{tokens: src, log: log}
+		}
+	} else {
+		log.Debug("ADC token source unavailable; registry resolution disabled: %v", terr)
 	}
+
 	return &Client{
-		api:      &gcpAPI{services: services, revisions: revisions, jobs: jobs},
-		resolver: resolver,
-		log:      log,
+		api:         &gcpAPI{services: services, revisions: revisions, jobs: jobs},
+		resolver:    digestRes,
+		tagResolver: tagRes,
+		log:         log,
 	}, nil
 }
 
@@ -149,6 +166,7 @@ func (c *Client) toService(ctx context.Context, raw *runpb.Service) (Service, er
 		}
 		revision := toRevision(rev)
 		c.resolveTagPinnedDigests(revision.Digests)
+		c.resolveNamesForDigestPinned(revision.Digests)
 		svc.Revisions = append(svc.Revisions, revision)
 	}
 	return svc, nil
@@ -191,6 +209,7 @@ func (c *Client) ListJobs(ctx context.Context, project, region string) ([]Job, e
 	for _, raw := range rawJobs {
 		job := toJob(raw)
 		c.resolveTagPinnedDigests(job.Digests)
+		c.resolveNamesForDigestPinned(job.Digests)
 		out = append(out, job)
 	}
 	return out, nil
@@ -220,6 +239,35 @@ func (c *Client) resolveTagPinnedDigests(digests map[string]string) {
 			continue
 		}
 		digests[image] = resolvedHex
+	}
+}
+
+// resolveNamesForDigestPinned walks the digests map and, for each entry
+// whose image string is digest-pinned (contains "@sha256:"), asks the tag
+// resolver for a tag pointing at the digest. On success the digest-pinned
+// key is replaced with a tag-pinned key ("image:<tag>"); the hex value
+// (the digest) is preserved. Failures are logged at debug level and leave
+// the entry untouched — never fatal.
+//
+// No-op when the Client was constructed with resolveNames=false (the
+// tagResolver is nil), or when ADC token-source construction failed.
+func (c *Client) resolveNamesForDigestPinned(digests map[string]string) {
+	if c.tagResolver == nil {
+		return
+	}
+	for image, hex := range digests {
+		idx := strings.Index(image, sha256Marker)
+		if idx < 0 {
+			continue // not digest-pinned
+		}
+		tag, err := c.tagResolver.LatestTag(image)
+		if err != nil {
+			c.log.Debug("tag resolution failed for %q: %v", image, err)
+			continue
+		}
+		tagPinned := image[:idx] + ":" + tag
+		delete(digests, image)
+		digests[tagPinned] = hex
 	}
 }
 

--- a/internal/cloudrun/registry.go
+++ b/internal/cloudrun/registry.go
@@ -37,8 +37,13 @@ var errNonGCPRegistry = errors.New("not a GCP registry host — skipping resolut
 // gcpRegistryResolver implements digestResolver for Artifact Registry
 // (*-docker.pkg.dev) and the legacy Container Registry (gcr.io family),
 // using a GCP OAuth access token from Application Default Credentials.
+// The HTTP client is built once in cloudrun.New() and shared across all
+// Resolve calls in a single snapshot — keeping the connection pool warm
+// so TCP/TLS handshakes amortize across the (potentially hundreds of)
+// artifacts in a report.
 type gcpRegistryResolver struct {
 	tokens oauth2.TokenSource
+	client *requests.Client
 	log    *logger.Logger
 }
 
@@ -54,7 +59,7 @@ func (r *gcpRegistryResolver) Resolve(image string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("getting GCP access token: %w", err)
 	}
-	hex, err := digest.RemoteDockerImageSha256(path, tag, "https://"+host+"/v2", tok.AccessToken, r.log)
+	hex, err := digest.RemoteDockerImageSha256(r.client, path, tag, "https://"+host+"/v2", tok.AccessToken)
 	if err != nil {
 		return "", err
 	}
@@ -127,9 +132,12 @@ type tagResolver interface {
 // gcpArtifactRegistryTagResolver implements tagResolver against
 // Artifact Registry (*-docker.pkg.dev). The legacy Container Registry
 // hosts (gcr.io family) do not expose an equivalent reverse-lookup
-// API, so they are rejected with errNonGCPRegistry.
+// API, so they are rejected with errNonGCPRegistry. The HTTP client
+// is shared with the forward (gcpRegistryResolver) path so a single
+// connection pool serves every per-artifact API call in the snapshot.
 type gcpArtifactRegistryTagResolver struct {
 	tokens oauth2.TokenSource
+	client *requests.Client
 	log    *logger.Logger
 }
 
@@ -152,11 +160,7 @@ func (r *gcpArtifactRegistryTagResolver) LatestTag(image string) (string, error)
 		parts.project, parts.location, parts.repo, parts.image, parts.digest,
 	)
 
-	client, err := requests.NewKosliClient("", 1, r.log.DebugEnabled, r.log)
-	if err != nil {
-		return "", fmt.Errorf("creating registry client: %w", err)
-	}
-	res, err := client.Do(&requests.RequestParams{
+	res, err := r.client.Do(&requests.RequestParams{
 		Method: http.MethodGet,
 		URL:    u,
 		Token:  tok.AccessToken,

--- a/internal/cloudrun/registry.go
+++ b/internal/cloudrun/registry.go
@@ -1,0 +1,115 @@
+package cloudrun
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/kosli-dev/cli/internal/digest"
+	"github.com/kosli-dev/cli/internal/logger"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+// digestResolver resolves a tag-pinned image reference (e.g.
+// "europe-west1-docker.pkg.dev/proj/repo/img:v1") to its sha256 digest by
+// querying the OCI Distribution endpoint of the hosting registry. Errors
+// are non-fatal at the call site: a failed resolution leaves the original
+// tag-pinned reference in place with an empty digest, mirroring the
+// existing fallback for tag-pinned ECS / Service container images.
+type digestResolver interface {
+	// Resolve returns (resolvedRef, hexDigest, err). On success
+	// resolvedRef is the same image with ":tag" replaced by "@sha256:<hex>".
+	Resolve(image string) (resolvedRef, hexDigest string, err error)
+}
+
+// errNonGCPRegistry is returned by gcpRegistryResolver when the image's
+// host is not a known GCP registry. We don't attempt to authenticate
+// against unknown hosts because the GCP OAuth token only works against
+// Artifact Registry and Container Registry.
+var errNonGCPRegistry = errors.New("not a GCP registry host — skipping resolution")
+
+// gcpRegistryResolver implements digestResolver for Artifact Registry
+// (*-docker.pkg.dev) and the legacy Container Registry (gcr.io family),
+// using a GCP OAuth access token from Application Default Credentials.
+type gcpRegistryResolver struct {
+	tokens oauth2.TokenSource
+	log    *logger.Logger
+}
+
+func newGCPRegistryResolver(ctx context.Context, log *logger.Logger) (digestResolver, error) {
+	src, err := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		return nil, fmt.Errorf("getting GCP token source: %w", err)
+	}
+	return &gcpRegistryResolver{tokens: src, log: log}, nil
+}
+
+func (r *gcpRegistryResolver) Resolve(image string) (string, string, error) {
+	host, path, tag, err := splitTagPinnedImage(image)
+	if err != nil {
+		return "", "", err
+	}
+	if !isGCPRegistryHost(host) {
+		return "", "", errNonGCPRegistry
+	}
+	tok, err := r.tokens.Token()
+	if err != nil {
+		return "", "", fmt.Errorf("getting GCP access token: %w", err)
+	}
+	hex, err := digest.RemoteDockerImageSha256(path, tag, "https://"+host+"/v2", tok.AccessToken, r.log)
+	if err != nil {
+		return "", "", err
+	}
+	if hex == "" {
+		return "", "", fmt.Errorf("registry returned empty digest for %q", image)
+	}
+	return host + "/" + path + "@sha256:" + hex, hex, nil
+}
+
+// splitTagPinnedImage parses a tag-pinned image reference of the form
+//
+//	host/path/segments...:tag
+//
+// returning (host, path, tag). It rejects digest-pinned references
+// (containing "@sha256:") and references without a host segment.
+func splitTagPinnedImage(image string) (host, path, tag string, err error) {
+	if strings.Contains(image, sha256Marker) {
+		return "", "", "", fmt.Errorf("image %q is already digest-pinned", image)
+	}
+	// The tag is everything after the last ":", which must come after the
+	// last "/" (otherwise the colon is a port separator like in
+	// "localhost:5000/foo").
+	lastSlash := strings.LastIndex(image, "/")
+	lastColon := strings.LastIndex(image, ":")
+	if lastColon < 0 || lastColon < lastSlash {
+		return "", "", "", fmt.Errorf("image %q is not tag-pinned", image)
+	}
+	ref := image[:lastColon]
+	tag = image[lastColon+1:]
+	firstSlash := strings.Index(ref, "/")
+	if firstSlash < 0 {
+		return "", "", "", fmt.Errorf("image %q has no host segment", image)
+	}
+	host = ref[:firstSlash]
+	path = ref[firstSlash+1:]
+	if tag == "" {
+		return "", "", "", fmt.Errorf("image %q has empty tag", image)
+	}
+	return host, path, tag, nil
+}
+
+// isGCPRegistryHost reports whether the host is a known GCP-hosted
+// registry that accepts a cloud-platform OAuth bearer token. Both
+// Artifact Registry (*-docker.pkg.dev) and the legacy Container
+// Registry (gcr.io family) are accepted.
+func isGCPRegistryHost(host string) bool {
+	if host == "docker.pkg.dev" || strings.HasSuffix(host, "-docker.pkg.dev") {
+		return true
+	}
+	if host == "gcr.io" || strings.HasSuffix(host, ".gcr.io") {
+		return true
+	}
+	return false
+}

--- a/internal/cloudrun/registry.go
+++ b/internal/cloudrun/registry.go
@@ -1,15 +1,17 @@
 package cloudrun
 
 import (
-	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/kosli-dev/cli/internal/digest"
 	"github.com/kosli-dev/cli/internal/logger"
+	"github.com/kosli-dev/cli/internal/requests"
 	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
 )
 
 // digestResolver resolves a tag-pinned image reference (e.g.
@@ -38,14 +40,6 @@ var errNonGCPRegistry = errors.New("not a GCP registry host — skipping resolut
 type gcpRegistryResolver struct {
 	tokens oauth2.TokenSource
 	log    *logger.Logger
-}
-
-func newGCPRegistryResolver(ctx context.Context, log *logger.Logger) (digestResolver, error) {
-	src, err := google.DefaultTokenSource(ctx, "https://www.googleapis.com/auth/cloud-platform")
-	if err != nil {
-		return nil, fmt.Errorf("getting GCP token source: %w", err)
-	}
-	return &gcpRegistryResolver{tokens: src, log: log}, nil
 }
 
 func (r *gcpRegistryResolver) Resolve(image string) (string, error) {
@@ -114,4 +108,133 @@ func isGCPRegistryHost(host string) bool {
 		return true
 	}
 	return false
+}
+
+// tagResolver resolves a digest-pinned image reference (e.g.
+// "europe-west1-docker.pkg.dev/proj/repo/img@sha256:<hex>") to a tag
+// pointing at that digest, by querying Artifact Registry's
+// dockerImages.list endpoint. Used by `kosli snapshot cloud-run
+// --resolve-names` to convert the artifact's display name from the
+// opaque digest to a human-readable tag (typically a commit SHA).
+type tagResolver interface {
+	// LatestTag returns one tag pointing at the digest. When the digest
+	// has multiple tags, the longest one wins (commit SHAs beat moving
+	// tags like ":released"), with lex order as tiebreak. Returns an
+	// error if no tags exist for the digest or the API call fails.
+	LatestTag(digestPinnedImage string) (tag string, err error)
+}
+
+// gcpArtifactRegistryTagResolver implements tagResolver against
+// Artifact Registry (*-docker.pkg.dev). The legacy Container Registry
+// hosts (gcr.io family) do not expose an equivalent reverse-lookup
+// API, so they are rejected with errNonGCPRegistry.
+type gcpArtifactRegistryTagResolver struct {
+	tokens oauth2.TokenSource
+	log    *logger.Logger
+}
+
+func (r *gcpArtifactRegistryTagResolver) LatestTag(image string) (string, error) {
+	parts, err := splitDigestPinnedAR(image)
+	if err != nil {
+		return "", err
+	}
+	tok, err := r.tokens.Token()
+	if err != nil {
+		return "", fmt.Errorf("getting GCP access token: %w", err)
+	}
+
+	// dockerImages.get returns a single DockerImage by exact resource name.
+	// The resource name is "<image>@sha256:<hex>" within the repo; "@" and
+	// ":" are allowed in URL path segments per RFC 3986 and Google's
+	// gateway accepts them unescaped.
+	u := fmt.Sprintf(
+		"https://artifactregistry.googleapis.com/v1/projects/%s/locations/%s/repositories/%s/dockerImages/%s@%s",
+		parts.project, parts.location, parts.repo, parts.image, parts.digest,
+	)
+
+	client, err := requests.NewKosliClient("", 1, r.log.DebugEnabled, r.log)
+	if err != nil {
+		return "", fmt.Errorf("creating registry client: %w", err)
+	}
+	res, err := client.Do(&requests.RequestParams{
+		Method: http.MethodGet,
+		URL:    u,
+		Token:  tok.AccessToken,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var resp struct {
+		Tags []string `json:"tags"`
+	}
+	if err := json.Unmarshal([]byte(res.Body), &resp); err != nil {
+		return "", fmt.Errorf("parsing AR get response: %w", err)
+	}
+	return pickLatestTag(resp.Tags)
+}
+
+// pickLatestTag selects a tag from those pointing at a single digest.
+// AR exposes no per-tag timestamp, so "latest" can't be time-based.
+// Rule: longest tag wins (commit SHAs are 40 hex chars; moving aliases
+// like ":released", ":latest", ":dev" are shorter). Lex order breaks
+// ties for deterministic output.
+func pickLatestTag(tags []string) (string, error) {
+	if len(tags) == 0 {
+		return "", errors.New("digest has no tags")
+	}
+	if len(tags) == 1 {
+		return tags[0], nil
+	}
+	sorted := append([]string(nil), tags...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if len(sorted[i]) != len(sorted[j]) {
+			return len(sorted[i]) > len(sorted[j])
+		}
+		return sorted[i] < sorted[j]
+	})
+	return sorted[0], nil
+}
+
+// digestPinnedRefParts holds the AR-resource-name components extracted
+// from a digest-pinned image reference, ready to interpolate into the
+// dockerImages.get resource URL.
+type digestPinnedRefParts struct {
+	project  string
+	location string
+	repo     string
+	image    string
+	digest   string // "sha256:<hex>"
+}
+
+// splitDigestPinnedAR parses a digest-pinned Artifact Registry image
+// reference into its constituent parts. Rejects non-AR hosts (including
+// gcr.io, since the legacy GCR API does not expose tag reverse-lookup),
+// non-digest-pinned references, and references with too few path
+// segments.
+func splitDigestPinnedAR(image string) (digestPinnedRefParts, error) {
+	idx := strings.Index(image, sha256Marker)
+	if idx < 0 {
+		return digestPinnedRefParts{}, fmt.Errorf("image %q is not digest-pinned", image)
+	}
+	ref := image[:idx]
+	digestPart := image[idx+1:] // strip "@" → "sha256:<hex>"
+
+	parts := strings.SplitN(ref, "/", 4)
+	if len(parts) < 4 {
+		return digestPinnedRefParts{}, fmt.Errorf("image %q has too few path segments for AR", image)
+	}
+	host, project, repo, imagePath := parts[0], parts[1], parts[2], parts[3]
+
+	location := strings.TrimSuffix(host, "-docker.pkg.dev")
+	if location == host {
+		return digestPinnedRefParts{}, fmt.Errorf("host %q is not Artifact Registry (tag resolution unsupported)", host)
+	}
+	return digestPinnedRefParts{
+		project:  project,
+		location: location,
+		repo:     repo,
+		image:    imagePath,
+		digest:   digestPart,
+	}, nil
 }

--- a/internal/cloudrun/registry.go
+++ b/internal/cloudrun/registry.go
@@ -19,9 +19,11 @@ import (
 // tag-pinned reference in place with an empty digest, mirroring the
 // existing fallback for tag-pinned ECS / Service container images.
 type digestResolver interface {
-	// Resolve returns (resolvedRef, hexDigest, err). On success
-	// resolvedRef is the same image with ":tag" replaced by "@sha256:<hex>".
-	Resolve(image string) (resolvedRef, hexDigest string, err error)
+	// Resolve returns the bare hex digest for the given tag-pinned image
+	// reference, or an error. Callers keep the original image string as
+	// the artifact's identifier and only use the returned hex as the
+	// digest value.
+	Resolve(image string) (hexDigest string, err error)
 }
 
 // errNonGCPRegistry is returned by gcpRegistryResolver when the image's
@@ -46,26 +48,26 @@ func newGCPRegistryResolver(ctx context.Context, log *logger.Logger) (digestReso
 	return &gcpRegistryResolver{tokens: src, log: log}, nil
 }
 
-func (r *gcpRegistryResolver) Resolve(image string) (string, string, error) {
+func (r *gcpRegistryResolver) Resolve(image string) (string, error) {
 	host, path, tag, err := splitTagPinnedImage(image)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 	if !isGCPRegistryHost(host) {
-		return "", "", errNonGCPRegistry
+		return "", errNonGCPRegistry
 	}
 	tok, err := r.tokens.Token()
 	if err != nil {
-		return "", "", fmt.Errorf("getting GCP access token: %w", err)
+		return "", fmt.Errorf("getting GCP access token: %w", err)
 	}
 	hex, err := digest.RemoteDockerImageSha256(path, tag, "https://"+host+"/v2", tok.AccessToken, r.log)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 	if hex == "" {
-		return "", "", fmt.Errorf("registry returned empty digest for %q", image)
+		return "", fmt.Errorf("registry returned empty digest for %q", image)
 	}
-	return host + "/" + path + "@sha256:" + hex, hex, nil
+	return hex, nil
 }
 
 // splitTagPinnedImage parses a tag-pinned image reference of the form

--- a/internal/cloudrun/registry_test.go
+++ b/internal/cloudrun/registry_test.go
@@ -1,0 +1,190 @@
+package cloudrun
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/kosli-dev/cli/internal/logger"
+	"github.com/stretchr/testify/require"
+)
+
+// newDiscardLogger returns a logger that drops all output. Used by tests
+// that exercise the resolver's debug-level failure path without polluting
+// the test output stream.
+func newDiscardLogger(_ *testing.T) *logger.Logger {
+	return logger.NewLogger(io.Discard, io.Discard, false)
+}
+
+func TestSplitTagPinnedImage_ArtifactRegistry(t *testing.T) {
+	host, path, tag, err := splitTagPinnedImage(
+		"europe-west1-docker.pkg.dev/proj/repo/img:c85b06b09190b24f8d14aae380ca0d79ab008fc5",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "europe-west1-docker.pkg.dev", host)
+	require.Equal(t, "proj/repo/img", path)
+	require.Equal(t, "c85b06b09190b24f8d14aae380ca0d79ab008fc5", tag)
+}
+
+func TestSplitTagPinnedImage_GCR(t *testing.T) {
+	host, path, tag, err := splitTagPinnedImage("gcr.io/proj/img:v1")
+	require.NoError(t, err)
+	require.Equal(t, "gcr.io", host)
+	require.Equal(t, "proj/img", path)
+	require.Equal(t, "v1", tag)
+}
+
+func TestSplitTagPinnedImage_DigestPinnedRejected(t *testing.T) {
+	_, _, _, err := splitTagPinnedImage("gcr.io/proj/img@sha256:abc123")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "already digest-pinned")
+}
+
+func TestSplitTagPinnedImage_NoTagRejected(t *testing.T) {
+	_, _, _, err := splitTagPinnedImage("gcr.io/proj/img")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not tag-pinned")
+}
+
+func TestSplitTagPinnedImage_PortInHostNotMistakenForTag(t *testing.T) {
+	// localhost:5000/foo has a colon that is a port separator, not a tag
+	// separator. The function should refuse rather than treat "5000/foo"
+	// as a tag.
+	_, _, _, err := splitTagPinnedImage("localhost:5000/foo")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not tag-pinned")
+}
+
+func TestSplitTagPinnedImage_PortAndTagBothPresent(t *testing.T) {
+	host, path, tag, err := splitTagPinnedImage("localhost:5000/foo:v1")
+	require.NoError(t, err)
+	require.Equal(t, "localhost:5000", host)
+	require.Equal(t, "foo", path)
+	require.Equal(t, "v1", tag)
+}
+
+func TestSplitTagPinnedImage_EmptyTagRejected(t *testing.T) {
+	_, _, _, err := splitTagPinnedImage("gcr.io/proj/img:")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty tag")
+}
+
+func TestSplitTagPinnedImage_NoHostRejected(t *testing.T) {
+	_, _, _, err := splitTagPinnedImage("img:v1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no host segment")
+}
+
+func TestIsGCPRegistryHost(t *testing.T) {
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{"europe-west1-docker.pkg.dev", true},
+		{"us-central1-docker.pkg.dev", true},
+		{"docker.pkg.dev", true},
+		{"gcr.io", true},
+		{"eu.gcr.io", true},
+		{"us.gcr.io", true},
+		{"asia.gcr.io", true},
+		{"docker.io", false},
+		{"index.docker.io", false},
+		{"quay.io", false},
+		{"localhost:5000", false},
+		{"123456789.dkr.ecr.us-east-1.amazonaws.com", false},
+	}
+	for _, c := range cases {
+		t.Run(c.host, func(t *testing.T) {
+			require.Equal(t, c.want, isGCPRegistryHost(c.host))
+		})
+	}
+}
+
+// fakeResolver is a digestResolver test double. It looks up the resolved
+// digest hex by exact-match on the input image string.
+type fakeResolver struct {
+	digests map[string]string // image:tag -> resolvedHex
+	err     error
+}
+
+func (f *fakeResolver) Resolve(image string) (string, string, error) {
+	if f.err != nil {
+		return "", "", f.err
+	}
+	hex, ok := f.digests[image]
+	if !ok {
+		return "", "", errors.New("not found in fake")
+	}
+	host, path, _, err := splitTagPinnedImage(image)
+	if err != nil {
+		return "", "", err
+	}
+	return host + "/" + path + "@sha256:" + hex, hex, nil
+}
+
+func TestResolveTagPinnedDigests_ReplacesEmptyDigest(t *testing.T) {
+	tagPinned := "europe-west1-docker.pkg.dev/proj/repo/ghost-job:c85b06b0"
+	digests := map[string]string{tagPinned: ""}
+
+	c := &Client{resolver: &fakeResolver{
+		digests: map[string]string{tagPinned: "abc123"},
+	}}
+	c.resolveTagPinnedDigests(digests)
+
+	require.Len(t, digests, 1)
+	require.Contains(t, digests, "europe-west1-docker.pkg.dev/proj/repo/ghost-job@sha256:abc123")
+	require.Equal(t, "abc123", digests["europe-west1-docker.pkg.dev/proj/repo/ghost-job@sha256:abc123"])
+	require.NotContains(t, digests, tagPinned, "tag-pinned key must be removed once resolved")
+}
+
+func TestResolveTagPinnedDigests_LeavesAlreadyResolvedAlone(t *testing.T) {
+	digestPinned := "europe-west1-docker.pkg.dev/proj/repo/img@sha256:abc123"
+	digests := map[string]string{digestPinned: "abc123"}
+
+	c := &Client{resolver: &fakeResolver{}} // empty fake; would error on any call
+	c.resolveTagPinnedDigests(digests)
+
+	require.Equal(t, map[string]string{digestPinned: "abc123"}, digests)
+}
+
+func TestResolveTagPinnedDigests_FailureLeavesEntryInPlace(t *testing.T) {
+	tagPinned := "europe-west1-docker.pkg.dev/proj/repo/img:v1"
+	digests := map[string]string{tagPinned: ""}
+
+	c := &Client{
+		resolver: &fakeResolver{err: errors.New("registry unreachable")},
+		log:      newDiscardLogger(t),
+	}
+	c.resolveTagPinnedDigests(digests)
+
+	require.Equal(t, map[string]string{tagPinned: ""}, digests,
+		"failed resolution must leave the original tag-pinned entry untouched")
+}
+
+func TestResolveTagPinnedDigests_NilResolverIsNoOp(t *testing.T) {
+	tagPinned := "europe-west1-docker.pkg.dev/proj/repo/img:v1"
+	digests := map[string]string{tagPinned: ""}
+
+	c := &Client{} // no resolver
+	c.resolveTagPinnedDigests(digests)
+
+	require.Equal(t, map[string]string{tagPinned: ""}, digests)
+}
+
+func TestResolveTagPinnedDigests_MixedMap(t *testing.T) {
+	already := "europe-west1-docker.pkg.dev/proj/repo/main@sha256:already"
+	tagPinned := "europe-west1-docker.pkg.dev/proj/repo/sidecar:v1"
+	digests := map[string]string{
+		already:   "already",
+		tagPinned: "",
+	}
+
+	c := &Client{resolver: &fakeResolver{
+		digests: map[string]string{tagPinned: "newhex"},
+	}}
+	c.resolveTagPinnedDigests(digests)
+
+	require.Len(t, digests, 2)
+	require.Equal(t, "already", digests[already])
+	require.Equal(t, "newhex", digests["europe-west1-docker.pkg.dev/proj/repo/sidecar@sha256:newhex"])
+}

--- a/internal/cloudrun/registry_test.go
+++ b/internal/cloudrun/registry_test.go
@@ -165,6 +165,142 @@ func TestResolveTagPinnedDigests_NilResolverIsNoOp(t *testing.T) {
 	require.Equal(t, map[string]string{tagPinned: ""}, digests)
 }
 
+// --- splitDigestPinnedAR ---
+
+func TestSplitDigestPinnedAR_HappyPath(t *testing.T) {
+	parts, err := splitDigestPinnedAR(
+		"europe-west1-docker.pkg.dev/hello-world-cli-demo/containers/hello-world@sha256:0b2fd168ee792a7b0c9d6f48a21f83a2ed6a4eaff9ce6cf49abec4a9e12ad6d7",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "hello-world-cli-demo", parts.project)
+	require.Equal(t, "europe-west1", parts.location)
+	require.Equal(t, "containers", parts.repo)
+	require.Equal(t, "hello-world", parts.image)
+	require.Equal(t, "sha256:0b2fd168ee792a7b0c9d6f48a21f83a2ed6a4eaff9ce6cf49abec4a9e12ad6d7", parts.digest)
+}
+
+func TestSplitDigestPinnedAR_NestedImagePath(t *testing.T) {
+	parts, err := splitDigestPinnedAR(
+		"europe-west1-docker.pkg.dev/proj/repo/parent/child/img@sha256:abc",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "parent/child/img", parts.image)
+}
+
+func TestSplitDigestPinnedAR_TagPinnedRejected(t *testing.T) {
+	_, err := splitDigestPinnedAR("europe-west1-docker.pkg.dev/proj/repo/img:v1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not digest-pinned")
+}
+
+func TestSplitDigestPinnedAR_NonARHostRejected(t *testing.T) {
+	// 4 path segments so the parser passes the segment-count check and
+	// reaches the host check. Refs from GCR or other registries do not
+	// share AR's region-prefixed pkg.dev host pattern.
+	_, err := splitDigestPinnedAR("eu.gcr.io/proj/repo/img@sha256:abc")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not Artifact Registry")
+}
+
+func TestSplitDigestPinnedAR_TooFewSegmentsRejected(t *testing.T) {
+	_, err := splitDigestPinnedAR("europe-west1-docker.pkg.dev/proj@sha256:abc")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too few path segments")
+}
+
+// --- pickLatestTag ---
+
+func TestPickLatestTag_SingleTag(t *testing.T) {
+	got, err := pickLatestTag([]string{"d37cf45b250a17eb71ed885785d1fc3f05200e71"})
+	require.NoError(t, err)
+	require.Equal(t, "d37cf45b250a17eb71ed885785d1fc3f05200e71", got)
+}
+
+func TestPickLatestTag_LongestWins(t *testing.T) {
+	// commit-SHA + moving tag: the longer (commit SHA) wins, since it's
+	// more useful as an artifact identifier than ":released" or ":latest".
+	got, err := pickLatestTag([]string{"released", "d37cf45b250a17eb71ed885785d1fc3f05200e71"})
+	require.NoError(t, err)
+	require.Equal(t, "d37cf45b250a17eb71ed885785d1fc3f05200e71", got)
+}
+
+func TestPickLatestTag_LexBreaksTie(t *testing.T) {
+	// Two tags of equal length — fall back to lex order for determinism.
+	got, err := pickLatestTag([]string{"v1.0.0-beta", "v1.0.0-alpha"})
+	require.NoError(t, err)
+	require.Equal(t, "v1.0.0-alpha", got)
+}
+
+func TestPickLatestTag_EmptyErrors(t *testing.T) {
+	_, err := pickLatestTag(nil)
+	require.Error(t, err)
+}
+
+// --- resolveNamesForDigestPinned ---
+
+type fakeTagResolver struct {
+	tags map[string]string // digest-pinned image -> resolved tag
+	err  error
+}
+
+func (f *fakeTagResolver) LatestTag(image string) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	tag, ok := f.tags[image]
+	if !ok {
+		return "", errors.New("not found in fake")
+	}
+	return tag, nil
+}
+
+func TestResolveNamesForDigestPinned_RewritesDigestToTag(t *testing.T) {
+	digestPinned := "europe-west1-docker.pkg.dev/proj/repo/img@sha256:abc"
+	digests := map[string]string{digestPinned: "abc"}
+
+	c := &Client{tagResolver: &fakeTagResolver{
+		tags: map[string]string{digestPinned: "v1.0.0"},
+	}}
+	c.resolveNamesForDigestPinned(digests)
+
+	require.Equal(t, map[string]string{
+		"europe-west1-docker.pkg.dev/proj/repo/img:v1.0.0": "abc",
+	}, digests, "digest-pinned key must be replaced by tag-pinned key; hex value preserved")
+}
+
+func TestResolveNamesForDigestPinned_LeavesTagPinnedAlone(t *testing.T) {
+	tagPinned := "europe-west1-docker.pkg.dev/proj/repo/img:v1"
+	digests := map[string]string{tagPinned: "abc"}
+
+	c := &Client{tagResolver: &fakeTagResolver{}} // empty fake; would error on any call
+	c.resolveNamesForDigestPinned(digests)
+
+	require.Equal(t, map[string]string{tagPinned: "abc"}, digests)
+}
+
+func TestResolveNamesForDigestPinned_FailureLeavesEntryInPlace(t *testing.T) {
+	digestPinned := "europe-west1-docker.pkg.dev/proj/repo/img@sha256:abc"
+	digests := map[string]string{digestPinned: "abc"}
+
+	c := &Client{
+		tagResolver: &fakeTagResolver{err: errors.New("api down")},
+		log:         newDiscardLogger(t),
+	}
+	c.resolveNamesForDigestPinned(digests)
+
+	require.Equal(t, map[string]string{digestPinned: "abc"}, digests)
+}
+
+func TestResolveNamesForDigestPinned_NilResolverIsNoOp(t *testing.T) {
+	digestPinned := "europe-west1-docker.pkg.dev/proj/repo/img@sha256:abc"
+	digests := map[string]string{digestPinned: "abc"}
+
+	c := &Client{} // no tagResolver
+	c.resolveNamesForDigestPinned(digests)
+
+	require.Equal(t, map[string]string{digestPinned: "abc"}, digests)
+}
+
 func TestResolveTagPinnedDigests_MixedMap(t *testing.T) {
 	already := "europe-west1-docker.pkg.dev/proj/repo/main@sha256:already"
 	tagPinned := "europe-west1-docker.pkg.dev/proj/repo/sidecar:v1"

--- a/internal/cloudrun/registry_test.go
+++ b/internal/cloudrun/registry_test.go
@@ -107,22 +107,18 @@ type fakeResolver struct {
 	err     error
 }
 
-func (f *fakeResolver) Resolve(image string) (string, string, error) {
+func (f *fakeResolver) Resolve(image string) (string, error) {
 	if f.err != nil {
-		return "", "", f.err
+		return "", f.err
 	}
 	hex, ok := f.digests[image]
 	if !ok {
-		return "", "", errors.New("not found in fake")
+		return "", errors.New("not found in fake")
 	}
-	host, path, _, err := splitTagPinnedImage(image)
-	if err != nil {
-		return "", "", err
-	}
-	return host + "/" + path + "@sha256:" + hex, hex, nil
+	return hex, nil
 }
 
-func TestResolveTagPinnedDigests_ReplacesEmptyDigest(t *testing.T) {
+func TestResolveTagPinnedDigests_FillsEmptyDigestKeepingTagPinnedKey(t *testing.T) {
 	tagPinned := "europe-west1-docker.pkg.dev/proj/repo/ghost-job:c85b06b0"
 	digests := map[string]string{tagPinned: ""}
 
@@ -131,10 +127,8 @@ func TestResolveTagPinnedDigests_ReplacesEmptyDigest(t *testing.T) {
 	}}
 	c.resolveTagPinnedDigests(digests)
 
-	require.Len(t, digests, 1)
-	require.Contains(t, digests, "europe-west1-docker.pkg.dev/proj/repo/ghost-job@sha256:abc123")
-	require.Equal(t, "abc123", digests["europe-west1-docker.pkg.dev/proj/repo/ghost-job@sha256:abc123"])
-	require.NotContains(t, digests, tagPinned, "tag-pinned key must be removed once resolved")
+	require.Equal(t, map[string]string{tagPinned: "abc123"}, digests,
+		"tag-pinned key must be preserved; only the digest value is filled in")
 }
 
 func TestResolveTagPinnedDigests_LeavesAlreadyResolvedAlone(t *testing.T) {
@@ -184,7 +178,8 @@ func TestResolveTagPinnedDigests_MixedMap(t *testing.T) {
 	}}
 	c.resolveTagPinnedDigests(digests)
 
-	require.Len(t, digests, 2)
-	require.Equal(t, "already", digests[already])
-	require.Equal(t, "newhex", digests["europe-west1-docker.pkg.dev/proj/repo/sidecar@sha256:newhex"])
+	require.Equal(t, map[string]string{
+		already:   "already",
+		tagPinned: "newhex",
+	}, digests, "both keys must be preserved; only the tag-pinned value is filled in")
 }

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -295,9 +295,8 @@ func extractImageDigestFromRepoDigest(imageID string, repoDigests []string) (str
 }
 
 // requestManifestFromRegistry makes an API request to a remote registry to get image manifest
-func requestManifestFromRegistry(registryEndPoint, imageName, imageTag, registryToken string,
-	dockerHeaders map[string]string, logger *logger.Logger) (*requests.HTTPResponse, error) {
-	// res, err := requests.DoRequestWithToken([]byte{}, registryEndPoint+"/"+imageName+"/"+"manifests/"+imageTag, registryToken, 3, http.MethodGet, dockerHeaders)
+func requestManifestFromRegistry(client *requests.Client, registryEndPoint, imageName, imageTag, registryToken string,
+	dockerHeaders map[string]string) (*requests.HTTPResponse, error) {
 	url, err := url.JoinPath(registryEndPoint, imageName, "manifests", imageTag)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build registry URL: %v", err)
@@ -308,16 +307,11 @@ func requestManifestFromRegistry(registryEndPoint, imageName, imageTag, registry
 		Token:             registryToken,
 		AdditionalHeaders: dockerHeaders,
 	}
-	kosliClient, err := requests.NewKosliClient("", 1, logger.DebugEnabled, logger)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get docker digest from registry: %v", err)
-	}
-	res, err := kosliClient.Do(reqParams)
+	res, err := client.Do(reqParams)
 	if err != nil {
 		return res, fmt.Errorf("failed to get docker digest from registry: %v", err)
 	}
 	return res, nil
-
 }
 
 // RemoteDockerImageSha256 returns a sha256 digest of a docker image by reading
@@ -327,7 +321,11 @@ func requestManifestFromRegistry(registryEndPoint, imageName, imageTag, registry
 // index — and lets the registry pick the best match in one round trip. The
 // canonical sha256 is read from the response's Docker-Content-Digest header,
 // which reflects whatever manifest was actually returned.
-func RemoteDockerImageSha256(imageName, imageTag, registryEndPoint, registryToken string, logger *logger.Logger) (string, error) {
+//
+// Callers pass a reusable *requests.Client so a single connection pool can
+// be reused across many manifest lookups (e.g. when resolving digests for
+// every artifact in a Cloud Run snapshot).
+func RemoteDockerImageSha256(client *requests.Client, imageName, imageTag, registryEndPoint, registryToken string) (string, error) {
 	acceptHeader := strings.Join([]string{
 		"application/vnd.docker.distribution.manifest.list.v2+json",
 		"application/vnd.docker.distribution.manifest.v2+json",
@@ -335,8 +333,8 @@ func RemoteDockerImageSha256(imageName, imageTag, registryEndPoint, registryToke
 		"application/vnd.oci.image.manifest.v1+json",
 	}, ", ")
 
-	res, err := requestManifestFromRegistry(registryEndPoint, imageName, imageTag, registryToken,
-		map[string]string{"Accept": acceptHeader}, logger)
+	res, err := requestManifestFromRegistry(client, registryEndPoint, imageName, imageTag, registryToken,
+		map[string]string{"Accept": acceptHeader})
 	if err != nil {
 		return "", err
 	}

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -320,39 +320,29 @@ func requestManifestFromRegistry(registryEndPoint, imageName, imageTag, registry
 
 }
 
-// RemoteDockerImageSha256 returns a sha256 digest of a docker image by reading it from
-// remote docker registry
+// RemoteDockerImageSha256 returns a sha256 digest of a docker image by reading
+// it from a remote registry. The Accept header advertises every manifest
+// media type the OCI Distribution spec defines — Docker single-arch, Docker
+// multi-arch ("fat") manifest list, OCI single-arch, and OCI multi-arch
+// index — and lets the registry pick the best match in one round trip. The
+// canonical sha256 is read from the response's Docker-Content-Digest header,
+// which reflects whatever manifest was actually returned.
 func RemoteDockerImageSha256(imageName, imageTag, registryEndPoint, registryToken string, logger *logger.Logger) (string, error) {
-	// Some docker images have Manifest list, aka "fat manifest" which combines
-	// image manifests for one or more platforms. Other images don't have such manifest.
-	// The response Content-Type header specifies whether an image has it or not.
-	// More details here: https://docs.docker.com/registry/spec/manifest-v2-2/
-	v2ManifestType := "application/vnd.docker.distribution.manifest.v2+json"
-	v2FatManifestType := "application/vnd.docker.distribution.manifest.list.v2+json"
+	acceptHeader := strings.Join([]string{
+		"application/vnd.docker.distribution.manifest.list.v2+json",
+		"application/vnd.docker.distribution.manifest.v2+json",
+		"application/vnd.oci.image.index.v1+json",
+		"application/vnd.oci.image.manifest.v1+json",
+	}, ", ")
 
-	var res *requests.HTTPResponse
-	var err error
-
-	dockerHeaders := map[string]string{"Accept": v2FatManifestType}
-	res, err = requestManifestFromRegistry(registryEndPoint, imageName, imageTag, registryToken, dockerHeaders, logger)
+	res, err := requestManifestFromRegistry(registryEndPoint, imageName, imageTag, registryToken,
+		map[string]string{"Accept": acceptHeader}, logger)
 	if err != nil {
 		return "", err
 	}
 
-	responseContentType := res.Resp.Header.Get("Content-Type")
-	if responseContentType != v2FatManifestType {
-		dockerHeaders = map[string]string{"Accept": v2ManifestType}
-
-		res, err = requestManifestFromRegistry(registryEndPoint, imageName, imageTag, registryToken, dockerHeaders, logger)
-		if err != nil {
-			return "", err
-		}
-	}
-
 	digestHeader := res.Resp.Header.Get("docker-content-digest")
-
-	fingerprint := strings.TrimPrefix(digestHeader, "sha256:")
-	return fingerprint, nil
+	return strings.TrimPrefix(digestHeader, "sha256:"), nil
 }
 
 // ValidateDigest checks if a digest matches the sha256 regex

--- a/internal/digest/digest_test.go
+++ b/internal/digest/digest_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kosli-dev/cli/internal/docker"
 	"github.com/kosli-dev/cli/internal/logger"
+	"github.com/kosli-dev/cli/internal/requests"
 	"github.com/kosli-dev/cli/internal/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -744,8 +745,9 @@ func (suite *DigestTestSuite) TestRemoteDockerImageSha256() {
 				err = docker.PushDockerImage(localImage)
 				require.NoErrorf(suite.T(), err, "TestRemoteDockerImageSha256: test image should be pushable")
 			}
-			actual, err := RemoteDockerImageSha256(t.localImageName, t.localImageTag, "http://localhost:5001/v2", "secret",
-				logger.NewStandardLogger())
+			client, clientErr := requests.NewKosliClient("", 1, false, logger.NewStandardLogger())
+			require.NoErrorf(suite.T(), clientErr, "TestRemoteDockerImageSha256: client construction must not fail")
+			actual, err := RemoteDockerImageSha256(client, t.localImageName, t.localImageTag, "http://localhost:5001/v2", "secret")
 			if t.want.expectError {
 				require.Errorf(suite.T(), err, "TestRemoteDockerImageSha256: error was expected")
 			} else {


### PR DESCRIPTION
- **fix(digest): accept all four OCI manifest media types in one request**
- **feat(cloudrun): resolve tag-pinned image digests via registry lookup (Slice 7, #4986)**
- **fix(cloudrun): keep tag-pinned image as artifact name after digest resolution**
- **feat(cloudrun): --resolve-names flag rewrites digest-pinned artifact names to tag-pinned (Slice 8, #4986)**
