### PR TITLE
fix: use git short sha as version metadata for unreleased builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ ifneq ($(BINARY_VERSION),)
 	LDFLAGS += -X github.com/kosli-dev/cli/internal/version.version=${BINARY_VERSION}
 endif
 
-VERSION_METADATA = unreleased
-# Clear the "unreleased" string in BuildMetadata
+VERSION_METADATA = $(GIT_SHA)
+# Clear the short-sha BuildMetadata for tagged releases
 ifneq ($(GIT_TAG),)
 	VERSION_METADATA =
 endif


### PR DESCRIPTION
Non-released builds reported a user agent of "Kosli/dev+unreleased".
Use the git short sha instead so dev builds identify their commit,
e.g. "Kosli/dev+2c570769". Tagged releases are unaffected.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
