### PR TITLE
feat(update): add default-org cmd to set user default organization

### DIFF
--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -439,6 +439,7 @@ func newRootCmd(out, errOut io.Writer, args []string) (*cobra.Command, error) {
 		newEvaluateCmd(out),
 		newDeleteCmd(out),
 		newRotateCmd(out),
+		newUpdateCmd(out),
 	)
 
 	cobra.AddTemplateFunc("isBeta", isBeta)

--- a/cmd/kosli/update.go
+++ b/cmd/kosli/update.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+const updateDesc = `All Kosli update commands.`
+
+func newUpdateCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "update",
+		Aliases: []string{"u", "up"},
+		Short:   updateDesc,
+		Long:    updateDesc,
+	}
+
+	// Add subcommands
+	cmd.AddCommand(
+		newUpdateDefaultOrgCmd(out),
+	)
+
+	return cmd
+}

--- a/cmd/kosli/updateDefaultOrg.go
+++ b/cmd/kosli/updateDefaultOrg.go
@@ -11,7 +11,9 @@ import (
 
 const updateDefaultOrgShortDesc = `Set the default organization for the current user.`
 
-const updateDefaultOrgLongDesc = updateDefaultOrgShortDesc
+const updateDefaultOrgLongDesc = updateDefaultOrgShortDesc + `
+The default organization is used by Kosli Web UI when logging in.
+`
 
 const updateDefaultOrgExample = `
 # set the default organization for the current user:

--- a/cmd/kosli/updateDefaultOrg.go
+++ b/cmd/kosli/updateDefaultOrg.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/kosli-dev/cli/internal/requests"
+	"github.com/spf13/cobra"
+)
+
+const updateDefaultOrgShortDesc = `Set the default organization for the current user.`
+
+const updateDefaultOrgLongDesc = updateDefaultOrgShortDesc
+
+const updateDefaultOrgExample = `
+# set the default organization for the current user:
+kosli update default-org yourOrgName \
+	--api-token yourAPIToken
+`
+
+func newUpdateDefaultOrgCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "default-org ORG-NAME",
+		Short:   updateDefaultOrgShortDesc,
+		Long:    updateDefaultOrgLongDesc,
+		Example: updateDefaultOrgExample,
+		Args:    cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			err := RequireGlobalFlags(global, []string{"ApiToken"})
+			if err != nil {
+				return ErrorBeforePrintingUsage(cmd, err.Error())
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			url, err := url.JoinPath(global.Host, "api/v2/user", args[0])
+			if err != nil {
+				return err
+			}
+
+			reqParams := &requests.RequestParams{
+				Method: http.MethodPut,
+				URL:    url,
+				DryRun: global.DryRun,
+				Token:  global.ApiToken,
+			}
+			_, err = kosliClient.Do(reqParams)
+			if err == nil && !global.DryRun {
+				logger.Info("default organization is set to: %s", args[0])
+			}
+			return err
+		},
+	}
+	addDryRunFlag(cmd)
+	return cmd
+}

--- a/cmd/kosli/updateDefaultOrg.go
+++ b/cmd/kosli/updateDefaultOrg.go
@@ -34,6 +34,10 @@ func newUpdateDefaultOrgCmd(out io.Writer) *cobra.Command {
 				return ErrorBeforePrintingUsage(cmd, err.Error())
 			}
 
+			if args[0] == "" {
+				return ErrorBeforePrintingUsage(cmd, "ORG-NAME argument is required")
+			}
+
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/kosli/updateDefaultOrg_test.go
+++ b/cmd/kosli/updateDefaultOrg_test.go
@@ -28,6 +28,12 @@ func (suite *UpdateDefaultOrgCommandTestSuite) TestUpdateDefaultOrgCmd() {
 			golden: "default organization is set to: docs-cmd-test-user\n",
 		},
 		{
+			wantError:   false,
+			name:        "dry-run builds the right url without contacting the server",
+			cmd:         fmt.Sprintf(`update default-org docs-cmd-test-user --dry-run %s`, suite.defaultKosliArguments),
+			goldenRegex: `the request would have been sent to: .*api/v2/user/docs-cmd-test-user`,
+		},
+		{
 			wantError: true,
 			name:      "setting default org fails when no args are provided",
 			cmd:       fmt.Sprintf(`update default-org %s`, suite.defaultKosliArguments),
@@ -38,6 +44,12 @@ func (suite *UpdateDefaultOrgCommandTestSuite) TestUpdateDefaultOrgCmd() {
 			name:      "setting default org fails when 2 args are provided",
 			cmd:       fmt.Sprintf(`update default-org org1 org2 %s`, suite.defaultKosliArguments),
 			golden:    "Error: accepts 1 arg(s), received 2\n",
+		},
+		{
+			wantError: true,
+			name:      "setting default org fails when org name is empty",
+			cmd:       fmt.Sprintf(`update default-org "" %s`, suite.defaultKosliArguments),
+			golden:    "Error: ORG-NAME argument is required\nUsage: kosli update default-org ORG-NAME [flags]\n",
 		},
 		{
 			wantError: true,

--- a/cmd/kosli/updateDefaultOrg_test.go
+++ b/cmd/kosli/updateDefaultOrg_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type UpdateDefaultOrgCommandTestSuite struct {
+	suite.Suite
+	defaultKosliArguments string
+}
+
+func (suite *UpdateDefaultOrgCommandTestSuite) SetupTest() {
+	global = &GlobalOpts{
+		ApiToken: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6ImNkNzg4OTg5In0.e8i_lA_QrEhFncb05Xw6E_tkCHU9QfcY4OLTVUCHffY",
+		Host:     "http://localhost:8001",
+	}
+	suite.defaultKosliArguments = fmt.Sprintf(" --host %s --api-token %s", global.Host, global.ApiToken)
+}
+
+func (suite *UpdateDefaultOrgCommandTestSuite) TestUpdateDefaultOrgCmd() {
+	tests := []cmdTestCase{
+		{
+			name:   "can set default organization",
+			cmd:    fmt.Sprintf(`update default-org docs-cmd-test-user %s`, suite.defaultKosliArguments),
+			golden: "default organization is set to: docs-cmd-test-user\n",
+		},
+		{
+			wantError: true,
+			name:      "setting default org fails when no args are provided",
+			cmd:       fmt.Sprintf(`update default-org %s`, suite.defaultKosliArguments),
+			golden:    "Error: accepts 1 arg(s), received 0\n",
+		},
+		{
+			wantError: true,
+			name:      "setting default org fails when 2 args are provided",
+			cmd:       fmt.Sprintf(`update default-org org1 org2 %s`, suite.defaultKosliArguments),
+			golden:    "Error: accepts 1 arg(s), received 2\n",
+		},
+		{
+			wantError: true,
+			name:      "setting default org fails for non-existing org",
+			cmd:       fmt.Sprintf(`update default-org non-existing-org-abc123 %s`, suite.defaultKosliArguments),
+			golden:    "Error: Organization named 'non-existing-org-abc123' does not exist\n",
+		},
+	}
+
+	runTestCmd(suite.T(), tests)
+}
+
+func TestUpdateDefaultOrgCommandTestSuite(t *testing.T) {
+	suite.Run(t, new(UpdateDefaultOrgCommandTestSuite))
+}

--- a/cmd/kosli/updateDefaultOrg_test.go
+++ b/cmd/kosli/updateDefaultOrg_test.go
@@ -43,7 +43,7 @@ func (suite *UpdateDefaultOrgCommandTestSuite) TestUpdateDefaultOrgCmd() {
 			wantError: true,
 			name:      "setting default org fails for non-existing org",
 			cmd:       fmt.Sprintf(`update default-org non-existing-org-abc123 %s`, suite.defaultKosliArguments),
-			golden:    "Error: Organization named 'non-existing-org-abc123' does not exist\n",
+			golden:    "Error: Access denied to /api/v2/user/non-existing-org-abc123\n",
 		},
 	}
 


### PR DESCRIPTION
Adds `kosli update default-org ORG-NAME` which calls PUT /api/v2/user/{org} to set the default organization for the currently authenticated user.