### PR TITLE
fix: add missing param to four eyes schema

### DIFF
--- a/bin/never_alone/four-eyes-result-schema.json
+++ b/bin/never_alone/four-eyes-result-schema.json
@@ -38,6 +38,10 @@
       "type": "string",
       "description": "SHA of the inclusive range end (the HEAD commit of this release, named as the attestation trail)"
     },
+    "params": {
+      "type": "object",
+      "description": "Parameters passed via --params, surfaced in the output. Available to the policy as data.params. attestation_name selects which attestation pr_attest reads (default \"pr-review\")."
+    },
     "input": {
       "type": "object",
       "description": "Raw trails input data included when kosli evaluate trails is run with --show-input"


### PR DESCRIPTION
Extend the schema and allow passing `params` to rego policy