### PR TITLE
docs(attest jira): improve CVE/multi-segment filtering help text

### DIFF
--- a/cmd/kosli/attestJira.go
+++ b/cmd/kosli/attestJira.go
@@ -38,18 +38,22 @@ const attestJiraShortDesc = `Report a jira attestation to an artifact or a trail
 
 const attestJiraLongDesc = attestJiraShortDesc + `
 Parses the given commit's message, current branch name or the content of the ^--jira-secondary-source^
-argument for Jira issue references of the form:  
+argument for Jira issue references of the form:
 'at least 2 characters long, starting with an uppercase letter project key followed by
 dash and one or more digits'.
+
+Any candidate match is automatically excluded if every occurrence in the parsed text is
+immediately followed by a hyphen and a digit — for example, ^CVE-2026-41284^ is excluded
+because ^CVE-2026^ would be followed by ^-4^. This applies across all parsed sources
+(commit message, branch name, and secondary source).
+Note: if your Jira project key itself matches this pattern (e.g. a project key of ^CVE^),
+its references will be filtered out. Use ^--jira-secondary-source^ with a different identifier
+format as a workaround.
 
 If you want to restrict the Jira issue matching to a specific project, use the
 ^--jira-project-key^ flag to specify your own project key. You can specify multiple project keys if needed.
 
 If the ^--ignore-branch-match^ is set, the branch name is not parsed for a match.
-
-Multi-segment identifiers such as CVE numbers (e.g. ^CVE-2026-41284^) are automatically
-excluded from matching — a candidate is discarded if every occurrence in the text is
-immediately followed by another ^-<digit>^ segment.
 
 The found issue references will be checked against Jira to confirm their existence.
 The attestation is reported in all cases, and its compliance status depends on referencing

--- a/cmd/kosli/attestJira.go
+++ b/cmd/kosli/attestJira.go
@@ -47,6 +47,10 @@ If you want to restrict the Jira issue matching to a specific project, use the
 
 If the ^--ignore-branch-match^ is set, the branch name is not parsed for a match.
 
+Multi-segment identifiers such as CVE numbers (e.g. ^CVE-2026-41284^) are automatically
+excluded from matching — a candidate is discarded if every occurrence in the text is
+immediately followed by another ^-<digit>^ segment.
+
 The found issue references will be checked against Jira to confirm their existence.
 The attestation is reported in all cases, and its compliance status depends on referencing
 existing Jira issues.  

--- a/cmd/kosli/attestJira.go
+++ b/cmd/kosli/attestJira.go
@@ -46,8 +46,9 @@ Any candidate match is automatically excluded if every occurrence in the parsed 
 immediately followed by a hyphen and a digit — for example, ^CVE-2026-41284^ is excluded
 because ^CVE-2026^ would be followed by ^-4^. This applies across all parsed sources
 (commit message, branch name, and secondary source).
-Note: if your Jira project key itself matches this pattern (e.g. a project key of ^CVE^),
-its references will be filtered out. Use ^--jira-secondary-source^ with a different identifier
+Note: if your Jira project key collides with this pattern (e.g. a project key of ^CVE^), an
+issue reference that happens to be the prefix of a longer hyphenated number (such as a CVE
+identifier) will be filtered out. Use ^--jira-secondary-source^ with a different identifier
 format as a workaround.
 
 If you want to restrict the Jira issue matching to a specific project, use the


### PR DESCRIPTION
## Summary

Improves `kosli attest jira --help` to surface the multi-segment identifier filtering behaviour that was previously only visible in internal godoc.

- Moved the filter description earlier so it reads as part of the matching rules (not as a branch-specific note)
- Broadened from CVE-only to any multi-segment match
- Replaced the ambiguous `^-<digit>^` placeholder with plain prose ("a hyphen and a digit")
- Added a warning for teams whose Jira project key itself matches the filter pattern (e.g. project key `CVE`), with a `--jira-secondary-source` workaround

Closes #949

## Test plan

- [ ] `kosli attest jira --help` shows the new paragraph in the correct position
- [ ] Wording is clear and the CVE example is accurate
- [ ] `make lint` passes