### PR TITLE
feat(docs): add Tutorial field to CommandMeta for tutorial links

### DIFF
--- a/cmd/kosli/docs.go
+++ b/cmd/kosli/docs.go
@@ -73,6 +73,7 @@ func (o *docsOptions) run() error {
 				UseLine:    cmd.UseLine(),
 				Runnable:   cmd.Runnable(),
 				Example:    cmd.Example,
+				Tutorial:   cmd.Annotations["tutorialURL"],
 			}
 		}
 

--- a/internal/docgen/formatter.go
+++ b/internal/docgen/formatter.go
@@ -13,6 +13,7 @@ type CommandMeta struct {
 	UseLine    string
 	Runnable   bool
 	Example    string
+	Tutorial   string
 }
 
 // Formatter defines the interface for generating doc output in different formats.
@@ -21,6 +22,7 @@ type Formatter interface {
 	FrontMatter(meta CommandMeta) string
 	BetaWarning(name string) string
 	DeprecatedWarning(name, message string) string
+	TutorialTip(url string) string
 	Synopsis(meta CommandMeta) string
 	FlagsSection(flags, inherited string) string
 	ExampleUseCases(commandName, example string) string

--- a/internal/docgen/generate.go
+++ b/internal/docgen/generate.go
@@ -70,6 +70,11 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, formatter Formatter, met
 		buf.WriteString(formatter.DeprecatedWarning(name, meta.DeprecMsg))
 	}
 
+	// Tutorial tip
+	if meta.Tutorial != "" {
+		buf.WriteString(formatter.TutorialTip(meta.Tutorial))
+	}
+
 	// Synopsis
 	buf.WriteString(formatter.Synopsis(meta))
 

--- a/internal/docgen/generate.go
+++ b/internal/docgen/generate.go
@@ -70,11 +70,6 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, formatter Formatter, met
 		buf.WriteString(formatter.DeprecatedWarning(name, meta.DeprecMsg))
 	}
 
-	// Tutorial tip
-	if meta.Tutorial != "" {
-		buf.WriteString(formatter.TutorialTip(meta.Tutorial))
-	}
-
 	// Synopsis
 	buf.WriteString(formatter.Synopsis(meta))
 
@@ -85,6 +80,11 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, formatter Formatter, met
 	// Example use cases
 	if len(meta.Example) > 0 {
 		buf.WriteString(formatter.ExampleUseCases(name, meta.Example))
+	}
+
+	// Tutorial tip
+	if meta.Tutorial != "" {
+		buf.WriteString(formatter.TutorialTip(meta.Tutorial))
 	}
 
 	_, err := fmt.Fprint(w, buf.String())

--- a/internal/docgen/generate_test.go
+++ b/internal/docgen/generate_test.go
@@ -125,6 +125,58 @@ func TestGenMarkdownTreeIncludesDeprecatedCommands(t *testing.T) {
 	}
 }
 
+func TestGenMarkdownTreeRendersTutorialTip(t *testing.T) {
+	dir := t.TempDir()
+
+	root := &cobra.Command{Use: "root"}
+	withTutorial := &cobra.Command{
+		Use:         "withtut",
+		Short:       "Cmd with tutorial",
+		Long:        "long desc",
+		Annotations: map[string]string{"tutorialURL": "https://docs.kosli.com/tutorials/x"},
+		RunE:        func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	without := &cobra.Command{
+		Use:   "withouttut",
+		Short: "Cmd without tutorial",
+		Long:  "long desc",
+		RunE:  func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	root.AddCommand(withTutorial, without)
+
+	metaFn := func(cmd *cobra.Command) CommandMeta {
+		return CommandMeta{
+			Name:     cmd.CommandPath(),
+			Summary:  cmd.Short,
+			Long:     cmd.Long,
+			UseLine:  cmd.UseLine(),
+			Runnable: cmd.Runnable(),
+			Tutorial: cmd.Annotations["tutorialURL"],
+		}
+	}
+
+	if err := GenMarkdownTree(root, dir, MintlifyFormatter{}, metaFn); err != nil {
+		t.Fatalf("GenMarkdownTree error: %v", err)
+	}
+
+	withContent, err := os.ReadFile(filepath.Join(dir, "root_withtut.md"))
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	if !strings.Contains(string(withContent), "<Tip>") ||
+		!strings.Contains(string(withContent), "https://docs.kosli.com/tutorials/x") {
+		t.Errorf("expected Tip block with tutorial URL, got:\n%s", string(withContent))
+	}
+
+	withoutContent, err := os.ReadFile(filepath.Join(dir, "root_withouttut.md"))
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	if strings.Contains(string(withoutContent), "<Tip>") {
+		t.Errorf("expected no Tip block when tutorial unset, got:\n%s", string(withoutContent))
+	}
+}
+
 func TestGenMarkdownTreeWithMintlifyFormatter(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/docgen/mintlify.go
+++ b/internal/docgen/mintlify.go
@@ -41,6 +41,10 @@ func (MintlifyFormatter) DeprecatedWarning(name, message string) string {
 	return b.String()
 }
 
+func (MintlifyFormatter) TutorialTip(url string) string {
+	return fmt.Sprintf("<Tip>\nSee the [tutorial](%s) for a walkthrough.\n</Tip>\n\n", url)
+}
+
 func (MintlifyFormatter) Synopsis(meta CommandMeta) string {
 	var b strings.Builder
 	if len(meta.Long) > 0 {

--- a/internal/docgen/mintlify_test.go
+++ b/internal/docgen/mintlify_test.go
@@ -50,6 +50,17 @@ func TestMintlifyBetaWarning(t *testing.T) {
 	}
 }
 
+func TestMintlifyTutorialTip(t *testing.T) {
+	f := MintlifyFormatter{}
+	got := f.TutorialTip("https://docs.kosli.com/tutorials/snyk")
+	if !strings.Contains(got, "<Tip>") || !strings.Contains(got, "</Tip>") {
+		t.Errorf("expected Tip component, got:\n%s", got)
+	}
+	if !strings.Contains(got, "[tutorial](https://docs.kosli.com/tutorials/snyk)") {
+		t.Errorf("expected markdown link to tutorial URL, got:\n%s", got)
+	}
+}
+
 func TestMintlifyDeprecatedWarning(t *testing.T) {
 	f := MintlifyFormatter{}
 	got := f.DeprecatedWarning("kosli artifact", "see kosli attest commands")


### PR DESCRIPTION
Commands can now declare a tutorial URL via the `tutorialURL` cobra annotation. When set, the Mintlify docs generator renders a <Tip> callout linking to the tutorial. When unset, nothing is emitted.