### PR TITLE
fix: remove problematic quotes from schema

### DIFF
--- a/bin/never_alone/four-eyes-result-schema.json
+++ b/bin/never_alone/four-eyes-result-schema.json
@@ -40,7 +40,7 @@
     },
     "params": {
       "type": "object",
-      "description": "Parameters passed via --params, surfaced in the output. Available to the policy as data.params. attestation_name selects which attestation pr_attest reads (default \"pr-review\")."
+      "description": "Parameters passed via --params, surfaced in the output. Available to the policy as data.params. attestation_name selects which attestation pr_attest reads (default: pr-review)."
     },
     "input": {
       "type": "object",


### PR DESCRIPTION
Quotes were incorrectly formatting JSON and not added to schema. Applied and tested locally and it works now.