### PR TITLE
fix: use url.JoinPath for list/diff command URLs

### DIFF
--- a/cmd/kosli/diffSnapshots.go
+++ b/cmd/kosli/diffSnapshots.go
@@ -113,12 +113,18 @@ func newDiffSnapshotsCmd(out io.Writer) *cobra.Command {
 func (o *diffSnapshotsOptions) run(out io.Writer, args []string) error {
 	snappish1 := args[0]
 	snappish2 := args[1]
-	url := fmt.Sprintf("%s/api/v2/env-diff/%s?snappish1=%s&snappish2=%s",
-		global.Host, global.Org, url.QueryEscape(snappish1), url.QueryEscape(snappish2))
+	base, err := url.JoinPath(global.Host, "api/v2/env-diff", global.Org)
+	if err != nil {
+		return err
+	}
+	params := url.Values{}
+	params.Set("snappish1", snappish1)
+	params.Set("snappish2", snappish2)
+	reqURL := base + "?" + params.Encode()
 
 	reqParams := &requests.RequestParams{
 		Method: http.MethodGet,
-		URL:    url,
+		URL:    reqURL,
 		Token:  global.ApiToken,
 	}
 	response, err := kosliClient.Do(reqParams)

--- a/cmd/kosli/listApprovals.go
+++ b/cmd/kosli/listApprovals.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/kosli-dev/cli/internal/output"
 	"github.com/kosli-dev/cli/internal/requests"
@@ -79,12 +80,18 @@ func newListApprovalsCmd(out io.Writer) *cobra.Command {
 }
 
 func (o *listApprovalsOptions) run(out io.Writer) error {
-	url := fmt.Sprintf("%s/api/v2/approvals/%s/%s?page=%d&per_page=%d",
-		global.Host, global.Org, o.flowName, o.pageNumber, o.pageLimit)
+	base, err := url.JoinPath(global.Host, "api/v2/approvals", global.Org, o.flowName)
+	if err != nil {
+		return err
+	}
+	params := url.Values{}
+	params.Set("page", fmt.Sprintf("%d", o.pageNumber))
+	params.Set("per_page", fmt.Sprintf("%d", o.pageLimit))
+	reqURL := base + "?" + params.Encode()
 
 	reqParams := &requests.RequestParams{
 		Method: http.MethodGet,
-		URL:    url,
+		URL:    reqURL,
 		Token:  global.ApiToken,
 	}
 	response, err := kosliClient.Do(reqParams)

--- a/cmd/kosli/listApprovals.go
+++ b/cmd/kosli/listApprovals.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	"github.com/kosli-dev/cli/internal/output"
 	"github.com/kosli-dev/cli/internal/requests"
@@ -85,8 +86,8 @@ func (o *listApprovalsOptions) run(out io.Writer) error {
 		return err
 	}
 	params := url.Values{}
-	params.Set("page", fmt.Sprintf("%d", o.pageNumber))
-	params.Set("per_page", fmt.Sprintf("%d", o.pageLimit))
+	params.Set("page", strconv.Itoa(o.pageNumber))
+	params.Set("per_page", strconv.Itoa(o.pageLimit))
 	reqURL := base + "?" + params.Encode()
 
 	reqParams := &requests.RequestParams{

--- a/cmd/kosli/listArtifacts.go
+++ b/cmd/kosli/listArtifacts.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	"github.com/kosli-dev/cli/internal/output"
 	"github.com/kosli-dev/cli/internal/requests"
@@ -85,8 +86,8 @@ func (o *listArtifactsOptions) run(out io.Writer) error {
 		return err
 	}
 	params := url.Values{}
-	params.Set("page", fmt.Sprintf("%d", o.pageNumber))
-	params.Set("per_page", fmt.Sprintf("%d", o.pageLimit))
+	params.Set("page", strconv.Itoa(o.pageNumber))
+	params.Set("per_page", strconv.Itoa(o.pageLimit))
 	if o.flowName != "" {
 		params.Set("flow_name", o.flowName)
 	} else if o.repoName != "" {

--- a/cmd/kosli/listArtifacts.go
+++ b/cmd/kosli/listArtifacts.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/kosli-dev/cli/internal/output"
 	"github.com/kosli-dev/cli/internal/requests"
@@ -79,18 +80,23 @@ func newListArtifactsCmd(out io.Writer) *cobra.Command {
 }
 
 func (o *listArtifactsOptions) run(out io.Writer) error {
-	url := fmt.Sprintf("%s/api/v2/artifacts/%s?page=%d&per_page=%d",
-		global.Host, global.Org, o.pageNumber, o.pageLimit)
-
-	if o.flowName != "" {
-		url = url + fmt.Sprintf("&flow_name=%s", o.flowName)
-	} else if o.repoName != "" {
-		url = url + fmt.Sprintf("&repo_name=%s", o.repoName)
+	base, err := url.JoinPath(global.Host, "api/v2/artifacts", global.Org)
+	if err != nil {
+		return err
 	}
+	params := url.Values{}
+	params.Set("page", fmt.Sprintf("%d", o.pageNumber))
+	params.Set("per_page", fmt.Sprintf("%d", o.pageLimit))
+	if o.flowName != "" {
+		params.Set("flow_name", o.flowName)
+	} else if o.repoName != "" {
+		params.Set("repo_name", o.repoName)
+	}
+	reqURL := base + "?" + params.Encode()
 
 	reqParams := &requests.RequestParams{
 		Method: http.MethodGet,
-		URL:    url,
+		URL:    reqURL,
 		Token:  global.ApiToken,
 	}
 	response, err := kosliClient.Do(reqParams)

--- a/cmd/kosli/listSnapshots.go
+++ b/cmd/kosli/listSnapshots.go
@@ -91,12 +91,20 @@ func (o *listSnapshotsOptions) run(out io.Writer, args []string) error {
 }
 
 func (o *listSnapshotsOptions) getSnapshotsList(out io.Writer, envName, interval string) error {
-	url := fmt.Sprintf("%s/api/v2/snapshots/%s/%s?page=%d&per_page=%d&interval=%s&reverse=%t",
-		global.Host, global.Org, envName, o.pageNumber, o.pageLimit, url.QueryEscape(interval), o.reverse)
+	base, err := url.JoinPath(global.Host, "api/v2/snapshots", global.Org, envName)
+	if err != nil {
+		return err
+	}
+	params := url.Values{}
+	params.Set("page", fmt.Sprintf("%d", o.pageNumber))
+	params.Set("per_page", fmt.Sprintf("%d", o.pageLimit))
+	params.Set("interval", interval)
+	params.Set("reverse", fmt.Sprintf("%t", o.reverse))
+	reqURL := base + "?" + params.Encode()
 
 	reqParams := &requests.RequestParams{
 		Method: http.MethodGet,
-		URL:    url,
+		URL:    reqURL,
 		Token:  global.ApiToken,
 	}
 	response, err := kosliClient.Do(reqParams)

--- a/cmd/kosli/listSnapshots.go
+++ b/cmd/kosli/listSnapshots.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/kosli-dev/cli/internal/output"
@@ -96,10 +97,10 @@ func (o *listSnapshotsOptions) getSnapshotsList(out io.Writer, envName, interval
 		return err
 	}
 	params := url.Values{}
-	params.Set("page", fmt.Sprintf("%d", o.pageNumber))
-	params.Set("per_page", fmt.Sprintf("%d", o.pageLimit))
+	params.Set("page", strconv.Itoa(o.pageNumber))
+	params.Set("per_page", strconv.Itoa(o.pageLimit))
 	params.Set("interval", interval)
-	params.Set("reverse", fmt.Sprintf("%t", o.reverse))
+	params.Set("reverse", strconv.FormatBool(o.reverse))
 	reqURL := base + "?" + params.Encode()
 
 	reqParams := &requests.RequestParams{


### PR DESCRIPTION
## Summary

Fixes the double-slash URL bug in four commands that were missed by #695. When `--host` or `KOSLI_HOST` has a trailing slash, the old `fmt.Sprintf("%s/api/v2/...", global.Host, ...)` pattern produced `//api/v2/...` URLs and 404 errors.

Affected commands:
- `kosli list artifacts`
- `kosli list approvals`
- `kosli list snapshots`
- `kosli diff snapshots`

All four now use `url.JoinPath` + `url.Values`, matching the pattern adopted across the rest of the codebase.

Closes #913

## Test plan
- [x] `make build` succeeds
- [x] `make lint` passes
- [x] Manually verify `kosli list artifacts --host https://app.kosli.com/ ...` no longer returns 404