### PR TITLE
fix: failing trail test

### DIFF
--- a/cmd/kosli/beginTrail_test.go
+++ b/cmd/kosli/beginTrail_test.go
@@ -51,7 +51,7 @@ func (suite *BeginTrailCommandTestSuite) TestBeginTrailCmd() {
 			wantError:   true,
 			name:        "beginning a trail with an invalid template fails",
 			cmd:         fmt.Sprintf("begin trail test-123 --flow %s --template-file testdata/invalid_template.yml %s", suite.flowName, suite.defaultKosliArguments),
-			goldenRegex: "Error: 3 validation errors for Template\n.*",
+			goldenRegex: "Error: .* validation errors for Template\n.*",
 		},
 		{
 			name:   "can begin a trail with a valid template",

--- a/cmd/kosli/testdata/invalid_template.yml
+++ b/cmd/kosli/testdata/invalid_template.yml
@@ -1,5 +1,5 @@
 version: 1
-trail: 
+trail:
   attestations:
   - name: foo
     type: not-supported


### PR DESCRIPTION
We've added the '*' attestation type as a valid literal, therefore increasing the validation-error count from 3 to 4. This is making the test more resilient to future changes.