### PR TITLE
fix(snapshot ecs): handle clusters with zero services

### DIFF
--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -161,6 +161,14 @@ func ResetLambdaClientFactory() {
 	NewLambdaClientFunc = defaultNewLambdaClient
 }
 
+// ECSServicesAPI is the subset of AWS ECS operations used when listing and
+// describing services in a cluster. The real *ecs.Client satisfies this
+// implicitly.
+type ECSServicesAPI interface {
+	ListServices(ctx context.Context, params *ecs.ListServicesInput, optFns ...func(*ecs.Options)) (*ecs.ListServicesOutput, error)
+	DescribeServices(ctx context.Context, params *ecs.DescribeServicesInput, optFns ...func(*ecs.Options)) (*ecs.DescribeServicesOutput, error)
+}
+
 // NewECSClient returns a new ECS API client
 func (staticCreds *AWSStaticCreds) NewECSClient() (*ecs.Client, error) {
 	cfg, err := staticCreds.NewAWSConfigFromEnvOrFlags()
@@ -623,7 +631,7 @@ func (staticCreds *AWSStaticCreds) GetEcsTasksData(clusterFilter, serviceFilter 
 }
 
 // getFilteredECSServicesInCluster fetches a filtered set of ECS services recursively (10 at a time) and returns a list of ecs Services
-func getFilteredECSServicesInCluster(client *ecs.Client, cluster string, allServices *[]ecsTypes.Service, serviceFilter *filters.ResourceFilterOptions,
+func getFilteredECSServicesInCluster(client ECSServicesAPI, cluster string, allServices *[]ecsTypes.Service, serviceFilter *filters.ResourceFilterOptions,
 	nextToken *string, logger *logger.Logger) (*[]ecsTypes.Service, error) {
 	listInput := &ecs.ListServicesInput{
 		Cluster: aws.String(cluster),
@@ -634,6 +642,14 @@ func getFilteredECSServicesInCluster(client *ecs.Client, cluster string, allServ
 	listServicesOutput, err := client.ListServices(context.TODO(), listInput)
 	if err != nil {
 		return allServices, err
+	}
+
+	// A cluster with no services yields an empty ServiceArns list. The AWS ECS
+	// DescribeServices API rejects an empty Services list with
+	// "InvalidParameterException: Services cannot be empty", so skip the call
+	// and let the cluster contribute zero services.
+	if len(listServicesOutput.ServiceArns) == 0 {
+		return allServices, nil
 	}
 
 	describeServicesOutput, err := client.DescribeServices(context.TODO(), &ecs.DescribeServicesInput{Cluster: aws.String(cluster), Services: listServicesOutput.ServiceArns})

--- a/internal/aws/ecs_services_test.go
+++ b/internal/aws/ecs_services_test.go
@@ -1,0 +1,58 @@
+package aws
+
+import (
+	"testing"
+
+	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/kosli-dev/cli/internal/filters"
+	"github.com/kosli-dev/cli/internal/logger"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetFilteredECSServicesInCluster_EmptyCluster reproduces the regression
+// where a cluster with no services caused DescribeServices to be called with an
+// empty Services list, which the real AWS API rejects with
+// "InvalidParameterException: Services cannot be empty".
+//
+// An empty cluster should simply contribute zero services without error.
+func TestGetFilteredECSServicesInCluster_EmptyCluster(t *testing.T) {
+	client := &FakeECSClient{
+		ServiceArns: []string{}, // cluster has no services
+		Services:    []ecsTypes.Service{},
+	}
+
+	allServices, err := getFilteredECSServicesInCluster(
+		client,
+		"empty-cluster",
+		&[]ecsTypes.Service{},
+		&filters.ResourceFilterOptions{},
+		nil,
+		logger.NewStandardLogger(),
+	)
+
+	require.NoError(t, err)
+	require.Empty(t, *allServices)
+}
+
+// TestGetFilteredECSServicesInCluster_WithServices verifies the happy path is
+// unchanged by the empty-cluster guard: a cluster with services returns them.
+func TestGetFilteredECSServicesInCluster_WithServices(t *testing.T) {
+	svcName := "my-service"
+	client := &FakeECSClient{
+		ServiceArns: []string{"arn:aws:ecs:eu-central-1:123:service/cluster/my-service"},
+		Services:    []ecsTypes.Service{{ServiceName: &svcName}},
+	}
+
+	allServices, err := getFilteredECSServicesInCluster(
+		client,
+		"cluster",
+		&[]ecsTypes.Service{},
+		&filters.ResourceFilterOptions{},
+		nil,
+		logger.NewStandardLogger(),
+	)
+
+	require.NoError(t, err)
+	require.Len(t, *allServices, 1)
+	require.Equal(t, svcName, *(*allServices)[0].ServiceName)
+}

--- a/internal/aws/fake_ecs.go
+++ b/internal/aws/fake_ecs.go
@@ -1,0 +1,32 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+)
+
+// FakeECSClient is an in-memory implementation of ECSServicesAPI for testing.
+// It returns the configured services for a cluster and reproduces the real AWS
+// contract where DescribeServices rejects an empty Services list.
+type FakeECSClient struct {
+	// ServiceArns is the list of service ARNs returned by ListServices.
+	ServiceArns []string
+	// Services is the list of services returned by DescribeServices.
+	Services []ecsTypes.Service
+}
+
+func (f *FakeECSClient) ListServices(_ context.Context, _ *ecs.ListServicesInput, _ ...func(*ecs.Options)) (*ecs.ListServicesOutput, error) {
+	return &ecs.ListServicesOutput{ServiceArns: f.ServiceArns}, nil
+}
+
+func (f *FakeECSClient) DescribeServices(_ context.Context, params *ecs.DescribeServicesInput, _ ...func(*ecs.Options)) (*ecs.DescribeServicesOutput, error) {
+	// Mirror the real AWS ECS API, which rejects an empty Services list with
+	// InvalidParameterException: Services cannot be empty.
+	if len(params.Services) == 0 {
+		return nil, fmt.Errorf("InvalidParameterException: Services cannot be empty")
+	}
+	return &ecs.DescribeServicesOutput{Services: f.Services}, nil
+}


### PR DESCRIPTION
## Summary

`kosli snapshot ecs` aborted when any scanned cluster had **no ECS services**, failing with:

```
Error: failed to filter ECS services in cluster <cluster>: operation error ECS: DescribeServices, ... InvalidParameterException: Services cannot be empty
```

This is a regression introduced in #556 (first in v2.11.26, present in v2.28.0). `getFilteredECSServicesInCluster` called `DescribeServices` with the service ARNs from `ListServices`; when a cluster has no services that list is empty, and the AWS ECS API rejects an empty `Services` list. The pre-#556 code guarded the equivalent describe call with a `len(...) > 0` check; the rewrite dropped it.

## Fix

Guard the empty case so an empty cluster contributes zero services instead of erroring.

## Testability

The repo had no mock layer for ECS, so this follows the existing Lambda pattern (`LambdaAPI` interface + `fake_lambda.go`):

- `ECSServicesAPI` interface — the real `*ecs.Client` satisfies it implicitly; `getFilteredECSServicesInCluster` now takes the interface (no production behaviour change).
- `fake_ecs.go` — `FakeECSClient` whose `DescribeServices` reproduces the real AWS contract (errors on an empty `Services` list).
- `ecs_services_test.go` — empty-cluster regression test (reproduces the exact bug-report error) plus a happy-path test.

These run via `go test ./internal/aws/` with **no Docker server and no AWS credentials**.

## Verification

- Regression test fails before the fix with `InvalidParameterException: Services cannot be empty`, passes after.
- `internal/aws` package green, `go vet` clean, `golangci-lint` 0 issues, `go build ./...` succeeds.

Closes #965