### PR TITLE
feat: add linux/s390x build target to release distribution

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,16 +25,22 @@ builds:
       - amd64
       - arm64
       - arm
+      - s390x
     ignore:
       - goos: windows
         goarch: arm
+      - goos: windows
+        goarch: s390x
+      - goos: darwin
+        goarch: s390x
     main: ./cmd/kosli/
     hooks:
       post:
         - cmd: >-
             bash -c '
-            OS="{{ .Os }}";
             ARCH="{{ .Arch }}";
+            if [ "$ARCH" = "s390x" ]; then exit 0; fi;
+            OS="{{ .Os }}";
             [ "$OS" = "windows" ] && OS="win32";
             [ "$ARCH" = "amd64" ] && ARCH="x64";
             EXT="";


### PR DESCRIPTION
## Summary
- Add `linux/s390x` to the GoReleaser build matrix so IBM Z users can install the CLI natively
- Ignore `s390x` for `darwin` and `windows` (not supported / not needed)
- Skip the npm post-hook for `s390x` since we don't publish an npm package for that arch

Closes #929

## Test plan
- [x] `GOOS=linux GOARCH=s390x CGO_ENABLED=0 go build` produces a 64-bit s390x ELF binary
- [x] Binary runs under qemu in `s390x/alpine` Docker container; `kosli --version` succeeds
- [ ] Next release publishes `linux/s390x` archive + `.deb` / `.rpm` artifacts