### PR TITLE
chore: wrap CLI flags in backticks in Mintlify doc output

### DIFF
--- a/cmd/kosli/testdata/output/docs/mintlify/artifact.md
+++ b/cmd/kosli/testdata/output/docs/mintlify/artifact.md
@@ -33,19 +33,19 @@ registry without needing a local Docker daemon.
 ## Flags
 | Flag | Description |
 | :--- | :--- |
-|    -t, --artifact-type string  |  The type of the artifact to calculate its SHA256 fingerprint. One of: [oci, docker, file, dir]. Only required if you want Kosli to calculate the fingerprint for you (i.e. when you don't specify '--fingerprint' on commands that allow it).  |
-|    -b, --build-url string  |  The url of CI pipeline that built the artifact. (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
-|    -u, --commit-url string  |  The url for the git commit that created the artifact. (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
-|    -D, --dry-run  |  [optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors.  |
-|    -x, --exclude strings  |  [optional] The comma separated list of directories and files to exclude from fingerprinting. Can take glob patterns. Only applicable for --artifact-type dir.  |
-|    -F, --fingerprint string  |  [conditional] The SHA256 fingerprint of the artifact. Only required if you don't specify '--artifact-type'.  |
-|    -f, --flow string  |  The Kosli flow name.  |
-|    -g, --git-commit string  |  [defaulted] The git commit from which the artifact was created. (defaulted in some CIs: [docs](/integrations/ci_cd), otherwise defaults to HEAD ).  |
-|    -h, --help  |  help for artifact  |
-|    -n, --name string  |  [optional] Artifact display name, if different from file, image or directory name.  |
-|        --registry-password string  |  [conditional] The container registry password or access token. Only required if you want to read container image SHA256 digest from a remote container registry.  |
-|        --registry-username string  |  [conditional] The container registry username. Only required if you want to read container image SHA256 digest from a remote container registry.  |
-|        --repo-root string  |  [defaulted] The directory where the source git repository is available. (default ".")  |
+|    `-t`, `--artifact-type` string  |  The type of the artifact to calculate its SHA256 fingerprint. One of: [oci, docker, file, dir]. Only required if you want Kosli to calculate the fingerprint for you (i.e. when you don't specify '`--fingerprint`' on commands that allow it).  |
+|    `-b`, `--build-url` string  |  The url of CI pipeline that built the artifact. (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
+|    `-u`, `--commit-url` string  |  The url for the git commit that created the artifact. (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
+|    `-D`, `--dry-run`  |  [optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors.  |
+|    `-x`, `--exclude` strings  |  [optional] The comma separated list of directories and files to exclude from fingerprinting. Can take glob patterns. Only applicable for `--artifact-type` dir.  |
+|    `-F`, `--fingerprint` string  |  [conditional] The SHA256 fingerprint of the artifact. Only required if you don't specify '`--artifact-type`'.  |
+|    `-f`, `--flow` string  |  The Kosli flow name.  |
+|    `-g`, `--git-commit` string  |  [defaulted] The git commit from which the artifact was created. (defaulted in some CIs: [docs](/integrations/ci_cd), otherwise defaults to HEAD ).  |
+|    `-h`, `--help`  |  help for artifact  |
+|    `-n`, `--name` string  |  [optional] Artifact display name, if different from file, image or directory name.  |
+|        `--registry-password` string  |  [conditional] The container registry password or access token. Only required if you want to read container image SHA256 digest from a remote container registry.  |
+|        `--registry-username` string  |  [conditional] The container registry username. Only required if you want to read container image SHA256 digest from a remote container registry.  |
+|        `--repo-root` string  |  [defaulted] The directory where the source git repository is available. (default ".")  |
 
 
 ## Examples Use Cases

--- a/cmd/kosli/testdata/output/docs/mintlify/snyk.md
+++ b/cmd/kosli/testdata/output/docs/mintlify/snyk.md
@@ -37,32 +37,32 @@ In other CI systems, set them explicitly to capture repository metadata.
 ## Flags
 | Flag | Description |
 | :--- | :--- |
-|        --annotate stringToString  |  [optional] Annotate the attestation with data using key=value.  |
-|    -t, --artifact-type string  |  The type of the artifact to calculate its SHA256 fingerprint. One of: [oci, docker, file, dir]. Only required if you want Kosli to calculate the fingerprint for you (i.e. when you don't specify '--fingerprint' on commands that allow it).  |
-|        --attachments strings  |  [optional] The comma-separated list of paths of attachments for the reported attestation. Attachments can be files or directories. All attachments are compressed and uploaded to Kosli's evidence vault.  |
-|    -g, --commit string  |  [conditional] The git commit for which the attestation is associated to. Becomes required when reporting an attestation for an artifact before reporting it to Kosli. (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
-|        --description string  |  [optional] attestation description  |
-|    -D, --dry-run  |  [optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors.  |
-|    -x, --exclude strings  |  [optional] The comma separated list of directories and files to exclude from fingerprinting. Can take glob patterns. Only applicable for --artifact-type dir.  |
-|        --external-fingerprint stringToString  |  [optional] A SHA256 fingerprint of an external attachment represented by --external-url. The format is label=fingerprint (labels cannot contain '.' or '='). This flag can be set multiple times. There must be an external url with a matching label for each external fingerprint.  |
-|        --external-url stringToString  |  [optional] Add labeled reference URL for an external resource. The format is label=url (labels cannot contain '.' or '='). This flag can be set multiple times. If the resource is a file or dir, you can optionally add its fingerprint via --external-fingerprint  |
-|    -F, --fingerprint string  |  [conditional] The SHA256 fingerprint of the artifact to attach the attestation to. Only required if the attestation is for an artifact and --artifact-type and artifact name/path are not used.  |
-|    -f, --flow string  |  The Kosli flow name.  |
-|    -h, --help  |  help for snyk  |
-|    -n, --name string  |  The name of the attestation as declared in the flow or trail yaml template.  |
-|    -o, --origin-url string  |  [optional] The url pointing to where the attestation came from or is related. (defaulted to the CI url in some CIs: [docs](/integrations/ci_cd/#defaulted-kosli-command-flags-from-ci-variables) ).  |
-|        --redact-commit-info strings  |  [optional] The list of commit info to be redacted before sending to Kosli. Allowed values are one or more of [author, message, branch].  |
-|        --registry-password string  |  [conditional] The container registry password or access token. Only required if you want to read container image SHA256 digest from a remote container registry.  |
-|        --registry-username string  |  [conditional] The container registry username. Only required if you want to read container image SHA256 digest from a remote container registry.  |
-|        --repo-id string  |  [conditional] The stable, unique identifier for the repository in your VCS provider (e.g. a numeric ID). Do not use the repository name as it can change if the repo is renamed. All three of --repo-id, --repo-url and --repository must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
-|        --repo-provider string  |  [optional] The source code hosting provider. One of: github, gitlab, bitbucket, azure-devops (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
-|        --repo-root string  |  [defaulted] The directory where the source git repository is available. Only used if --commit is used or defaulted in CI, see [docs](/integrations/ci_cd/#defaulted-kosli-command-flags-from-ci-variables) . (default ".")  |
-|        --repo-url string  |  [conditional] The URL of the repository. Must be a valid URL. All three of --repo-id, --repo-url and --repository must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
-|        --repository string  |  [conditional] The name of the repository (e.g. owner/repo-name). All three of --repo-id, --repo-url and --repository must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
-|    -R, --scan-results string  |  The path to Snyk scan SARIF results file from 'snyk test' and 'snyk container test'. By default, the Snyk results will be uploaded to Kosli's evidence vault.  |
-|    -T, --trail string  |  The Kosli trail name.  |
-|        --upload-results  |  [defaulted] Whether to upload the provided Snyk results file as an attachment to Kosli or not. (default true)  |
-|    -u, --user-data string  |  [optional] The path to a JSON file containing additional data you would like to attach to the attestation.  |
+|        `--annotate` stringToString  |  [optional] Annotate the attestation with data using key=value.  |
+|    `-t`, `--artifact-type` string  |  The type of the artifact to calculate its SHA256 fingerprint. One of: [oci, docker, file, dir]. Only required if you want Kosli to calculate the fingerprint for you (i.e. when you don't specify '`--fingerprint`' on commands that allow it).  |
+|        `--attachments` strings  |  [optional] The comma-separated list of paths of attachments for the reported attestation. Attachments can be files or directories. All attachments are compressed and uploaded to Kosli's evidence vault.  |
+|    `-g`, `--commit` string  |  [conditional] The git commit for which the attestation is associated to. Becomes required when reporting an attestation for an artifact before reporting it to Kosli. (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
+|        `--description` string  |  [optional] attestation description  |
+|    `-D`, `--dry-run`  |  [optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors.  |
+|    `-x`, `--exclude` strings  |  [optional] The comma separated list of directories and files to exclude from fingerprinting. Can take glob patterns. Only applicable for `--artifact-type` dir.  |
+|        `--external-fingerprint` stringToString  |  [optional] A SHA256 fingerprint of an external attachment represented by `--external-url`. The format is label=fingerprint (labels cannot contain '.' or '='). This flag can be set multiple times. There must be an external url with a matching label for each external fingerprint.  |
+|        `--external-url` stringToString  |  [optional] Add labeled reference URL for an external resource. The format is label=url (labels cannot contain '.' or '='). This flag can be set multiple times. If the resource is a file or dir, you can optionally add its fingerprint via `--external-fingerprint`  |
+|    `-F`, `--fingerprint` string  |  [conditional] The SHA256 fingerprint of the artifact to attach the attestation to. Only required if the attestation is for an artifact and `--artifact-type` and artifact name/path are not used.  |
+|    `-f`, `--flow` string  |  The Kosli flow name.  |
+|    `-h`, `--help`  |  help for snyk  |
+|    `-n`, `--name` string  |  The name of the attestation as declared in the flow or trail yaml template.  |
+|    `-o`, `--origin-url` string  |  [optional] The url pointing to where the attestation came from or is related. (defaulted to the CI url in some CIs: [docs](/integrations/ci_cd/#defaulted-kosli-command-flags-from-ci-variables) ).  |
+|        `--redact-commit-info` strings  |  [optional] The list of commit info to be redacted before sending to Kosli. Allowed values are one or more of [author, message, branch].  |
+|        `--registry-password` string  |  [conditional] The container registry password or access token. Only required if you want to read container image SHA256 digest from a remote container registry.  |
+|        `--registry-username` string  |  [conditional] The container registry username. Only required if you want to read container image SHA256 digest from a remote container registry.  |
+|        `--repo-id` string  |  [conditional] The stable, unique identifier for the repository in your VCS provider (e.g. a numeric ID). Do not use the repository name as it can change if the repo is renamed. All three of `--repo-id`, `--repo-url` and `--repository` must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
+|        `--repo-provider` string  |  [optional] The source code hosting provider. One of: github, gitlab, bitbucket, azure-devops (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
+|        `--repo-root` string  |  [defaulted] The directory where the source git repository is available. Only used if `--commit` is used or defaulted in CI, see [docs](/integrations/ci_cd/#defaulted-kosli-command-flags-from-ci-variables) . (default ".")  |
+|        `--repo-url` string  |  [conditional] The URL of the repository. Must be a valid URL. All three of `--repo-id`, `--repo-url` and `--repository` must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
+|        `--repository` string  |  [conditional] The name of the repository (e.g. owner/repo-name). All three of `--repo-id`, `--repo-url` and `--repository` must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
+|    `-R`, `--scan-results` string  |  The path to Snyk scan SARIF results file from 'snyk test' and 'snyk container test'. By default, the Snyk results will be uploaded to Kosli's evidence vault.  |
+|    `-T`, `--trail` string  |  The Kosli trail name.  |
+|        `--upload-results`  |  [defaulted] Whether to upload the provided Snyk results file as an attachment to Kosli or not. (default true)  |
+|    `-u`, `--user-data` string  |  [optional] The path to a JSON file containing additional data you would like to attach to the attestation.  |
 
 
 ## Examples Use Cases

--- a/internal/docgen/mintlify.go
+++ b/internal/docgen/mintlify.go
@@ -189,19 +189,13 @@ func backtickFlags(s string) string {
 	return strings.Join(parts, "```")
 }
 
+// nonBoundaryByte matches a single byte that cannot precede a CLI flag:
+// a word char (\w), backtick, slash, or dash.
+var nonBoundaryByte = regexp.MustCompile("[`/\\w-]")
+
+// isFlagBoundaryChar reports whether c is a valid character before a flag.
 func isFlagBoundaryChar(c byte) bool {
-	// A flag must be preceded by start-of-string or a character that is not
-	// a word char, slash, dash, or backtick.
-	if c == '/' || c == '-' || c == '`' {
-		return false
-	}
-	if c == '_' {
-		return false
-	}
-	if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
-		return false
-	}
-	return true
+	return !nonBoundaryByte.Match([]byte{c})
 }
 
 func backtickFlagsFragment(s string) string {

--- a/internal/docgen/mintlify.go
+++ b/internal/docgen/mintlify.go
@@ -58,8 +58,10 @@ func (MintlifyFormatter) Synopsis(meta CommandMeta) string {
 func (MintlifyFormatter) FlagsSection(flags, inherited string) string {
 	flags = linkifyKosliDocsURLs(flags)
 	flags = escapeMintlifyProse(flags)
+	flags = backtickFlags(flags)
 	inherited = linkifyKosliDocsURLs(inherited)
 	inherited = escapeMintlifyProse(inherited)
+	inherited = backtickFlags(inherited)
 	var b strings.Builder
 	if flags != "" {
 		b.WriteString("## Flags\n")
@@ -169,6 +171,71 @@ var htmlTags = map[string]bool{
 // Real links should use markdown syntax [text](url) in the flag description;
 // single quotes are reserved for example/placeholder URLs.
 var singleQuotedURLPattern = regexp.MustCompile(`'(https?://[^\s']+)'`)
+
+// flagPattern matches the body of a CLI flag like --name or -x. The caller
+// must check the preceding character to ensure it is a real flag boundary
+// (start-of-string or a non-word, non-slash, non-dash character).
+var flagPattern = regexp.MustCompile(`^-{1,2}[a-zA-Z][\w-]*`)
+
+// backtickFlags wraps every CLI flag mention (--flag, -x) in backticks so
+// Mintlify's smart-typography renderer does not turn `--` into an em dash
+// inside Markdown table cells. Idempotent: flags already inside inline-code
+// spans or fenced code blocks are left alone.
+func backtickFlags(s string) string {
+	parts := strings.Split(s, "```")
+	for i := 0; i < len(parts); i += 2 {
+		parts[i] = backtickFlagsFragment(parts[i])
+	}
+	return strings.Join(parts, "```")
+}
+
+func isFlagBoundaryChar(c byte) bool {
+	// A flag must be preceded by start-of-string or a character that is not
+	// a word char, slash, dash, or backtick.
+	if c == '/' || c == '-' || c == '`' {
+		return false
+	}
+	if c == '_' {
+		return false
+	}
+	if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
+		return false
+	}
+	return true
+}
+
+func backtickFlagsFragment(s string) string {
+	var b strings.Builder
+	i := 0
+	for i < len(s) {
+		if s[i] == '`' {
+			b.WriteByte(s[i])
+			i++
+			for i < len(s) && s[i] != '`' {
+				b.WriteByte(s[i])
+				i++
+			}
+			if i < len(s) {
+				b.WriteByte(s[i])
+				i++
+			}
+			continue
+		}
+		boundary := i == 0 || isFlagBoundaryChar(s[i-1])
+		if boundary && (s[i] == '-') {
+			if loc := flagPattern.FindStringIndex(s[i:]); loc != nil {
+				b.WriteByte('`')
+				b.WriteString(s[i : i+loc[1]])
+				b.WriteByte('`')
+				i += loc[1]
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}
 
 func escapeProseFragment(s string) string {
 	// Escape curly braces: {expr} -> \{expr\}

--- a/internal/docgen/mintlify_test.go
+++ b/internal/docgen/mintlify_test.go
@@ -217,6 +217,90 @@ func TestEscapeMintlifyProse(t *testing.T) {
 	}
 }
 
+func TestBacktickFlags(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "double-dash flag at start",
+			input: "--api-token",
+			want:  "`--api-token`",
+		},
+		{
+			name:  "single-dash flag at start",
+			input: "-x",
+			want:  "`-x`",
+		},
+		{
+			name:  "flag in middle of sentence",
+			input: "use --api-token to authenticate",
+			want:  "use `--api-token` to authenticate",
+		},
+		{
+			name:  "flag in table cell",
+			input: "| --api-token | API token |",
+			want:  "| `--api-token` | API token |",
+		},
+		{
+			name:  "two adjacent flags",
+			input: "--foo --bar",
+			want:  "`--foo` `--bar`",
+		},
+		{
+			name:  "comma-separated flags",
+			input: "--foo,--bar",
+			want:  "`--foo`,`--bar`",
+		},
+		{
+			name:  "already-backticked flag is left alone",
+			input: "use `--api-token` here",
+			want:  "use `--api-token` here",
+		},
+		{
+			name:  "hyphenated word is not a flag",
+			input: "this is built-in behaviour",
+			want:  "this is built-in behaviour",
+		},
+		{
+			name:  "code fence content is untouched",
+			input: "see ```\nkosli foo --bar\n``` for example",
+			want:  "see ```\nkosli foo --bar\n``` for example",
+		},
+		{
+			name:  "flag with hyphen in name",
+			input: "use --jira-base-url here",
+			want:  "use `--jira-base-url` here",
+		},
+		{
+			name:  "short flag in middle",
+			input: "use -h for help",
+			want:  "use `-h` for help",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := backtickFlags(tt.input)
+			if got != tt.want {
+				t.Errorf("backtickFlags(%q):\ngot:  %q\nwant: %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMintlifyFlagsSectionBackticksFlags(t *testing.T) {
+	f := MintlifyFormatter{}
+	flags := "| --api-token string | required (default $KOSLI_API_TOKEN) |\n"
+	got := f.FlagsSection(flags, "")
+	if !strings.Contains(got, "`--api-token`") {
+		t.Errorf("expected --api-token to be backticked, got:\n%s", got)
+	}
+	if strings.Contains(got, "| --api-token string |") {
+		t.Errorf("expected bare --api-token to be replaced, got:\n%s", got)
+	}
+}
+
 func TestSanitizeDescription(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/docgen/mintlify_test.go
+++ b/internal/docgen/mintlify_test.go
@@ -278,6 +278,21 @@ func TestBacktickFlags(t *testing.T) {
 			input: "use -h for help",
 			want:  "use `-h` for help",
 		},
+		{
+			name:  "bare double-dash is not a flag",
+			input: "use -- to separate flags from args",
+			want:  "use -- to separate flags from args",
+		},
+		{
+			name:  "flag with equals value",
+			input: "use --output=json here",
+			want:  "use `--output`=json here",
+		},
+		{
+			name:  "numeric arg is not a flag",
+			input: "use -1 for default",
+			want:  "use -1 for default",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Mintlify's smart-typography renderer converts bare `--` to an em dash inside Markdown table cells, garbling flag names in the generated client_reference pages. Wrap every flag mention (--flag, -x) in backticks so the renderer treats them as inline code.