### PR TITLE
chore: use full SHA for Kosli flows

### DIFF
--- a/.github/workflows/init_kosli.yml
+++ b/.github/workflows/init_kosli.yml
@@ -23,7 +23,7 @@ on:
             required: false
             type: string
             default: 'none'
-        secrets:        
+        secrets:
             kosli_api_token:
                 required: true
             pr_github_token:
@@ -75,8 +75,8 @@ jobs:
           if: ${{ inputs.report_to_kosli != 'none' }}
           env:
             KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
-          run: kosli begin trail ${{inputs.trail_name}} 
-                --flow ${{inputs.flow_name}} 
+          run: kosli begin trail ${{inputs.trail_name}}
+                --flow ${{inputs.flow_name}}
                 --org ${{inputs.kosli_org}}
 
         - name: Report pull-request attestation to Kosli
@@ -85,11 +85,10 @@ jobs:
             KOSLI_API_TOKEN: ${{ secrets.kosli_api_token }}
           run: kosli attest pullrequest github
                 --flow ${{inputs.flow_name}}
-                --trail ${{inputs.trail_name}} 
+                --trail ${{inputs.trail_name}}
                 --name pr
                 --github-token ${{ secrets.pr_github_token }}
                 --org ${{inputs.kosli_org}}
-        
 
         - name: Report never-alone attestation to Kosli
           if: ${{ inputs.report_to_kosli == 'all' }}
@@ -99,8 +98,8 @@ jobs:
             GH_TOKEN: ${{ github.token }}
           run: |
             USER_DATA_FILENAME=never-alone-user-data.json
-            ./bin/never_alone/get_commit_and_pr_info.sh -c ${GITHUB_SHA} -o ${USER_DATA_FILENAME} 
-            
+            ./bin/never_alone/get_commit_and_pr_info.sh -c ${GITHUB_SHA} -o ${USER_DATA_FILENAME}
+
             PR_URL=$(cat ${USER_DATA_FILENAME} | jq -r '.pullRequest.url // empty')
             if [ -n "$PR_URL" ]; then
                 PR_ANNOTATE_ARG="--annotate pull_request=$PR_URL"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,8 @@ jobs:
           else
             SHA=$GITHUB_SHA
           fi
-          TAG=$(echo $SHA | head -c7)
-          echo "TAG=${TAG}" >> ${GITHUB_ENV}
+          TAG=$(echo $SHA | head -c 8)
+          echo "TAG=${TAG}" >> $GITHUB_ENV
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "checkout_ref=$SHA" >> $GITHUB_OUTPUT
 
@@ -48,7 +48,7 @@ jobs:
             TRAIL_NAME=${GITHUB_REF##refs/tags/}
             TRAIL_TEMPLATE_FILE=release-flow-template.yml
           else
-            TRAIL_NAME=$(echo $SHA | head -c 7)
+            TRAIL_NAME=$SHA
             TRAIL_TEMPLATE_FILE=main-flow-template.yml
           fi
           echo "TRAIL_NAME=${TRAIL_NAME}" >> $GITHUB_ENV


### PR DESCRIPTION
* Use full SHA for Kosli Flow names
* Extend docker build to 8 byte SHAs (customer probably use tagged images, but perhaps we should switch to full as well)
* Empty spaces clean-up