### PR TITLE
fix(deps): bump go to 1.26.4 to address stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kosli-dev/cli
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cloud.google.com/go/run v1.21.0


### PR DESCRIPTION
## Summary
Bumps the Go directive in \`go.mod\` from 1.26.3 → 1.26.4 to resolve Snyk-flagged Go stdlib vulnerabilities:

- \`SNYK-GOLANG-STDCRYPTOX509-17135840\` (crypto/x509)
- \`SNYK-GOLANG-STDMIME-17135844\` (mime)
- \`SNYK-GOLANG-STDNETTEXTPROTO-17135843\` (net/textproto)

All three are fixed in Go 1.26.4.

## Test plan
- [x] CI passes (Snyk Dependency Test green)
- [x] No code changes required; stdlib upgrade only