### PR TITLE
feat: display control identifier in assert artifact output for for_control policy failures

### DIFF
--- a/cmd/kosli/assertArtifact.go
+++ b/cmd/kosli/assertArtifact.go
@@ -221,13 +221,23 @@ func printAssertAsTable(raw string, out io.Writer, page int) error {
 							ruleDefinition := rule["definition"].(map[string]interface{})
 							attestationName := ruleDefinition["name"]
 							attestationType := ruleDefinition["type"]
+							context, _ := resolution["context"].(map[string]interface{})
+							forControl, _ := context["for_control"].(string)
 							switch resolutionType {
 							case "legacy_flow":
 								failures = append(failures, "artifact comes from a legacy flow and does not have the new attestations")
 							case "missing_attestation":
-								failures = append(failures, fmt.Sprintf("artifact is missing required '%v' (type: %v) attestation in trail", attestationName, attestationType))
+								if forControl != "" {
+									failures = append(failures, fmt.Sprintf("artifact is missing required decision for control '%v'", forControl))
+								} else {
+									failures = append(failures, fmt.Sprintf("artifact is missing required '%v' (type: %v) attestation in trail", attestationName, attestationType))
+								}
 							case "non_compliant_attestation":
-								failures = append(failures, fmt.Sprintf("attestation '%v' is non-compliant in trail", attestationName))
+								if forControl != "" {
+									failures = append(failures, fmt.Sprintf("decision for control '%v' is non-compliant in trail", forControl))
+								} else {
+									failures = append(failures, fmt.Sprintf("attestation '%v' is non-compliant in trail", attestationName))
+								}
 							case "non_compliant_in_trail":
 								failures = append(failures, "artifact is not compliant in trail")
 							}

--- a/cmd/kosli/assertArtifact.go
+++ b/cmd/kosli/assertArtifact.go
@@ -228,7 +228,7 @@ func printAssertAsTable(raw string, out io.Writer, page int) error {
 								failures = append(failures, "artifact comes from a legacy flow and does not have the new attestations")
 							case "missing_attestation":
 								if forControl != "" {
-									failures = append(failures, fmt.Sprintf("artifact is missing required decision for control '%v'", forControl))
+									failures = append(failures, fmt.Sprintf("artifact is missing required %v for control '%v'", attestationType, forControl))
 								} else {
 									failures = append(failures, fmt.Sprintf("artifact is missing required '%v' (type: %v) attestation in trail", attestationName, attestationType))
 								}

--- a/cmd/kosli/assertArtifact_test.go
+++ b/cmd/kosli/assertArtifact_test.go
@@ -30,6 +30,17 @@ type AssertArtifactCommandTestSuite struct {
 	artifactName3         string
 	artifact3Path         string
 	fingerprint3          string
+	// for_control test fixtures
+	controlIdentifier    string
+	controlPolicyName    string
+	controlEnvName       string
+	flowNameForControl   string
+	trailNameNoDecision  string
+	artifact4Path        string
+	fingerprint4         string
+	trailNameBadDecision string
+	artifact5Path        string
+	fingerprint5         string
 }
 
 func (suite *AssertArtifactCommandTestSuite) SetupTest() {
@@ -78,6 +89,34 @@ func (suite *AssertArtifactCommandTestSuite) SetupTest() {
 	require.NoError(suite.T(), err)
 	CreateGenericArtifactAttestation(suite.flowName3, suite.trailName, suite.fingerprint3, "failing-attestation", false, suite.T())
 	require.NoError(suite.T(), err)
+
+	// Setup for for_control policy evaluation tests
+	suite.controlIdentifier = "assert-artifact-ctl"
+	suite.controlPolicyName = "assert-artifact-control-pol"
+	suite.controlEnvName = "assert-artifact-control-env"
+	suite.flowNameForControl = "assert-artifact-control-flow"
+	suite.trailNameNoDecision = "assert-artifact-no-decision-trail"
+	suite.trailNameBadDecision = "assert-artifact-bad-decision-trail"
+	suite.artifact4Path = "testdata/artifacts/AssertArtifactCommandTestSuiteArtifact4.txt"
+	suite.artifact5Path = "testdata/artifacts/AssertArtifactCommandTestSuiteArtifact5.txt"
+
+	CreateControl(global.Org, suite.controlIdentifier, "Test Control For Assert", suite.T())
+	CreatePolicyWithFile(global.Org, suite.controlPolicyName, "testdata/policy-files/test-policy-for-control.yml", suite.T())
+	CreateEnv(global.Org, suite.controlEnvName, "server", suite.T())
+	AttachPolicy([]string{suite.controlEnvName}, suite.controlPolicyName, suite.T())
+
+	CreateFlow(suite.flowNameForControl, suite.T())
+
+	BeginTrail(suite.trailNameNoDecision, suite.flowNameForControl, "", suite.T())
+	suite.fingerprint4, err = GetSha256Digest(suite.artifact4Path, fingerprintOptions, logger)
+	require.NoError(suite.T(), err)
+	CreateArtifactOnTrail(suite.flowNameForControl, suite.trailNameNoDecision, "cli", suite.fingerprint4, "arti-no-decision", suite.T())
+
+	BeginTrail(suite.trailNameBadDecision, suite.flowNameForControl, "", suite.T())
+	suite.fingerprint5, err = GetSha256Digest(suite.artifact5Path, fingerprintOptions, logger)
+	require.NoError(suite.T(), err)
+	CreateArtifactOnTrail(suite.flowNameForControl, suite.trailNameBadDecision, "cli", suite.fingerprint5, "arti-bad-decision", suite.T())
+	CreateDecisionAttestation(suite.flowNameForControl, suite.trailNameBadDecision, suite.controlIdentifier, "decision", false, suite.T())
 }
 
 func (suite *AssertArtifactCommandTestSuite) TestAssertArtifactCmd() {
@@ -198,6 +237,18 @@ func (suite *AssertArtifactCommandTestSuite) TestAssertArtifactCmd() {
 			name:        "17 asserting a single existing non-compliant artifact (using --artifact-type) results in non-zero exit",
 			cmd:         fmt.Sprintf(`assert artifact %s --artifact-type file %s`, suite.artifact3Path, suite.defaultKosliArguments),
 			goldenRegex: "^Error: NON-COMPLIANT\n",
+		},
+		{
+			wantError:   true,
+			name:        "18 asserting artifact against env policy with for_control reports control ID when decision is missing",
+			cmd:         fmt.Sprintf(`assert artifact --fingerprint %s --environment %s %s`, suite.fingerprint4, suite.controlEnvName, suite.defaultKosliArguments),
+			goldenRegex: fmt.Sprintf("(?s).*artifact is missing required decision for control '%v'.*", suite.controlIdentifier),
+		},
+		{
+			wantError:   true,
+			name:        "19 asserting artifact against env policy with for_control reports control ID when decision is non-compliant",
+			cmd:         fmt.Sprintf(`assert artifact --fingerprint %s --environment %s %s`, suite.fingerprint5, suite.controlEnvName, suite.defaultKosliArguments),
+			goldenRegex: fmt.Sprintf("(?s).*decision for control '%v' is non-compliant in trail.*", suite.controlIdentifier),
 		},
 	}
 

--- a/cmd/kosli/testHelpers.go
+++ b/cmd/kosli/testHelpers.go
@@ -551,6 +551,44 @@ func CreatePolicy(org, policyName string, t *testing.T) {
 	require.NoError(t, err, "policy should be created without error")
 }
 
+// CreatePolicyWithFile creates a policy on the server using the given policy file.
+func CreatePolicyWithFile(org, policyName, policyFilePath string, t *testing.T) {
+	t.Helper()
+	o := &createPolicyOptions{
+		payload: PolicyPayload{
+			Name:        policyName,
+			Type:        "env",
+			Description: "test policy",
+		},
+	}
+
+	err := o.run([]string{policyName, policyFilePath})
+	require.NoError(t, err, "policy should be created without error")
+}
+
+// CreateDecisionAttestation records a decision attestation against a trail.
+func CreateDecisionAttestation(flowName, trailName, controlID, attestationName string, compliant bool, t *testing.T) {
+	t.Helper()
+	o := &attestDecisionOptions{
+		CommonAttestationOptions: &CommonAttestationOptions{
+			flowName:                flowName,
+			trailName:               trailName,
+			fingerprintOptions:      &fingerprintOptions{},
+			attestationNameTemplate: attestationName,
+		},
+		payload: DecisionAttestationPayload{
+			CommonAttestationPayload: &CommonAttestationPayload{},
+			TypeName:                 "decision",
+			Control:                  controlID,
+			AttestationData: DecisionAttestationData{
+				Compliant: compliant,
+			},
+		},
+	}
+	err := o.run([]string{})
+	require.NoError(t, err, "decision attestation should be created without error")
+}
+
 func AttachPolicy(envNames []string, policyName string, t *testing.T) {
 	t.Helper()
 	o := &attachPolicyOptions{

--- a/cmd/kosli/testHelpers.go
+++ b/cmd/kosli/testHelpers.go
@@ -539,16 +539,7 @@ func CreateControl(org, identifier, name string, t *testing.T) {
 // CreatePolicy creates a policy on the server
 func CreatePolicy(org, policyName string, t *testing.T) {
 	t.Helper()
-	o := &createPolicyOptions{
-		payload: PolicyPayload{
-			Name:        policyName,
-			Type:        "env",
-			Description: "test policy",
-		},
-	}
-
-	err := o.run([]string{policyName, "testdata/policy-files/test-policy.yml"})
-	require.NoError(t, err, "policy should be created without error")
+	CreatePolicyWithFile(org, policyName, "testdata/policy-files/test-policy.yml", t)
 }
 
 // CreatePolicyWithFile creates a policy on the server using the given policy file.

--- a/cmd/kosli/testdata/artifacts/AssertArtifactCommandTestSuiteArtifact4.txt
+++ b/cmd/kosli/testdata/artifacts/AssertArtifactCommandTestSuiteArtifact4.txt
@@ -1,0 +1,1 @@
+artifact for AssertArtifactCommandTestSuite missing-decision test

--- a/cmd/kosli/testdata/artifacts/AssertArtifactCommandTestSuiteArtifact5.txt
+++ b/cmd/kosli/testdata/artifacts/AssertArtifactCommandTestSuiteArtifact5.txt
@@ -1,0 +1,1 @@
+artifact for AssertArtifactCommandTestSuite non-compliant-decision test

--- a/cmd/kosli/testdata/policy-files/test-policy-for-control.yml
+++ b/cmd/kosli/testdata/policy-files/test-policy-for-control.yml
@@ -1,0 +1,9 @@
+_schema: https://kosli.com/schemas/policy/environment/v1
+
+artifacts:
+  provenance:
+    required: true
+  attestations:
+    - name: decision
+      type: decision
+      for_control: assert-artifact-ctl


### PR DESCRIPTION
## Summary

Closes the CLI portion of kosli-dev/server#5700.

- In `printAssertAsTable`, checks the resolution `context` for `for_control` on each `missing_attestation` and `non_compliant_attestation` resolution. When present, outputs control-specific failure messages:
  - `artifact is missing required decision for control '<id>'`
  - `decision for control '<id>' is non-compliant in trail`
- Existing messages are unchanged when `for_control` is absent (backwards-compatible — nil-map reads in Go return the zero value so no panic).

Server-side change that surfaces `for_control` in the response: kosli-dev/server#5814.

## Test plan

- [x] `go vet ./cmd/kosli/` — clean
- [x] `make build` — clean
- [ ] `make test_integration_single TARGET=AssertArtifactCommandTestSuite` — two new test cases (18, 19) verify the control identifier appears in the failure output for missing and non-compliant decision scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)