### PR TITLE
fix(api-keys): inline confirmation prompt and unify message style

### DIFF
--- a/cmd/kosli/apiKey_test.go
+++ b/cmd/kosli/apiKey_test.go
@@ -218,7 +218,7 @@ func (suite *ApiKeyCommandTestSuite) TestDeleteApiKeyCmd() {
 			wantError: false,
 			name:      "delete without confirmation (empty stdin) is cancelled and makes no call",
 			cmd:       "delete api-key key-123 --service-account test-sa" + suite.defaultKosliArguments,
-			golden:    "Are you sure you want to delete API key(s) key-123 for service account test-sa? [y/N] Deletion of API key(s) key-123 was cancelled!\n",
+			golden:    "Are you sure you want to delete API key(s) key-123 for service account test-sa? [y/N] Deletion of API key(s) key-123 was cancelled.\n",
 		},
 		{
 			wantError:   false,

--- a/cmd/kosli/apiKey_test.go
+++ b/cmd/kosli/apiKey_test.go
@@ -218,7 +218,7 @@ func (suite *ApiKeyCommandTestSuite) TestDeleteApiKeyCmd() {
 			wantError: false,
 			name:      "delete without confirmation (empty stdin) is cancelled and makes no call",
 			cmd:       "delete api-key key-123 --service-account test-sa" + suite.defaultKosliArguments,
-			golden:    "Are you sure you want to delete API key(s) key-123 for service account test-sa? [y/N]\ndeletion of API key(s) key-123 was cancelled\n",
+			golden:    "Are you sure you want to delete API key(s) key-123 for service account test-sa? [y/N] Deletion of API key(s) key-123 was cancelled!\n",
 		},
 		{
 			wantError:   false,
@@ -360,7 +360,7 @@ func (suite *ApiKeyCommandTestSuite) TestDeletePartialFailure() {
 			wantError:   true,
 			name:        "delete reports deleted keys before a later key fails",
 			cmd:         "delete api-key k1 k2 -s test-sa --assume-yes" + args,
-			goldenRegex: `(?s)API key k1 for service account test-sa was deleted.*already deleted before this failure: k1.*failed to delete API key k2.*API key not found`,
+			goldenRegex: `(?s)API key k1 for service account test-sa was deleted!.*already deleted before this failure: k1.*failed to delete API key k2.*API key not found`,
 		},
 	}
 

--- a/cmd/kosli/deleteApiKey.go
+++ b/cmd/kosli/deleteApiKey.go
@@ -90,21 +90,16 @@ func (o *deleteApiKeyOptions) run(out io.Writer, in io.Reader, args []string) er
 			return err
 		}
 		if !confirmed {
-			logger.Info("deletion of API key(s) %s was cancelled", strings.Join(args, ", "))
+			logger.Info("Deletion of API key(s) %s was cancelled!", strings.Join(styleApiKeyIDs(out, args), ", "))
 			return nil
 		}
 	}
 
 	// deletion is destructive and one-way: on any failure mid-batch, make clear
-	// which keys were already deleted before it (user-facing, styled green), while
-	// keeping the returned error plain (no ANSI).
+	// which keys were already deleted before it.
 	reportAlreadyDeleted := func(i int) {
 		if i > 0 {
-			deleted := make([]string, i)
-			for j, k := range args[:i] {
-				deleted[j] = style(out, k, ansiBold, ansiGreen)
-			}
-			logger.Info("keys already deleted before this failure: %s", strings.Join(deleted, ", "))
+			logger.Info("keys already deleted before this failure: %s", strings.Join(styleApiKeyIDs(out, args[:i]), ", "))
 		}
 	}
 
@@ -126,22 +121,30 @@ func (o *deleteApiKeyOptions) run(out io.Writer, in io.Reader, args []string) er
 			return fmt.Errorf("failed to delete API key %s: %w", keyID, err)
 		}
 		if !global.DryRun {
-			logger.Info("API key %s for service account %s was deleted", style(out, keyID, ansiBold, ansiGreen), o.serviceAccount)
+			logger.Info("API key %s for service account %s was deleted!", style(out, keyID, ansiBold, ansiCyan), o.serviceAccount)
 		}
 	}
 	return nil
 }
 
-// confirmApiKeyDeletion prompts the user to confirm deletion and returns true
-// only when the answer is an affirmative "y"/"yes" (case-insensitive).
-func confirmApiKeyDeletion(keyIDs []string, serviceAccount string, out io.Writer, in io.Reader) (bool, error) {
+// styleApiKeyIDs styles key IDs for user-facing messages (bold cyan when
+// styling is enabled for out).
+func styleApiKeyIDs(out io.Writer, keyIDs []string) []string {
 	styledKeys := make([]string, len(keyIDs))
 	for i, keyID := range keyIDs {
-		styledKeys[i] = style(out, keyID, ansiBold, ansiMagenta)
+		styledKeys[i] = style(out, keyID, ansiBold, ansiCyan)
 	}
+	return styledKeys
+}
 
-	logger.Info("Are you sure you want to delete API key(s) %s for service account %s? [y/N]",
-		strings.Join(styledKeys, ", "), style(out, serviceAccount, ansiBold, ansiGreen))
+// confirmApiKeyDeletion prompts the user to confirm deletion and returns true
+// only when the answer is an affirmative "y"/"yes" (case-insensitive). The
+// prompt has no trailing newline so the answer is typed on the same line.
+func confirmApiKeyDeletion(keyIDs []string, serviceAccount string, out io.Writer, in io.Reader) (bool, error) {
+	if _, err := fmt.Fprintf(out, "Are you sure you want to delete API key(s) %s for service account %s? [y/N] ",
+		strings.Join(styleApiKeyIDs(out, keyIDs), ", "), style(out, serviceAccount, ansiBold, ansiGreen)); err != nil {
+		return false, err
+	}
 
 	answer, err := bufio.NewReader(in).ReadString('\n')
 	if err != nil && err != io.EOF {

--- a/cmd/kosli/deleteApiKey.go
+++ b/cmd/kosli/deleteApiKey.go
@@ -62,7 +62,7 @@ func newDeleteApiKeyCmd(out io.Writer) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return o.run(out, cmd.InOrStdin(), args)
+			return o.run(cmd.InOrStdin(), args)
 		},
 	}
 
@@ -83,14 +83,14 @@ func newDeleteApiKeyCmd(out io.Writer) *cobra.Command {
 	return cmd
 }
 
-func (o *deleteApiKeyOptions) run(out io.Writer, in io.Reader, args []string) error {
+func (o *deleteApiKeyOptions) run(in io.Reader, args []string) error {
 	if !o.assumeYes && !global.DryRun {
-		confirmed, err := confirmApiKeyDeletion(args, o.serviceAccount, out, in)
+		confirmed, err := confirmApiKeyDeletion(args, o.serviceAccount, in)
 		if err != nil {
 			return err
 		}
 		if !confirmed {
-			logger.Info("Deletion of API key(s) %s was cancelled!", strings.Join(styleApiKeyIDs(out, args), ", "))
+			logger.Info("Deletion of API key(s) %s was cancelled.", strings.Join(styleApiKeyIDs(args), ", "))
 			return nil
 		}
 	}
@@ -99,7 +99,7 @@ func (o *deleteApiKeyOptions) run(out io.Writer, in io.Reader, args []string) er
 	// which keys were already deleted before it.
 	reportAlreadyDeleted := func(i int) {
 		if i > 0 {
-			logger.Info("keys already deleted before this failure: %s", strings.Join(styleApiKeyIDs(out, args[:i]), ", "))
+			logger.Info("Keys already deleted before this failure: %s", strings.Join(styleApiKeyIDs(args[:i]), ", "))
 		}
 	}
 
@@ -121,18 +121,18 @@ func (o *deleteApiKeyOptions) run(out io.Writer, in io.Reader, args []string) er
 			return fmt.Errorf("failed to delete API key %s: %w", keyID, err)
 		}
 		if !global.DryRun {
-			logger.Info("API key %s for service account %s was deleted!", style(out, keyID, ansiBold, ansiCyan), o.serviceAccount)
+			logger.Info("API key %s for service account %s was deleted!", style(logger.Out, keyID, ansiBold, ansiCyan), o.serviceAccount)
 		}
 	}
 	return nil
 }
 
-// styleApiKeyIDs styles key IDs for user-facing messages (bold cyan when
-// styling is enabled for out).
-func styleApiKeyIDs(out io.Writer, keyIDs []string) []string {
+// styleApiKeyIDs styles key IDs for user-facing messages printed via logger
+// (bold cyan when styling is enabled for the logger's info stream).
+func styleApiKeyIDs(keyIDs []string) []string {
 	styledKeys := make([]string, len(keyIDs))
 	for i, keyID := range keyIDs {
-		styledKeys[i] = style(out, keyID, ansiBold, ansiCyan)
+		styledKeys[i] = style(logger.Out, keyID, ansiBold, ansiCyan)
 	}
 	return styledKeys
 }
@@ -140,11 +140,9 @@ func styleApiKeyIDs(out io.Writer, keyIDs []string) []string {
 // confirmApiKeyDeletion prompts the user to confirm deletion and returns true
 // only when the answer is an affirmative "y"/"yes" (case-insensitive). The
 // prompt has no trailing newline so the answer is typed on the same line.
-func confirmApiKeyDeletion(keyIDs []string, serviceAccount string, out io.Writer, in io.Reader) (bool, error) {
-	if _, err := fmt.Fprintf(out, "Are you sure you want to delete API key(s) %s for service account %s? [y/N] ",
-		strings.Join(styleApiKeyIDs(out, keyIDs), ", "), style(out, serviceAccount, ansiBold, ansiGreen)); err != nil {
-		return false, err
-	}
+func confirmApiKeyDeletion(keyIDs []string, serviceAccount string, in io.Reader) (bool, error) {
+	logger.Print("Are you sure you want to delete API key(s) %s for service account %s? [y/N] ",
+		strings.Join(styleApiKeyIDs(keyIDs), ", "), style(logger.Out, serviceAccount, ansiBold, ansiGreen))
 
 	answer, err := bufio.NewReader(in).ReadString('\n')
 	if err != nil && err != io.EOF {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -70,3 +70,9 @@ func (l *Logger) Info(format string, v ...interface{}) {
 	format = fmt.Sprintf("%s\n", format)
 	l.infoLog.Printf(format, v...)
 }
+
+// Print writes to the info output without appending a trailing newline
+// (log.Logger always appends one), e.g. for inline prompts.
+func (l *Logger) Print(format string, v ...interface{}) {
+	_, _ = fmt.Fprintf(l.infoLog.Writer(), format, v...)
+}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -37,18 +37,46 @@ func TestWarnEmittedWhenQuietDisabled(t *testing.T) {
 	}
 }
 
-func TestQuietDoesNotSuppressInfoOrDebug(t *testing.T) {
+func TestPrintWritesToInfoOutWithoutTrailingNewline(t *testing.T) {
+	var out, errOut bytes.Buffer
+	l := logger.NewLogger(&out, &errOut, false)
+
+	l.Print("answer? [y/N] ")
+	l.Print("key %s", "k1")
+
+	if out.String() != "answer? [y/N] key k1" {
+		t.Fatalf("expected raw output without newlines, got %q", out.String())
+	}
+}
+
+func TestPrintFollowsSetInfoOut(t *testing.T) {
+	var out, redirected bytes.Buffer
+	l := logger.NewLogger(&out, &out, false)
+	l.SetInfoOut(&redirected)
+
+	l.Print("prompt")
+
+	if out.Len() != 0 || redirected.String() != "prompt" {
+		t.Fatalf("expected output on redirected stream, got out=%q redirected=%q", out.String(), redirected.String())
+	}
+}
+
+func TestQuietDoesNotSuppressInfoDebugOrPrint(t *testing.T) {
 	var out, errOut bytes.Buffer
 	l := logger.NewLogger(&out, &errOut, true)
 	l.QuietEnabled = true
 
 	l.Info("hello")
 	l.Debug("debug-line")
+	l.Print("prompt-line")
 
 	if !strings.Contains(out.String(), "hello") {
 		t.Fatalf("expected info preserved, got %q", out.String())
 	}
 	if !strings.Contains(errOut.String(), "[debug] debug-line") {
 		t.Fatalf("expected debug preserved, got %q", errOut.String())
+	}
+	if !strings.Contains(out.String(), "prompt-line") {
+		t.Fatalf("expected print preserved, got %q", out.String())
 	}
 }


### PR DESCRIPTION
* The prompt no longer ends with a newline, so the answer is typed on the same line. The cancellation message is now capitalised and the key IDs use the same styling as the prompt.
* Add new logger helper to print without trailing new line.