### PR TITLE
feat: add s390x support to install-cli.sh

### DIFF
--- a/install-cli.sh
+++ b/install-cli.sh
@@ -150,9 +150,13 @@ else
             ARCH="arm64"
             debug_print "Mapped to ARM64 architecture"
             ;;
+        s390x)
+            ARCH="s390x"
+            debug_print "Mapped to s390x architecture"
+            ;;
         *)
             echo "Error: Unsupported Linux architecture: $MACHINE_TYPE"
-            echo "Kosli CLI is only available for amd64 and arm64 on Linux."
+            echo "Kosli CLI is only available for amd64, arm64, and s390x on Linux."
             exit 1
             ;;
     esac


### PR DESCRIPTION
## Summary
- Map the `s390x` machine type to the `s390x` release asset in `install-cli.sh`
- Update the unsupported-arch error message to list s390x alongside amd64 and arm64

The `linux/s390x` build target was added in 4acd31e9, but the install script still rejected the architecture, forcing s390x users to download the tarball manually.

## Test plan
- [x] Run `install-cli.sh` on a linux/s390x host and verify it downloads `kosli_<version>_linux_s390x.tar.gz` and installs successfully
- [x] Confirm existing amd64 / arm64 / darwin / windows paths still work