### PR TITLE
feat: add short aliases to top-level verb commands

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -68,6 +68,8 @@ jobs:
 
             Use `gh pr comment --edit-last --create-if-none` for top-level feedback,
             so the summary replaces the previous run's summary instead of stacking.
+            The posted comment body must contain only the review content —
+            no branch name, commit hash, or other metadata appended at the end.
             Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues.
             Only post GitHub comments - don't submit review text as messages.
 
@@ -150,5 +152,7 @@ jobs:
 
             Use `gh pr comment --edit-last --create-if-none` for top-level feedback,
             so the summary replaces the previous run's summary instead of stacking.
+            The posted comment body must contain only the review content —
+            no branch name, commit hash, or other metadata appended at the end.
             Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues.
             Only post GitHub comments - don't submit review text as messages.

--- a/cmd/kosli/disable.go
+++ b/cmd/kosli/disable.go
@@ -10,9 +10,10 @@ const disableDesc = `Kosli disable commands.`
 
 func newDisableCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "disable",
-		Short: disableDesc,
-		Long:  disableDesc,
+		Use:     "disable",
+		Aliases: []string{"dis"},
+		Short:   disableDesc,
+		Long:    disableDesc,
 	}
 
 	// Add subcommands

--- a/cmd/kosli/enable.go
+++ b/cmd/kosli/enable.go
@@ -10,9 +10,10 @@ const enableDesc = `Kosli enable commands.`
 
 func newEnableCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "enable",
-		Short: enableDesc,
-		Long:  enableDesc,
+		Use:     "enable",
+		Aliases: []string{"en"},
+		Short:   enableDesc,
+		Long:    enableDesc,
 	}
 
 	// Add subcommands

--- a/cmd/kosli/get.go
+++ b/cmd/kosli/get.go
@@ -10,9 +10,10 @@ const getDesc = `All Kosli get commands.`
 
 func newGetCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "get",
-		Short: getDesc,
-		Long:  getDesc,
+		Use:     "get",
+		Aliases: []string{"g"},
+		Short:   getDesc,
+		Long:    getDesc,
 	}
 
 	// Add subcommands

--- a/cmd/kosli/log.go
+++ b/cmd/kosli/log.go
@@ -10,9 +10,10 @@ const logDesc = `All Kosli log commands.`
 
 func newLogCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "log",
-		Short: logDesc,
-		Long:  logDesc,
+		Use:     "log",
+		Aliases: []string{"lo"},
+		Short:   logDesc,
+		Long:    logDesc,
 	}
 
 	// Add subcommands

--- a/cmd/kosli/rename.go
+++ b/cmd/kosli/rename.go
@@ -10,9 +10,10 @@ const renameDesc = `All Kosli rename commands.`
 
 func newRenameCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "rename",
-		Short: renameDesc,
-		Long:  renameDesc,
+		Use:     "rename",
+		Aliases: []string{"re"},
+		Short:   renameDesc,
+		Long:    renameDesc,
 	}
 
 	// Add subcommands

--- a/cmd/kosli/report.go
+++ b/cmd/kosli/report.go
@@ -11,6 +11,7 @@ const reportDesc = `All Kosli report commands.`
 func newReportCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:        "report",
+		Aliases:    []string{"r", "rep"},
 		Short:      reportDesc,
 		Long:       reportDesc,
 		Deprecated: "this command is deprecated and will be removed in a future release.",

--- a/cmd/kosli/report.go
+++ b/cmd/kosli/report.go
@@ -11,7 +11,6 @@ const reportDesc = `All Kosli report commands.`
 func newReportCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:        "report",
-		Aliases:    []string{"r", "rep"},
 		Short:      reportDesc,
 		Long:       reportDesc,
 		Deprecated: "this command is deprecated and will be removed in a future release.",

--- a/cmd/kosli/search.go
+++ b/cmd/kosli/search.go
@@ -77,6 +77,7 @@ func newSearchCmd(out io.Writer) *cobra.Command {
 	o := new(searchOptions)
 	cmd := &cobra.Command{
 		Use:     "search {GIT-COMMIT | FINGERPRINT}",
+		Aliases: []string{"se"},
 		Short:   searchShortDesc,
 		Long:    searchLongDesc,
 		Example: searchExample,

--- a/cmd/kosli/status.go
+++ b/cmd/kosli/status.go
@@ -24,7 +24,7 @@ func newStatusCmd(out io.Writer) *cobra.Command {
 	o := new(statusOptions)
 	cmd := &cobra.Command{
 		Use:     "status",
-		Aliases: []string{"s", "st"},
+		Aliases: []string{"st"},
 		Short:   statusShortDesc,
 		Long:    statusLongDesc,
 		Args:    cobra.NoArgs,

--- a/cmd/kosli/status.go
+++ b/cmd/kosli/status.go
@@ -23,10 +23,11 @@ type statusOptions struct {
 func newStatusCmd(out io.Writer) *cobra.Command {
 	o := new(statusOptions)
 	cmd := &cobra.Command{
-		Use:   "status",
-		Short: statusShortDesc,
-		Long:  statusLongDesc,
-		Args:  cobra.NoArgs,
+		Use:     "status",
+		Aliases: []string{"s", "st"},
+		Short:   statusShortDesc,
+		Long:    statusLongDesc,
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return o.run(out)
 		},


### PR DESCRIPTION
Introduce new verb aliases: `get: g; rename: re; disable: dis; enable: en; log: lo; status: st`

No alias collides with an existing command name or alias.