### PR TITLE
fix: remove duplicate keyID on failure and add details when failing to rotate API keys

### DIFF
--- a/cmd/kosli/apiKey_test.go
+++ b/cmd/kosli/apiKey_test.go
@@ -332,7 +332,7 @@ func (suite *ApiKeyCommandTestSuite) TestUpdatePartialFailure() {
 			wantError:   true,
 			name:        "rotate prints already-rotated keys then surfaces the error",
 			cmd:         "rotate api-key k1 k2 -s test-sa --output json" + args,
-			goldenRegex: `(?s)sk_one.*Error: API key not found`,
+			goldenRegex: `(?s)sk_one.*Error: failed to rotate API key: API key not found`,
 		},
 	}
 
@@ -360,7 +360,7 @@ func (suite *ApiKeyCommandTestSuite) TestDeletePartialFailure() {
 			wantError:   true,
 			name:        "delete reports deleted keys before a later key fails",
 			cmd:         "delete api-key k1 k2 -s test-sa --assume-yes" + args,
-			goldenRegex: `(?s)API key k1 for service account test-sa was deleted!.*already deleted before this failure: k1.*failed to delete API key k2.*API key not found`,
+			goldenRegex: `(?s)API key k1 for service account test-sa was deleted!.*already deleted before this failure: k1.*failed to delete API key: API key not found`,
 		},
 	}
 
@@ -384,7 +384,7 @@ func (suite *ApiKeyCommandTestSuite) TestDeleteApiKeyNotFound() {
 			wantError:   true,
 			name:        "delete surfaces a 404 from the API as an error",
 			cmd:         "delete api-key missing-key --service-account test-sa --assume-yes" + args,
-			goldenRegex: `(?s)failed to delete API key missing-key.*API key not found`,
+			goldenRegex: `(?s)failed to delete API key: API key not found`,
 		},
 	}
 
@@ -421,7 +421,7 @@ func (suite *ApiKeyCommandTestSuite) TestApiErrorsAreSurfaced() {
 			wantError:   true,
 			name:        "rotate surfaces a 404 from the API as an error",
 			cmd:         "rotate api-key missing-key --service-account test-sa" + args,
-			goldenRegex: `Error: API key not found`,
+			goldenRegex: `Error: failed to rotate API key: API key not found`,
 		},
 		{
 			wantError:   true,

--- a/cmd/kosli/deleteApiKey.go
+++ b/cmd/kosli/deleteApiKey.go
@@ -118,7 +118,7 @@ func (o *deleteApiKeyOptions) run(in io.Reader, args []string) error {
 		}
 		if _, err := kosliClient.Do(reqParams); err != nil {
 			reportAlreadyDeleted(i)
-			return fmt.Errorf("failed to delete API key %s: %w", keyID, err)
+			return fmt.Errorf("failed to delete API key: %w", err)
 		}
 		if !global.DryRun {
 			logger.Info("API key %s for service account %s was deleted!", style(logger.Out, keyID, ansiBold, ansiCyan), o.serviceAccount)

--- a/cmd/kosli/rotateApiKey.go
+++ b/cmd/kosli/rotateApiKey.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -125,7 +126,7 @@ func (o *rotateApiKeyOptions) run(out io.Writer, args []string) error {
 		}
 		response, err := kosliClient.Do(reqParams)
 		if err != nil {
-			runErr = err
+			runErr = fmt.Errorf("failed to rotate API key: %w", err)
 			break
 		}
 		if !global.DryRun {


### PR DESCRIPTION
Couple of small cosmetic fixes, following server fix to properly report API errors now.