### PR TITLE
chore: add release Slack notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
+  notify-start:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kosli-dev/reusable-actions/slack-release-notify@main
+        with:
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ vars.SLACK_CHANNEL_ID }}
+          stage: start
+
   pre-build:
     runs-on: ubuntu-latest
     outputs:
@@ -302,6 +311,30 @@ jobs:
       tag: ${{ needs.pre-build.outputs.tag }}
       AWS_ACCOUNT_ID: 585008075785
       AWS_REGION: eu-central-1
+
+  notify-finish:
+    needs: [notify-start, goreleaser, environment-reporter-upload-layer]
+    if: always() && needs.notify-start.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read     # ← needed to fetch run_started_at for duration
+      contents: read    # ← needed to read release notes via `gh release view`
+    steps:
+      - name: Determine status
+        id: status
+        run: |
+          if [[ "${{ needs.release.result }}" == "success" ]]; then
+            echo "value=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=failure" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: kosli-dev/reusable-actions/slack-release-notify@main
+        with:
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack-channel-id: ${{ vars.SLACK_CHANNEL_ID }}
+          stage: finish
+          status: ${{ steps.status.outputs.value }}
 
   slack-notification-on-failure:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ jobs:
   notify-start:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
       - uses: kosli-dev/reusable-actions/slack-release-notify@main
         with:
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -335,6 +340,11 @@ jobs:
       actions: read     # ← needed to fetch run_started_at for duration
       contents: read    # ← needed to read release notes via `gh release view`
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
       - name: Determine status
         id: status
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,7 +313,22 @@ jobs:
       AWS_REGION: eu-central-1
 
   notify-finish:
-    needs: [notify-start, goreleaser, environment-reporter-upload-layer]
+    needs:
+      [
+        notify-start,
+        pre-build,
+        init-kosli,
+        never-alone-trail,
+        test,
+        docker,
+        goreleaser,
+        binary-provenance,
+        homebrew-pr,
+        docs-repo-dispatch,
+        evidence-reporter-upload-package-and-deploy,
+        environment-reporter-upload-package-and-deploy,
+        environment-reporter-upload-layer
+      ]
     if: always() && needs.notify-start.result == 'success'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,7 +323,7 @@ jobs:
       - name: Determine status
         id: status
         run: |
-          if [[ "${{ needs.release.result }}" == "success" ]]; then
+          if [[ "${{ needs.goreleaser.result }}" == "success" && "${{ needs.environment-reporter-upload-layer.result }}" == "success" ]]; then
             echo "value=success" >> "$GITHUB_OUTPUT"
           else
             echo "value=failure" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -360,38 +360,3 @@ jobs:
           slack-channel-id: ${{ vars.SLACK_CHANNEL_ID }}
           stage: finish
           status: ${{ steps.status.outputs.value }}
-
-  slack-notification-on-failure:
-    runs-on: ubuntu-24.04
-    permissions:
-      actions: read
-      contents: read
-    needs:
-      [
-        pre-build,
-        init-kosli,
-        never-alone-trail,
-        test,
-        docker,
-        goreleaser,
-        binary-provenance,
-        homebrew-pr,
-        docs-repo-dispatch,
-        evidence-reporter-upload-package-and-deploy,
-        environment-reporter-upload-package-and-deploy,
-        environment-reporter-upload-layer,
-        notify-start,
-        notify-finish
-      ]
-    if: ${{ always() && contains(join(needs.*.result, ','), 'failure') && github.ref == 'refs/heads/main' }}
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
-        with:
-          egress-policy: audit
-
-      - name: Slack Notification on Failure
-        uses: kosli-dev/reusable-actions/.github/actions/send-ci-failure-slack-message@main
-        with:
-          slack_url: ${{ secrets.MERKELY_SLACK_CI_FAILURES_WEBHOOK }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,10 +338,11 @@ jobs:
       - name: Determine status
         id: status
         run: |
-          if [[ "${{ needs.goreleaser.result }}" == "success" && "${{ needs.environment-reporter-upload-layer.result }}" == "success" ]]; then
+          if [[ "${{ !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled') }}" == "true" ]]; then
             echo "value=success" >> "$GITHUB_OUTPUT"
           else
             echo "value=failure" >> "$GITHUB_OUTPUT"
+          fi
           fi
 
       - uses: kosli-dev/reusable-actions/slack-release-notify@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,7 +353,6 @@ jobs:
           else
             echo "value=failure" >> "$GITHUB_OUTPUT"
           fi
-          fi
 
       - uses: kosli-dev/reusable-actions/slack-release-notify@main
         with:
@@ -380,7 +379,9 @@ jobs:
         docs-repo-dispatch,
         evidence-reporter-upload-package-and-deploy,
         environment-reporter-upload-package-and-deploy,
-        environment-reporter-upload-layer
+        environment-reporter-upload-layer,
+        notify-start,
+        notify-finish
       ]
     if: ${{ always() && contains(join(needs.*.result, ','), 'failure') && github.ref == 'refs/heads/main' }}
     steps:


### PR DESCRIPTION
* Add notifications to Slack on CLI releases.
* Removed old and not used `slack-notification-on-failure` (it was dead path of code - pushing a tag would never trigger merge to `main`)