### PR TITLE
chore: align compliance status messages to NON-COMPLIANT

### DIFF
--- a/cmd/kosli/assertSnapshot.go
+++ b/cmd/kosli/assertSnapshot.go
@@ -87,7 +87,7 @@ func run(out io.Writer, args []string) error {
 	if environmentData["compliant"].(bool) {
 		logger.Info("COMPLIANT")
 	} else {
-		return fmt.Errorf("INCOMPLIANT")
+		return fmt.Errorf("NON-COMPLIANT")
 	}
 
 	return nil

--- a/cmd/kosli/assertSnapshot_test.go
+++ b/cmd/kosli/assertSnapshot_test.go
@@ -83,13 +83,13 @@ func (suite *AssertSnapshotCommandTestSuite) TestAssertSnapshotCmd() {
 		},
 		{
 			wantError: true,
-			name:      "04 asserting a non compliant env results in INCOMPLIANT and non-zero exit",
+			name:      "04 asserting a non compliant env results in NON-COMPLIANT and non-zero exit",
 			cmd:       fmt.Sprintf(`assert snapshot %s %s`, suite.nonCompliantEnvName, suite.defaultKosliArguments),
 			additionalConfig: assertSnapshotTestConfig{
 				reportToEnv: true,
 				envName:     suite.nonCompliantEnvName,
 			},
-			golden: "Error: INCOMPLIANT\n",
+			golden: "Error: NON-COMPLIANT\n",
 		},
 		{
 			wantError: false,

--- a/cmd/kosli/getEnvironment.go
+++ b/cmd/kosli/getEnvironment.go
@@ -83,7 +83,7 @@ func printEnvironmentAsTable(raw string, out io.Writer, page int) error {
 	if env["state"] != nil && env["state"].(bool) {
 		state = "COMPLIANT"
 	} else if env["state"] != nil {
-		state = "INCOMPLIANT"
+		state = "NON-COMPLIANT"
 	}
 
 	tags := env["tags"].(map[string]interface{})


### PR DESCRIPTION
For ENV and snapshot assertions the CLI printed INCOMPLIANT, which did not match the NON-COMPLIANT framing used in the UI and elsewhere in the CLI. Align the wording in `assert snapshot` and `get environment`.

Closes #969