### PR TITLE
chore: remove windows-arm from release template

### DIFF
--- a/release-flow-template.yml
+++ b/release-flow-template.yml
@@ -23,10 +23,6 @@ trail:
     attestations:
     - name: sbom
       type: generic
-  - name: windows-arm
-    attestations:
-    - name: sbom
-      type: generic
   - name: windows-arm64
     attestations:
     - name: sbom


### PR DESCRIPTION
We don't produce artifacts for Windows Arm: https://github.com/kosli-dev/cli/blob/main/.goreleaser.yml#L28-L30 

Let's make this Trail compliant again :smile: 