### PR TITLE
fix: record git author identity and authored timestamp in PR attestations across providers (server#5479)

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -13,3 +13,7 @@ exclude:
   global:
     - internal/azure/azure_apps.go
     - cmd/kosli/root.go
+    # False positive: Snyk Code flags the GitHub username in this test fixture
+    # (a graphql `Login` field) as a hardcoded credential. It is a public
+    # identifier in test data, not a secret. See kosli-dev/server#5479.
+    - internal/github/build_pr_evidence_test.go

--- a/internal/azure/azure.go
+++ b/internal/azure/azure.go
@@ -168,13 +168,13 @@ func (c *AzureConfig) GetPullRequestCommits(pr git.GitPullRequest) ([]types.Comm
 
 	for _, commit := range prCommitsResponse.Value {
 		commits = append(commits, types.Commit{
-			SHA:               *commit.CommitId,
-			Message:           *commit.Comment,
-			Committer:         *commit.Author.Name,
-			Timestamp:         commit.Committer.Date.Time.Unix(),
-			URL:               *commit.Url,
-			Branch:            *pr.SourceRefName,
-			CommitterUsername: *commit.Committer.Name,
+			SHA:            *commit.CommitId,
+			Message:        *commit.Comment,
+			Author:         *commit.Author.Name,
+			Timestamp:      commit.Committer.Date.Time.Unix(),
+			URL:            *commit.Url,
+			Branch:         *pr.SourceRefName,
+			AuthorUsername: *commit.Committer.Name,
 		})
 	}
 

--- a/internal/azure/azure.go
+++ b/internal/azure/azure.go
@@ -178,12 +178,10 @@ func commitFromAzureCommit(commit git.GitCommitRef, branch string) types.Commit 
 	return types.Commit{
 		SHA:       *commit.CommitId,
 		Message:   *commit.Comment,
-		Author:    *commit.Author.Name,
+		Author:    fmt.Sprintf("%s <%s>", *commit.Author.Name, *commit.Author.Email),
 		Timestamp: commit.Committer.Date.Time.Unix(),
 		URL:       *commit.Url,
 		Branch:    branch,
-		// TODO(server#5479): AuthorUsername is sourced from the committer; should be the author.
-		AuthorUsername: *commit.Committer.Name,
 	}
 }
 

--- a/internal/azure/azure.go
+++ b/internal/azure/azure.go
@@ -168,12 +168,13 @@ func (c *AzureConfig) GetPullRequestCommits(pr git.GitPullRequest) ([]types.Comm
 
 	for _, commit := range prCommitsResponse.Value {
 		commits = append(commits, types.Commit{
-			SHA:            *commit.CommitId,
-			Message:        *commit.Comment,
-			Author:         *commit.Author.Name,
-			Timestamp:      commit.Committer.Date.Time.Unix(),
-			URL:            *commit.Url,
-			Branch:         *pr.SourceRefName,
+			SHA:       *commit.CommitId,
+			Message:   *commit.Comment,
+			Author:    *commit.Author.Name,
+			Timestamp: commit.Committer.Date.Time.Unix(),
+			URL:       *commit.Url,
+			Branch:    *pr.SourceRefName,
+			// TODO(server#5479): AuthorUsername is sourced from the committer; should be the author.
 			AuthorUsername: *commit.Committer.Name,
 		})
 	}

--- a/internal/azure/azure.go
+++ b/internal/azure/azure.go
@@ -167,19 +167,24 @@ func (c *AzureConfig) GetPullRequestCommits(pr git.GitPullRequest) ([]types.Comm
 	}
 
 	for _, commit := range prCommitsResponse.Value {
-		commits = append(commits, types.Commit{
-			SHA:       *commit.CommitId,
-			Message:   *commit.Comment,
-			Author:    *commit.Author.Name,
-			Timestamp: commit.Committer.Date.Time.Unix(),
-			URL:       *commit.Url,
-			Branch:    *pr.SourceRefName,
-			// TODO(server#5479): AuthorUsername is sourced from the committer; should be the author.
-			AuthorUsername: *commit.Committer.Name,
-		})
+		commits = append(commits, commitFromAzureCommit(commit, *pr.SourceRefName))
 	}
 
 	return commits, nil
+}
+
+// commitFromAzureCommit maps an Azure DevOps API commit to a types.Commit.
+func commitFromAzureCommit(commit git.GitCommitRef, branch string) types.Commit {
+	return types.Commit{
+		SHA:       *commit.CommitId,
+		Message:   *commit.Comment,
+		Author:    *commit.Author.Name,
+		Timestamp: commit.Committer.Date.Time.Unix(),
+		URL:       *commit.Url,
+		Branch:    branch,
+		// TODO(server#5479): AuthorUsername is sourced from the committer; should be the author.
+		AuthorUsername: *commit.Committer.Name,
+	}
 }
 
 // PullRequestsForCommit returns a list of pull requests for a specific commit

--- a/internal/azure/azure.go
+++ b/internal/azure/azure.go
@@ -179,7 +179,7 @@ func commitFromAzureCommit(commit git.GitCommitRef, branch string) types.Commit 
 		SHA:       *commit.CommitId,
 		Message:   *commit.Comment,
 		Author:    fmt.Sprintf("%s <%s>", *commit.Author.Name, *commit.Author.Email),
-		Timestamp: commit.Committer.Date.Time.Unix(),
+		Timestamp: commit.Author.Date.Time.Unix(),
 		URL:       *commit.Url,
 		Branch:    branch,
 	}

--- a/internal/azure/commit_mapping_test.go
+++ b/internal/azure/commit_mapping_test.go
@@ -1,0 +1,45 @@
+package azure
+
+import (
+	"testing"
+	"time"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/git"
+	"github.com/stretchr/testify/require"
+)
+
+func azStr(s string) *string { return &s }
+
+func azTestCommit() git.GitCommitRef {
+	authorDate := azuredevops.Time{Time: time.Unix(1772630000, 0)}
+	committerDate := azuredevops.Time{Time: time.Unix(1772635812, 0)}
+	return git.GitCommitRef{
+		CommitId: azStr("abc1230000000000000000000000000000000000"),
+		Comment:  azStr("Apply suggestions from code review"),
+		Url:      azStr("https://dev.azure.com/kosli/_git/x/commit/abc123"),
+		Author: &git.GitUserDate{
+			Name:  azStr("Steve Tooke"),
+			Email: azStr("tooky@kosli.com"),
+			Date:  &authorDate,
+		},
+		Committer: &git.GitUserDate{
+			Name:  azStr("GitHub"),
+			Email: azStr("noreply@github.com"),
+			Date:  &committerDate,
+		},
+	}
+}
+
+// TestCommitFromAzureCommit_RecordsAuthorIdentity is a regression test for
+// server#5479. Azure recorded the author display name only, and populated
+// author_username from the committer. Record the author as "Name <email>",
+// and drop author_username (Azure commits carry no login).
+func TestCommitFromAzureCommit_RecordsAuthorIdentity(t *testing.T) {
+	c := commitFromAzureCommit(azTestCommit(), "my-branch")
+
+	require.Equal(t, "Steve Tooke <tooky@kosli.com>", c.Author,
+		"author must be name <email> of the git author")
+	require.Empty(t, c.AuthorUsername,
+		"Azure commits carry no login; author_username must be omitted, not the committer name")
+}

--- a/internal/azure/commit_mapping_test.go
+++ b/internal/azure/commit_mapping_test.go
@@ -43,3 +43,12 @@ func TestCommitFromAzureCommit_RecordsAuthorIdentity(t *testing.T) {
 	require.Empty(t, c.AuthorUsername,
 		"Azure commits carry no login; author_username must be omitted, not the committer name")
 }
+
+// TestCommitFromAzureCommit_UsesAuthorDate is a regression test for server#5479:
+// the timestamp must match the recorded author identity.
+func TestCommitFromAzureCommit_UsesAuthorDate(t *testing.T) {
+	c := commitFromAzureCommit(azTestCommit(), "my-branch")
+
+	require.Equal(t, int64(1772630000), c.Timestamp,
+		"timestamp must be the author date, not the committer date")
+}

--- a/internal/bitbucket/bitbucket.go
+++ b/internal/bitbucket/bitbucket.go
@@ -243,7 +243,7 @@ func (c *Config) getPullRequestCommitsFromBitbucket(prID int) ([]types.Commit, e
 			allCommits = append(allCommits, types.Commit{
 				SHA:       commit["hash"].(string),
 				Message:   commit["message"].(string),
-				Committer: commit["author"].(map[string]any)["raw"].(string),
+				Author:    commit["author"].(map[string]any)["raw"].(string),
 				Timestamp: timestamp,
 				URL:       commit["links"].(map[string]any)["html"].(map[string]any)["href"].(string),
 			})

--- a/internal/github/build_pr_evidence_test.go
+++ b/internal/github/build_pr_evidence_test.go
@@ -21,12 +21,9 @@ func TestBuildPREvidence_RecordsAuthorNotCommitter(t *testing.T) {
 	node.Commit.CommittedDate = "2026-03-01T12:00:00Z"
 	node.Commit.URL = "https://github.com/kosli-dev/cli/commit/0e723254516c841126e81f76100be57258ff1386"
 
-	// Committer is GitHub's web-flow identity, with no associated user.
-	node.Commit.Committer.Name = "GitHub"
-	node.Commit.Committer.Email = "noreply@github.com"
-	node.Commit.Committer.User = nil
-
-	// Author is the real person who wrote the change.
+	// Author is the real person who wrote the change. The query no longer
+	// fetches the committer at all (it would be GitHub's web-flow identity for
+	// applied-suggestion / bot commits), so only the author is recorded.
 	node.Commit.Author.Name = "Steve Tooke"
 	node.Commit.Author.Email = "tooky@kosli.com"
 	node.Commit.Author.User = &struct {

--- a/internal/github/build_pr_evidence_test.go
+++ b/internal/github/build_pr_evidence_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"testing"
+	"time"
 
 	"github.com/shurcooL/graphql"
 	"github.com/stretchr/testify/require"
@@ -52,4 +53,58 @@ func TestBuildPREvidence_RecordsAuthorNotCommitter(t *testing.T) {
 		"the commit author (wire field author) must be the git author, not the committer")
 	require.Equal(t, "tooky", c.AuthorUsername,
 		"author_username must be the author's GitHub login, not the committer's (absent) one")
+}
+
+// TestBuildPREvidence_UsesAuthoredDate is a regression test for server#5479.
+// Now that the recorded identity is the author, the timestamp should be the
+// author date too. For rebased / applied-suggestion commits the authored and
+// committed dates differ.
+func TestBuildPREvidence_UsesAuthoredDate(t *testing.T) {
+	node := graphqlCommitNode{}
+	node.Commit.Oid = "0e723254516c841126e81f76100be57258ff1386"
+	node.Commit.MessageHeadline = "Apply suggestions from code review"
+	node.Commit.AuthoredDate = "2026-03-01T10:00:00Z"
+	node.Commit.CommittedDate = "2026-03-01T12:00:00Z"
+	node.Commit.Author.Name = "Steve Tooke"
+	node.Commit.Author.Email = "tooky@kosli.com"
+
+	evidence, err := buildPREvidence(
+		"https://github.com/kosli-dev/cli/pull/671",
+		"0e723254516c841126e81f76100be57258ff1386",
+		"MERGED", "tooky", "2026-03-01T09:00:00Z", "",
+		"Introduce kosli evaluate", "introduce-kosli-evaluate",
+		[]graphqlCommitNode{node}, nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, evidence.Commits, 1)
+
+	wantAuthored, _ := time.Parse(time.RFC3339, "2026-03-01T10:00:00Z")
+	require.Equal(t, wantAuthored.Unix(), evidence.Commits[0].Timestamp,
+		"timestamp must be the author date, not the committer date")
+}
+
+// TestBuildPREvidence_FallsBackToCommittedDate ensures the timestamp falls back
+// to the committed date when the GraphQL response omits the authored date.
+func TestBuildPREvidence_FallsBackToCommittedDate(t *testing.T) {
+	node := graphqlCommitNode{}
+	node.Commit.Oid = "0e723254516c841126e81f76100be57258ff1386"
+	node.Commit.MessageHeadline = "msg"
+	node.Commit.AuthoredDate = ""
+	node.Commit.CommittedDate = "2026-03-01T12:00:00Z"
+	node.Commit.Author.Name = "Steve Tooke"
+	node.Commit.Author.Email = "tooky@kosli.com"
+
+	evidence, err := buildPREvidence(
+		"https://github.com/kosli-dev/cli/pull/671",
+		"0e723254516c841126e81f76100be57258ff1386",
+		"MERGED", "tooky", "2026-03-01T09:00:00Z", "",
+		"title", "branch",
+		[]graphqlCommitNode{node}, nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, evidence.Commits, 1)
+
+	wantCommitted, _ := time.Parse(time.RFC3339, "2026-03-01T12:00:00Z")
+	require.Equal(t, wantCommitted.Unix(), evidence.Commits[0].Timestamp,
+		"timestamp must fall back to the committed date when authored date is absent")
 }

--- a/internal/github/build_pr_evidence_test.go
+++ b/internal/github/build_pr_evidence_test.go
@@ -1,0 +1,55 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/shurcooL/graphql"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildPREvidence_RecordsAuthorNotCommitter is a regression test for
+// server#5479. PR commit attestations were recording the git committer in the
+// "author" field. For GitHub web-flow commits (applied suggestions, bot
+// commits) the committer is "GitHub <noreply@github.com>", distinct from the
+// real author — so the true author was being lost and the author_username
+// dropped entirely (the committer has no associated GitHub user).
+func TestBuildPREvidence_RecordsAuthorNotCommitter(t *testing.T) {
+	node := graphqlCommitNode{}
+	node.Commit.Oid = "0e723254516c841126e81f76100be57258ff1386"
+	node.Commit.MessageHeadline = "Apply suggestions from code review"
+	node.Commit.CommittedDate = "2026-03-01T12:00:00Z"
+	node.Commit.URL = "https://github.com/kosli-dev/cli/commit/0e723254516c841126e81f76100be57258ff1386"
+
+	// Committer is GitHub's web-flow identity, with no associated user.
+	node.Commit.Committer.Name = "GitHub"
+	node.Commit.Committer.Email = "noreply@github.com"
+	node.Commit.Committer.User = nil
+
+	// Author is the real person who wrote the change.
+	node.Commit.Author.Name = "Steve Tooke"
+	node.Commit.Author.Email = "tooky@kosli.com"
+	node.Commit.Author.User = &struct {
+		Login graphql.String
+	}{Login: "tooky"}
+
+	evidence, err := buildPREvidence(
+		"https://github.com/kosli-dev/cli/pull/671",
+		"0e723254516c841126e81f76100be57258ff1386",
+		"MERGED",
+		"tooky",
+		"2026-03-01T11:00:00Z",
+		"",
+		"Introduce kosli evaluate",
+		"introduce-kosli-evaluate",
+		[]graphqlCommitNode{node},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, evidence.Commits, 1)
+
+	c := evidence.Commits[0]
+	require.Equal(t, "Steve Tooke <tooky@kosli.com>", c.Author,
+		"the commit author (wire field author) must be the git author, not the committer")
+	require.Equal(t, "tooky", c.AuthorUsername,
+		"author_username must be the author's GitHub login, not the committer's (absent) one")
+}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -326,6 +326,8 @@ func buildPREvidence(
 	}
 
 	for _, n := range commitNodes {
+		// TODO(server#5479): timestamp uses the committer date; consider authoredDate for
+		// author-consistency (cross-provider: also Azure commit.Committer.Date, GitLab CreatedAt).
 		timestamp, err := time.Parse(time.RFC3339, string(n.Commit.CommittedDate))
 		if err != nil {
 			return nil, err

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -272,6 +272,13 @@ type graphqlCommitNode struct {
 				Login graphql.String
 			}
 		}
+		Author struct {
+			Name  graphql.String
+			Email graphql.String
+			User  *struct {
+				Login graphql.String
+			}
+		}
 	}
 }
 
@@ -323,15 +330,15 @@ func buildPREvidence(
 		if err != nil {
 			return nil, err
 		}
-		committerUsername := ""
-		if n.Commit.Committer.User != nil {
-			committerUsername = string(n.Commit.Committer.User.Login)
+		authorUsername := ""
+		if n.Commit.Author.User != nil {
+			authorUsername = string(n.Commit.Author.User.Login)
 		}
 		evidence.Commits = append(evidence.Commits, types.Commit{
 			SHA:            string(n.Commit.Oid),
 			Message:        string(n.Commit.MessageHeadline),
-			Author:         fmt.Sprintf("%s <%s>", string(n.Commit.Committer.Name), string(n.Commit.Committer.Email)),
-			AuthorUsername: committerUsername,
+			Author:         fmt.Sprintf("%s <%s>", string(n.Commit.Author.Name), string(n.Commit.Author.Email)),
+			AuthorUsername: authorUsername,
 			Timestamp:      timestamp.Unix(),
 			Branch:         headRef,
 			URL:            string(n.Commit.URL),

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -328,13 +328,13 @@ func buildPREvidence(
 			committerUsername = string(n.Commit.Committer.User.Login)
 		}
 		evidence.Commits = append(evidence.Commits, types.Commit{
-			SHA:               string(n.Commit.Oid),
-			Message:           string(n.Commit.MessageHeadline),
-			Committer:         fmt.Sprintf("%s <%s>", string(n.Commit.Committer.Name), string(n.Commit.Committer.Email)),
-			CommitterUsername: committerUsername,
-			Timestamp:         timestamp.Unix(),
-			Branch:            headRef,
-			URL:               string(n.Commit.URL),
+			SHA:            string(n.Commit.Oid),
+			Message:        string(n.Commit.MessageHeadline),
+			Author:         fmt.Sprintf("%s <%s>", string(n.Commit.Committer.Name), string(n.Commit.Committer.Email)),
+			AuthorUsername: committerUsername,
+			Timestamp:      timestamp.Unix(),
+			Branch:         headRef,
+			URL:            string(n.Commit.URL),
 		})
 	}
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -265,15 +265,7 @@ type graphqlCommitNode struct {
 		CommittedDate   graphql.String
 		AuthoredDate    graphql.String
 		URL             graphql.String
-		Committer       struct {
-			Name  graphql.String
-			Email graphql.String
-			Date  graphql.String
-			User  *struct {
-				Login graphql.String
-			}
-		}
-		Author struct {
+		Author          struct {
 			Name  graphql.String
 			Email graphql.String
 			User  *struct {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -263,6 +263,7 @@ type graphqlCommitNode struct {
 		Oid             graphql.String
 		MessageHeadline graphql.String
 		CommittedDate   graphql.String
+		AuthoredDate    graphql.String
 		URL             graphql.String
 		Committer       struct {
 			Name  graphql.String
@@ -326,9 +327,13 @@ func buildPREvidence(
 	}
 
 	for _, n := range commitNodes {
-		// TODO(server#5479): timestamp uses the committer date; consider authoredDate for
-		// author-consistency (cross-provider: also Azure commit.Committer.Date, GitLab CreatedAt).
-		timestamp, err := time.Parse(time.RFC3339, string(n.Commit.CommittedDate))
+		// Use the author date to match the recorded author identity; fall back to
+		// the committed date if the API omits it (server#5479).
+		dateStr := string(n.Commit.AuthoredDate)
+		if dateStr == "" {
+			dateStr = string(n.Commit.CommittedDate)
+		}
+		timestamp, err := time.Parse(time.RFC3339, dateStr)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/gitlab/commit_mapping_test.go
+++ b/internal/gitlab/commit_mapping_test.go
@@ -1,0 +1,31 @@
+package gitlab
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+)
+
+// TestCommitFromGitlabCommit_RecordsAuthorNotCommitter is a regression test for
+// server#5479. PR commit attestations were recording the git committer in the
+// author field. They must record the git author.
+func TestCommitFromGitlabCommit_RecordsAuthorNotCommitter(t *testing.T) {
+	created := time.Unix(1772635812, 0)
+	commit := &gitlab.Commit{
+		ID:             "abc1230000000000000000000000000000000000",
+		Message:        "Apply suggestions from code review",
+		AuthorName:     "Steve Tooke",
+		AuthorEmail:    "tooky@kosli.com",
+		CommitterName:  "GitHub",
+		CommitterEmail: "noreply@github.com",
+		CreatedAt:      &created,
+		WebURL:         "https://gitlab.com/kosli/x/-/commit/abc123",
+	}
+
+	c := commitFromGitlabCommit(commit, "my-branch")
+
+	require.Equal(t, "Steve Tooke <tooky@kosli.com>", c.Author,
+		"author must be the git author, not the committer")
+}

--- a/internal/gitlab/commit_mapping_test.go
+++ b/internal/gitlab/commit_mapping_test.go
@@ -29,3 +29,44 @@ func TestCommitFromGitlabCommit_RecordsAuthorNotCommitter(t *testing.T) {
 	require.Equal(t, "Steve Tooke <tooky@kosli.com>", c.Author,
 		"author must be the git author, not the committer")
 }
+
+// TestCommitFromGitlabCommit_UsesAuthoredDate is a regression test for
+// server#5479: the timestamp must match the recorded author identity.
+func TestCommitFromGitlabCommit_UsesAuthoredDate(t *testing.T) {
+	authored := time.Unix(1772630000, 0)
+	created := time.Unix(1772635812, 0)
+	commit := &gitlab.Commit{
+		ID:           "abc1230000000000000000000000000000000000",
+		Message:      "msg",
+		AuthorName:   "Steve Tooke",
+		AuthorEmail:  "tooky@kosli.com",
+		AuthoredDate: &authored,
+		CreatedAt:    &created,
+		WebURL:       "https://gitlab.com/kosli/x/-/commit/abc123",
+	}
+
+	c := commitFromGitlabCommit(commit, "my-branch")
+
+	require.Equal(t, int64(1772630000), c.Timestamp,
+		"timestamp must be the authored date, not created_at")
+}
+
+// TestCommitFromGitlabCommit_FallsBackToCreatedAt ensures the timestamp falls
+// back to created_at when the API omits the authored date.
+func TestCommitFromGitlabCommit_FallsBackToCreatedAt(t *testing.T) {
+	created := time.Unix(1772635812, 0)
+	commit := &gitlab.Commit{
+		ID:           "abc1230000000000000000000000000000000000",
+		Message:      "msg",
+		AuthorName:   "Steve Tooke",
+		AuthorEmail:  "tooky@kosli.com",
+		AuthoredDate: nil,
+		CreatedAt:    &created,
+		WebURL:       "https://gitlab.com/kosli/x/-/commit/abc123",
+	}
+
+	c := commitFromGitlabCommit(commit, "my-branch")
+
+	require.Equal(t, int64(1772635812), c.Timestamp,
+		"timestamp must fall back to created_at when authored date is absent")
+}

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -181,11 +181,17 @@ func (c *GitlabConfig) GetMergeRequestCommits(mr *gitlab.BasicMergeRequest) ([]t
 
 // commitFromGitlabCommit maps a GitLab API commit to a types.Commit.
 func commitFromGitlabCommit(commit *gitlab.Commit, branch string) types.Commit {
+	// Use the authored date to match the recorded author identity; fall back to
+	// created_at if the API omits it (server#5479).
+	timestamp := commit.CreatedAt.Unix()
+	if commit.AuthoredDate != nil {
+		timestamp = commit.AuthoredDate.Unix()
+	}
 	return types.Commit{
 		SHA:       commit.ID,
 		Message:   commit.Message,
 		Author:    fmt.Sprintf("%s <%s>", commit.AuthorName, commit.AuthorEmail),
-		Timestamp: commit.CreatedAt.Unix(),
+		Timestamp: timestamp,
 		Branch:    branch,
 		URL:       commit.WebURL,
 	}

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -182,10 +182,9 @@ func (c *GitlabConfig) GetMergeRequestCommits(mr *gitlab.BasicMergeRequest) ([]t
 // commitFromGitlabCommit maps a GitLab API commit to a types.Commit.
 func commitFromGitlabCommit(commit *gitlab.Commit, branch string) types.Commit {
 	return types.Commit{
-		SHA:     commit.ID,
-		Message: commit.Message,
-		// TODO(server#5479): author is sourced from the committer; switch to AuthorName/AuthorEmail.
-		Author:    fmt.Sprintf("%s <%s>", commit.CommitterName, commit.CommitterEmail),
+		SHA:       commit.ID,
+		Message:   commit.Message,
+		Author:    fmt.Sprintf("%s <%s>", commit.AuthorName, commit.AuthorEmail),
 		Timestamp: commit.CreatedAt.Unix(),
 		Branch:    branch,
 		URL:       commit.WebURL,

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -177,7 +177,7 @@ func (c *GitlabConfig) GetMergeRequestCommits(mr *gitlab.BasicMergeRequest) ([]t
 		commits = append(commits, types.Commit{
 			SHA:       commit.ID,
 			Message:   commit.Message,
-			Committer: fmt.Sprintf("%s <%s>", commit.CommitterName, commit.CommitterEmail),
+			Author:    fmt.Sprintf("%s <%s>", commit.CommitterName, commit.CommitterEmail),
 			Timestamp: commit.CreatedAt.Unix(),
 			Branch:    mr.SourceBranch,
 			URL:       commit.WebURL,

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -175,8 +175,9 @@ func (c *GitlabConfig) GetMergeRequestCommits(mr *gitlab.BasicMergeRequest) ([]t
 	}
 	for _, commit := range glCommits {
 		commits = append(commits, types.Commit{
-			SHA:       commit.ID,
-			Message:   commit.Message,
+			SHA:     commit.ID,
+			Message: commit.Message,
+			// TODO(server#5479): author is sourced from the committer; switch to AuthorName/AuthorEmail.
 			Author:    fmt.Sprintf("%s <%s>", commit.CommitterName, commit.CommitterEmail),
 			Timestamp: commit.CreatedAt.Unix(),
 			Branch:    mr.SourceBranch,

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -174,15 +174,20 @@ func (c *GitlabConfig) GetMergeRequestCommits(mr *gitlab.BasicMergeRequest) ([]t
 		return commits, err
 	}
 	for _, commit := range glCommits {
-		commits = append(commits, types.Commit{
-			SHA:     commit.ID,
-			Message: commit.Message,
-			// TODO(server#5479): author is sourced from the committer; switch to AuthorName/AuthorEmail.
-			Author:    fmt.Sprintf("%s <%s>", commit.CommitterName, commit.CommitterEmail),
-			Timestamp: commit.CreatedAt.Unix(),
-			Branch:    mr.SourceBranch,
-			URL:       commit.WebURL,
-		})
+		commits = append(commits, commitFromGitlabCommit(commit, mr.SourceBranch))
 	}
 	return commits, nil
+}
+
+// commitFromGitlabCommit maps a GitLab API commit to a types.Commit.
+func commitFromGitlabCommit(commit *gitlab.Commit, branch string) types.Commit {
+	return types.Commit{
+		SHA:     commit.ID,
+		Message: commit.Message,
+		// TODO(server#5479): author is sourced from the committer; switch to AuthorName/AuthorEmail.
+		Author:    fmt.Sprintf("%s <%s>", commit.CommitterName, commit.CommitterEmail),
+		Timestamp: commit.CreatedAt.Unix(),
+		Branch:    branch,
+		URL:       commit.WebURL,
+	}
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -20,13 +20,13 @@ type PRApprovals struct {
 }
 
 type Commit struct {
-	SHA               string `json:"sha1"`
-	Message           string `json:"message"`
-	Committer         string `json:"author"`
-	CommitterUsername string `json:"author_username,omitempty"`
-	Timestamp         int64  `json:"timestamp"`
-	Branch            string `json:"branch"`
-	URL               string `json:"url,omitempty"`
+	SHA            string `json:"sha1"`
+	Message        string `json:"message"`
+	Author         string `json:"author"`
+	AuthorUsername string `json:"author_username,omitempty"`
+	Timestamp      int64  `json:"timestamp"`
+	Branch         string `json:"branch"`
+	URL            string `json:"url,omitempty"`
 }
 
 type PRRetriever interface {


### PR DESCRIPTION
## What and why

Fixes [kosli-dev/server#5479](https://github.com/kosli-dev/server/issues/5479): `kosli attest pr` recorded the git **committer** in the commit `author` field, and the commit timestamp from the committer/commit date. For commits made through a web flow (applied review suggestions, bot commits, rebases) the committer differs from the author, so the real author was lost — e.g. an agent-authored commit committed via GitHub web flow attested as `GitHub <noreply@github.com>` with no `author_username`.

This PR records the **git author's identity and authored timestamp** across all providers. It consolidates the former #958 (folded into this branch so the whole change is one reviewable unit); plan: https://github.com/kosli-dev/server/issues/5479#issuecomment-4690357750

## Per-provider before → after

| Provider | `author` | `author_username` | `timestamp` |
|---|---|---|---|
| **GitHub** | committer → **author** (GraphQL `author { name email user { login } }`) | committer login → **author login** | committed → **authored** (fallback committed) |
| **GitLab** | committer → **author** (`AuthorName`/`AuthorEmail`) | — (none; unchanged) | created_at → **authored_date** (fallback created_at) |
| **Azure** | display-name only → **`Name <email>`** | committer name → **dropped** | committer date → **author date** |
| **Bitbucket** | already author (`author.raw`) — unchanged | — (none) | single `date` field — unchanged |

The Go field `types.Commit.Committer` (tagged `json:"author"`) — the naming mismatch at the root of the conflation — is renamed to `Author`/`AuthorUsername`; wire tags are unchanged. Azure commits expose no login, so `author_username` is dropped (`omitempty`) rather than populated from the wrong source.

## How it's built

Each provider's commit mapping is a pure function (`buildPREvidence` for GitHub, `commitFrom<Provider>Commit` for GitLab/Azure) so the logic is unit-tested without live API calls. Refactor-then-fix per slice, every fix preceded by a failing test (web-flow fixture with author ≠ committer; authored ≠ committed date). Bitbucket verified read-only.

## Compatibility note (for changelog + docs)

Wire schema unchanged; **values change**. Policies (Rego or jq) reading commit `author` or `timestamp` may legitimately flip outcomes — never-alone / four-eyes checks comparing commit author to approvers, and any commit-time-window logic. Azure payloads lose `author_username` (previously the committer's display name).

## Verification

`go build ./...`, `go vet`, `make lint` (0 issues), and unit tests for all changed packages pass. The full integration suite (`test / Test`) and the multi-LLM review passed on the consolidated change in #958 before the fold; CI re-runs here on the combined branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)