### PR TITLE
fix: include filename in JUnit XML parse errors and consolidate directory walk

### DIFF
--- a/cmd/kosli/attestJunit.go
+++ b/cmd/kosli/attestJunit.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -213,11 +214,11 @@ func ingestJunitDir(testResultsDir string) ([]*JUnitResults, []string, error) {
 	var junitFilenames []string
 
 	var allSuites []junit.Suite
-	err := filepath.Walk(testResultsDir, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(testResultsDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if info.Mode().IsRegular() && strings.HasSuffix(info.Name(), ".xml") {
+		if d.Type().IsRegular() && strings.HasSuffix(d.Name(), ".xml") {
 			suites, err := junit.IngestFile(path)
 			if err != nil {
 				if strings.Contains(err.Error(), "Decoder.CharsetReader is nil") {
@@ -238,14 +239,14 @@ func ingestJunitDir(testResultsDir string) ([]*JUnitResults, []string, error) {
 	}
 
 	if len(allSuites) == 0 {
-		return results, nil, fmt.Errorf("no tests found in %s directory", testResultsDir)
+		return nil, nil, fmt.Errorf("no tests found in %s directory", testResultsDir)
 	}
 
 	for _, suite := range allSuites {
 		var timestamp float64
 		timestamp, err := parseTimestamp(suite.Properties["timestamp"])
 		if err != nil {
-			return results, nil, err
+			return nil, nil, err
 		}
 
 		// The values in suite.Totals are based on the results of the tests in the suite and not in the header of the suite.

--- a/cmd/kosli/attestJunit.go
+++ b/cmd/kosli/attestJunit.go
@@ -220,7 +220,11 @@ func ingestJunitDir(testResultsDir string) ([]*JUnitResults, []string, error) {
 		if info.Mode().IsRegular() && strings.HasSuffix(info.Name(), ".xml") {
 			suites, err := junit.IngestFile(path)
 			if err != nil {
-				return fmt.Errorf("failed to parse JUnit XML file %s: %w", path, err)
+				if strings.Contains(err.Error(), "Decoder.CharsetReader is nil") {
+					return fmt.Errorf("failed to parse XML file %s: only UTF-8 encoding is supported. "+
+						"If this is not a JUnit results file, use --results-dir to specify the directory containing only JUnit XML files", path)
+				}
+				return fmt.Errorf("failed to parse XML file %s: %w", path, err)
 			}
 			if len(suites) > 0 {
 				allSuites = append(allSuites, suites...)

--- a/cmd/kosli/attestJunit.go
+++ b/cmd/kosli/attestJunit.go
@@ -230,7 +230,7 @@ func ingestJunitDir(testResultsDir string) ([]*JUnitResults, []string, error) {
 		return nil
 	})
 	if err != nil {
-		return results, nil, err
+		return nil, nil, err
 	}
 
 	if len(allSuites) == 0 {

--- a/cmd/kosli/attestJunit.go
+++ b/cmd/kosli/attestJunit.go
@@ -214,16 +214,30 @@ type JUnitResults struct {
 
 func ingestJunitDir(testResultsDir string) ([]*JUnitResults, error) {
 	results := []*JUnitResults{}
-	suites, err := junit.IngestDir(testResultsDir)
+
+	var allSuites []junit.Suite
+	err := filepath.Walk(testResultsDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.Mode().IsRegular() && strings.HasSuffix(info.Name(), ".xml") {
+			suites, err := junit.IngestFile(path)
+			if err != nil {
+				return fmt.Errorf("failed to parse JUnit XML file %s: %w", path, err)
+			}
+			allSuites = append(allSuites, suites...)
+		}
+		return nil
+	})
 	if err != nil {
 		return results, err
 	}
 
-	if len(suites) == 0 {
+	if len(allSuites) == 0 {
 		return results, fmt.Errorf("no tests found in %s directory", testResultsDir)
 	}
 
-	for _, suite := range suites {
+	for _, suite := range allSuites {
 		var timestamp float64
 		timestamp, err := parseTimestamp(suite.Properties["timestamp"])
 		if err != nil {

--- a/cmd/kosli/attestJunit.go
+++ b/cmd/kosli/attestJunit.go
@@ -161,17 +161,13 @@ func (o *attestJunitOptions) run(args []string) error {
 		return err
 	}
 
-	o.payload.JUnitResults, err = ingestJunitDir(o.testResultsDir)
+	var junitFilenames []string
+	o.payload.JUnitResults, junitFilenames, err = ingestJunitDir(o.testResultsDir)
 	if err != nil {
 		return err
 	}
 
 	if o.uploadResultsDir {
-		// prepare the files to upload as attachments. We are only interested in the actual Junit XMl files
-		junitFilenames, err := getJunitFilenames(o.testResultsDir)
-		if err != nil {
-			return err
-		}
 		o.attachments = append(o.attachments, junitFilenames...)
 	}
 
@@ -212,8 +208,9 @@ type JUnitResults struct {
 	Timestamp float64 `json:"timestamp,omitempty"`
 }
 
-func ingestJunitDir(testResultsDir string) ([]*JUnitResults, error) {
+func ingestJunitDir(testResultsDir string) ([]*JUnitResults, []string, error) {
 	results := []*JUnitResults{}
+	var junitFilenames []string
 
 	var allSuites []junit.Suite
 	err := filepath.Walk(testResultsDir, func(path string, info os.FileInfo, err error) error {
@@ -225,23 +222,26 @@ func ingestJunitDir(testResultsDir string) ([]*JUnitResults, error) {
 			if err != nil {
 				return fmt.Errorf("failed to parse JUnit XML file %s: %w", path, err)
 			}
-			allSuites = append(allSuites, suites...)
+			if len(suites) > 0 {
+				allSuites = append(allSuites, suites...)
+				junitFilenames = append(junitFilenames, path)
+			}
 		}
 		return nil
 	})
 	if err != nil {
-		return results, err
+		return results, nil, err
 	}
 
 	if len(allSuites) == 0 {
-		return results, fmt.Errorf("no tests found in %s directory", testResultsDir)
+		return results, nil, fmt.Errorf("no tests found in %s directory", testResultsDir)
 	}
 
 	for _, suite := range allSuites {
 		var timestamp float64
 		timestamp, err := parseTimestamp(suite.Properties["timestamp"])
 		if err != nil {
-			return results, err
+			return results, nil, err
 		}
 
 		// The values in suite.Totals are based on the results of the tests in the suite and not in the header of the suite.
@@ -258,36 +258,7 @@ func ingestJunitDir(testResultsDir string) ([]*JUnitResults, error) {
 		results = append(results, suiteResult)
 	}
 
-	return results, nil
-}
-
-func getJunitFilenames(directory string) ([]string, error) {
-	var filenames []string
-
-	err := filepath.Walk(directory, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-
-		// Add all regular files that end with ".xml"
-		if info.Mode().IsRegular() && strings.HasSuffix(info.Name(), ".xml") {
-			suites, err := junit.IngestFile(path)
-			if err != nil {
-				return fmt.Errorf("failed to parse JUnit XML file %s: %w", path, err)
-			}
-			if len(suites) > 0 {
-				filenames = append(filenames, path)
-			}
-		}
-
-		return nil
-	})
-
-	if err != nil {
-		return filenames, err
-	}
-
-	return filenames, nil
+	return results, junitFilenames, nil
 }
 
 func parseTimestamp(timestampStr string) (float64, error) {

--- a/cmd/kosli/attestJunit.go
+++ b/cmd/kosli/attestJunit.go
@@ -273,7 +273,7 @@ func getJunitFilenames(directory string) ([]string, error) {
 		if info.Mode().IsRegular() && strings.HasSuffix(info.Name(), ".xml") {
 			suites, err := junit.IngestFile(path)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to parse JUnit XML file %s: %w", path, err)
 			}
 			if len(suites) > 0 {
 				filenames = append(filenames, path)

--- a/cmd/kosli/attestJunit.go
+++ b/cmd/kosli/attestJunit.go
@@ -3,9 +3,9 @@ package main
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"net/url"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"

--- a/cmd/kosli/attestJunit_test.go
+++ b/cmd/kosli/attestJunit_test.go
@@ -161,3 +161,11 @@ func TestIngestJunitDir(t *testing.T) {
 		assert.NotEmpty(t, results)
 	})
 }
+
+func TestGetJunitFilenames(t *testing.T) {
+	t.Run("error includes filename when XML parsing fails", func(t *testing.T) {
+		_, err := getJunitFilenames("testdata_junit_iso8859")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "results.xml")
+	})
+}

--- a/cmd/kosli/attestJunit_test.go
+++ b/cmd/kosli/attestJunit_test.go
@@ -160,9 +160,7 @@ func TestIngestJunitDir(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEmpty(t, results)
 	})
-}
 
-func TestIngestJunitDir_ReturnsFilenames(t *testing.T) {
 	t.Run("returns filenames of parsed JUnit XML files", func(t *testing.T) {
 		results, filenames, err := ingestJunitDir("testdata/junit")
 		require.NoError(t, err)

--- a/cmd/kosli/attestJunit_test.go
+++ b/cmd/kosli/attestJunit_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -137,4 +139,25 @@ func (suite *AttestJunitCommandTestSuite) TestAttestJunitCmd() {
 // a normal test function and pass our suite to suite.Run
 func TestAttestJunitCommandTestSuite(t *testing.T) {
 	suite.Run(t, new(AttestJunitCommandTestSuite))
+}
+
+func TestIngestJunitDir(t *testing.T) {
+	t.Run("error includes filename when XML parsing fails", func(t *testing.T) {
+		_, err := ingestJunitDir("testdata_junit_iso8859")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "results.xml")
+	})
+
+	t.Run("returns no tests found for empty directory", func(t *testing.T) {
+		dir := t.TempDir()
+		_, err := ingestJunitDir(dir)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no tests found")
+	})
+
+	t.Run("parses valid JUnit XML correctly", func(t *testing.T) {
+		results, err := ingestJunitDir("testdata/junit")
+		require.NoError(t, err)
+		assert.NotEmpty(t, results)
+	})
 }

--- a/cmd/kosli/attestJunit_test.go
+++ b/cmd/kosli/attestJunit_test.go
@@ -142,10 +142,12 @@ func TestAttestJunitCommandTestSuite(t *testing.T) {
 }
 
 func TestIngestJunitDir(t *testing.T) {
-	t.Run("error includes filename when XML parsing fails", func(t *testing.T) {
+	t.Run("error includes filename and user-friendly message for unsupported encoding", func(t *testing.T) {
 		_, _, err := ingestJunitDir("testdata_junit_iso8859")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "results.xml")
+		assert.Contains(t, err.Error(), "only UTF-8 encoding is supported")
+		assert.Contains(t, err.Error(), "--results-dir")
 	})
 
 	t.Run("returns no tests found for empty directory", func(t *testing.T) {

--- a/cmd/kosli/attestJunit_test.go
+++ b/cmd/kosli/attestJunit_test.go
@@ -167,7 +167,7 @@ func TestIngestJunitDir(t *testing.T) {
 		results, filenames, err := ingestJunitDir("testdata/junit")
 		require.NoError(t, err)
 		assert.NotEmpty(t, results)
-		assert.NotEmpty(t, filenames)
+		assert.Len(t, filenames, 1)
 		assert.Contains(t, filenames[0], ".xml")
 	})
 }

--- a/cmd/kosli/attestJunit_test.go
+++ b/cmd/kosli/attestJunit_test.go
@@ -143,29 +143,31 @@ func TestAttestJunitCommandTestSuite(t *testing.T) {
 
 func TestIngestJunitDir(t *testing.T) {
 	t.Run("error includes filename when XML parsing fails", func(t *testing.T) {
-		_, err := ingestJunitDir("testdata_junit_iso8859")
+		_, _, err := ingestJunitDir("testdata_junit_iso8859")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "results.xml")
 	})
 
 	t.Run("returns no tests found for empty directory", func(t *testing.T) {
 		dir := t.TempDir()
-		_, err := ingestJunitDir(dir)
+		_, _, err := ingestJunitDir(dir)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no tests found")
 	})
 
 	t.Run("parses valid JUnit XML correctly", func(t *testing.T) {
-		results, err := ingestJunitDir("testdata/junit")
+		results, _, err := ingestJunitDir("testdata/junit")
 		require.NoError(t, err)
 		assert.NotEmpty(t, results)
 	})
 }
 
-func TestGetJunitFilenames(t *testing.T) {
-	t.Run("error includes filename when XML parsing fails", func(t *testing.T) {
-		_, err := getJunitFilenames("testdata_junit_iso8859")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "results.xml")
+func TestIngestJunitDir_ReturnsFilenames(t *testing.T) {
+	t.Run("returns filenames of parsed JUnit XML files", func(t *testing.T) {
+		results, filenames, err := ingestJunitDir("testdata/junit")
+		require.NoError(t, err)
+		assert.NotEmpty(t, results)
+		assert.NotEmpty(t, filenames)
+		assert.Contains(t, filenames[0], ".xml")
 	})
 }

--- a/cmd/kosli/testdata_junit_iso8859/results.xml
+++ b/cmd/kosli/testdata_junit_iso8859/results.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="ISO-8859-15"?>
+<testsuites>
+  <testsuite name="com.example.MyTest" tests="2" failures="0" errors="0" time="0.123">
+    <testcase name="testPass" classname="com.example.MyTest" time="0.05"/>
+    <testcase name="testAlsoPass" classname="com.example.MyTest" time="0.073"/>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
## Summary

- `kosli attest junit` now includes the filename and a user-friendly message when XML parsing fails, making errors actionable instead of cryptic
- Consolidated the double directory walk into a single pass, halving time/memory/allocations

**Before:**
```
Error: xml: encoding "ISO-8859-15" declared but Decoder.CharsetReader is nil
```

**After:**
```
Error: failed to parse XML file /path/to/results.xml: only UTF-8 encoding is supported.
If this is not a JUnit results file, use --results-dir to specify the directory containing only JUnit XML files
```

## Changes

1. Replaced `junit.IngestDir()` with our own `filepath.Walk` that calls `junit.IngestFile()` per file and wraps errors with the filename
2. Encoding errors get a user-friendly message (what's wrong, what to do) instead of the raw Go stdlib error
3. `ingestJunitDir` now returns both parsed results and the list of JUnit filenames in a single pass
4. Removed `getJunitFilenames()` — its work is folded into the single walk
5. Added test fixture with ISO-8859-15 encoding declaration
6. Added 4 unit tests for `ingestJunitDir`

## Decision: no charset support (Fix 2 dropped)

We considered adding `golang.org/x/net/html/charset` to handle non-UTF-8 XML encodings transparently. We decided against it because:
- The CLI walks all `.xml` files in `--results-dir` (default `.`), so non-JUnit XML files (pom.xml, config files) get parsed too
- We can't assume a non-UTF-8 XML file is a JUnit file with incorrect encoding — it may just be an unrelated file swept up by the walk
- The right fix for users is to use `--results-dir` to narrow scope, and the error message now guides them to do that

Closes #894