### PR TITLE
fix: specify custom attestation type

### DIFF
--- a/main-flow-template.yml
+++ b/main-flow-template.yml
@@ -14,7 +14,7 @@ trail:
   - name: never-alone-data
     type: generic
   - name: four-eyes-result
-    type: custom
+    type: custom:four-eyes-result
   artifacts:
   - name: cli-docker
     attestations:


### PR DESCRIPTION
Previous PR #891 didn't provide custom attestation type (https://github.com/kosli-dev/cli/pull/891/changes#diff-ec60bba356baa9a1db241eb6796050a8c987897efa9784975f6a9174085eb1d9R17) in the Flow template. This is fixing this :rocket: 