### PR TITLE
fix: keep hardcoded visibility for backwards compatibility

### DIFF
--- a/cmd/kosli/createFlow.go
+++ b/cmd/kosli/createFlow.go
@@ -100,7 +100,6 @@ func (o *createFlowOptions) run(args []string) error {
 	var url string
 	var err error
 	o.payload.Name = args[0]
-	// TODO: Remove when not required anymore
 	o.payload.Visibility = "private"
 
 	if o.TemplateFile != "" || o.UseEmptyTemplate {

--- a/cmd/kosli/createFlow.go
+++ b/cmd/kosli/createFlow.go
@@ -45,9 +45,14 @@ type createFlowOptions struct {
 }
 
 type FlowPayload struct {
-	Name        string   `json:"name"`
-	Description string   `json:"description"`
-	Template    []string `json:"template,omitempty"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	// TODO: Visibility is deprecated and ignored by recent Kosli servers, but older
+	// instances still reject the payload without it. Keep sending
+	// "private" until the minimum supported server version no longer requires
+	// this field, then remove the field and the assignment in run().
+	Visibility string   `json:"visibility"`
+	Template   []string `json:"template,omitempty"`
 }
 
 func newCreateFlowCmd(out io.Writer) *cobra.Command {
@@ -95,6 +100,8 @@ func (o *createFlowOptions) run(args []string) error {
 	var url string
 	var err error
 	o.payload.Name = args[0]
+	// TODO: Remove when not required anymore
+	o.payload.Visibility = "private"
 
 	if o.TemplateFile != "" || o.UseEmptyTemplate {
 		url, err = neturl.JoinPath(global.Host, "api/v2/flows", global.Org, "template_file")


### PR DESCRIPTION
Restore payload removed in #918 to make it compatible with older Kosli instances. 

Recent Kosli servers accept flow create/update without `visibility`, but older instances might still reject the payload without it. Keep sending `visibility: "private"` for backwards compatibility, with a comment marking it for removal once the minimum supported server version no longer requires the field.