### PR TITLE
chore: bump MongoDB version to 5.0.33

### DIFF
--- a/mongo/Dockerfile
+++ b/mongo/Dockerfile
@@ -1,4 +1,4 @@
-FROM mongo:5.0.32
+FROM mongo:5.0.33
 WORKDIR /mongo
 COPY . .
 RUN chmod 400 key.cert


### PR DESCRIPTION
Use latest v5 MongoDB container