### PR TITLE
feat(repo): support tagging repos by their internal id

### DIFF
--- a/cmd/kosli/getRepo.go
+++ b/cmd/kosli/getRepo.go
@@ -90,15 +90,13 @@ func (o *getRepoOptions) run(out io.Writer, args []string) error {
 	}
 
 	var parsed struct {
-		Embedded struct {
-			Repos []map[string]any `json:"repos"`
-		} `json:"_embedded"`
+		Repos []map[string]any `json:"repos"`
 	}
 	if err := json.Unmarshal([]byte(response.Body), &parsed); err != nil {
 		return err
 	}
-	if len(parsed.Embedded.Repos) > 1 {
-		return fmt.Errorf("found %d repos matching %q. Use --provider or --repo-id to narrow down the search", len(parsed.Embedded.Repos), args[0])
+	if len(parsed.Repos) > 1 {
+		return fmt.Errorf("found %d repos matching %q. Use --provider or --repo-id to narrow down the search", len(parsed.Repos), args[0])
 	}
 
 	return output.FormattedPrint(response.Body, o.output, out, 0,

--- a/cmd/kosli/getRepo.go
+++ b/cmd/kosli/getRepo.go
@@ -41,7 +41,6 @@ func newGetRepoCmd(out io.Writer) *cobra.Command {
 	o := new(getRepoOptions)
 	cmd := &cobra.Command{
 		Use:     "repo REPO-NAME",
-		Hidden:  true,
 		Short:   getRepoShortDesc,
 		Long:    getRepoLongDesc,
 		Example: getRepoExample,

--- a/cmd/kosli/getRepo_test.go
+++ b/cmd/kosli/getRepo_test.go
@@ -37,9 +37,11 @@ func (suite *GetRepoCommandTestSuite) SetupTest() {
 	BeginTrail("trail-name", "get-repo", "", suite.T())
 
 	// two repos sharing a name but with different external ids, to exercise
-	// the "narrow down the search" guard
+	// the "narrow down the search" guard. The name is deliberately distinctive
+	// so no other suite creates a same-named repo in this shared org and makes
+	// the match count (asserted below) unstable.
 	SetEnvVars(map[string]string{
-		"GITHUB_REPOSITORY":    "ambiguous-org/ambiguous-repo",
+		"GITHUB_REPOSITORY":    "get-repo-suite-org/get-repo-ambiguous-repo",
 		"GITHUB_REPOSITORY_ID": "111",
 	}, suite.T())
 	BeginTrail("ambiguous-trail-1", "get-repo", "", suite.T())
@@ -108,12 +110,12 @@ func (suite *GetRepoCommandTestSuite) TestGetRepoCmd() {
 		{
 			wantError: true,
 			name:      "10-getting a repo with multiple matches suggests narrowing the search",
-			cmd:       fmt.Sprintf(`get repo ambiguous-org/ambiguous-repo %s`, suite.acmeOrgKosliArguments),
-			golden:    "Error: found 2 repos matching \"ambiguous-org/ambiguous-repo\". Use --provider or --repo-id to narrow down the search\n",
+			cmd:       fmt.Sprintf(`get repo get-repo-suite-org/get-repo-ambiguous-repo %s`, suite.acmeOrgKosliArguments),
+			golden:    "Error: found 2 repos matching \"get-repo-suite-org/get-repo-ambiguous-repo\". Use --provider or --repo-id to narrow down the search\n",
 		},
 		{
 			name: "11-narrowing an ambiguous repo down with --repo-id works",
-			cmd:  fmt.Sprintf(`get repo ambiguous-org/ambiguous-repo --repo-id 111 %s`, suite.acmeOrgKosliArguments),
+			cmd:  fmt.Sprintf(`get repo get-repo-suite-org/get-repo-ambiguous-repo --repo-id 111 %s`, suite.acmeOrgKosliArguments),
 		},
 	}
 

--- a/cmd/kosli/getRepo_test.go
+++ b/cmd/kosli/getRepo_test.go
@@ -35,6 +35,18 @@ func (suite *GetRepoCommandTestSuite) SetupTest() {
 		"GITHUB_REPOSITORY_ID": "1234567890",
 	}, suite.T())
 	BeginTrail("trail-name", "get-repo", "", suite.T())
+
+	// two repos sharing a name but with different external ids, to exercise
+	// the "narrow down the search" guard
+	SetEnvVars(map[string]string{
+		"GITHUB_REPOSITORY":    "ambiguous-org/ambiguous-repo",
+		"GITHUB_REPOSITORY_ID": "111",
+	}, suite.T())
+	BeginTrail("ambiguous-trail-1", "get-repo", "", suite.T())
+	SetEnvVars(map[string]string{
+		"GITHUB_REPOSITORY_ID": "222",
+	}, suite.T())
+	BeginTrail("ambiguous-trail-2", "get-repo", "", suite.T())
 }
 
 func (suite *GetRepoCommandTestSuite) TearDownTest() {
@@ -92,6 +104,16 @@ func (suite *GetRepoCommandTestSuite) TestGetRepoCmd() {
 			name:      "09-providing more than one argument fails",
 			cmd:       fmt.Sprintf(`get repo foo bar %s`, suite.defaultKosliArguments),
 			golden:    "Error: accepts 1 arg(s), received 2\n",
+		},
+		{
+			wantError: true,
+			name:      "10-getting a repo with multiple matches suggests narrowing the search",
+			cmd:       fmt.Sprintf(`get repo ambiguous-org/ambiguous-repo %s`, suite.acmeOrgKosliArguments),
+			golden:    "Error: found 2 repos matching \"ambiguous-org/ambiguous-repo\". Use --provider or --repo-id to narrow down the search\n",
+		},
+		{
+			name: "11-narrowing an ambiguous repo down with --repo-id works",
+			cmd:  fmt.Sprintf(`get repo ambiguous-org/ambiguous-repo --repo-id 111 %s`, suite.acmeOrgKosliArguments),
 		},
 	}
 

--- a/cmd/kosli/listRepos.go
+++ b/cmd/kosli/listRepos.go
@@ -24,11 +24,10 @@ type listReposOptions struct {
 func newListReposCmd(out io.Writer) *cobra.Command {
 	o := new(listReposOptions)
 	cmd := &cobra.Command{
-		Use:    "repos",
-		Hidden: true,
-		Short:  listReposDesc,
-		Long:   listReposDesc,
-		Args:   cobra.NoArgs,
+		Use:   "repos",
+		Short: listReposDesc,
+		Long:  listReposDesc,
+		Args:  cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			err := RequireGlobalFlags(global, []string{"Org", "ApiToken"})
 			if err != nil {

--- a/cmd/kosli/tag.go
+++ b/cmd/kosli/tag.go
@@ -27,6 +27,10 @@ const tagShortDesc = `Tag a resource in Kosli with key-value pairs.  `
 
 const tagLongDesc = tagShortDesc + `
 use --set to add or update tags, and --unset to remove tags.
+
+Flows, environments and controls are identified by their name or identifier.
+Repos are identified by their internal id (repo names are not unique across
+VCS providers), which you can find with: kosli get repo REPO-NAME
 `
 
 const tagExample = `
@@ -59,6 +63,12 @@ kosli tag env yourEnvironmentName \
 
 # tag a control
 kosli tag control yourControlIdentifier \
+	--set key1=value1 \
+	--api-token yourApiToken \
+	--org yourOrgName
+
+# tag a repo (identified by its internal id, see: kosli get repo)
+kosli tag repo yourRepoID \
 	--set key1=value1 \
 	--api-token yourApiToken \
 	--org yourOrgName
@@ -149,7 +159,7 @@ func (o *tagOptions) run(args []string) error {
 }
 
 func validateResourceType(resourceType string) error {
-	options := []string{"flow", "flows", "env", "environment", "environments", "control", "controls"}
+	options := []string{"flow", "flows", "env", "environment", "environments", "control", "controls", "repo", "repos"}
 	match := false
 	for _, opt := range options {
 		if resourceType == opt {

--- a/cmd/kosli/tag_test.go
+++ b/cmd/kosli/tag_test.go
@@ -26,7 +26,9 @@ func (suite *TagTestSuite) SetupTest() {
 	suite.envName = "tag-env"
 	suite.envType = "K8S"
 	suite.controlID = "tag-control"
-	suite.repoName = "kosli-dev/cli"
+	// unique name: in CI, other suites implicitly create a repo for the real
+	// GITHUB_REPOSITORY in this org, and same-name repos make lookup ambiguous
+	suite.repoName = "tag-test-org/tag-test-repo"
 	global = &GlobalOpts{
 		ApiToken: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6ImNkNzg4OTg5In0.e8i_lA_QrEhFncb05Xw6E_tkCHU9QfcY4OLTVUCHffY",
 		Org:      "docs-cmd-test-user",

--- a/cmd/kosli/tag_test.go
+++ b/cmd/kosli/tag_test.go
@@ -49,7 +49,7 @@ func (suite *TagTestSuite) SetupTest() {
 	}, suite.T())
 	CreateFlowWithTemplate("tag-repo-flow", "testdata/valid_template.yml", suite.T())
 	BeginTrail("tag-repo-trail", "tag-repo-flow", "", suite.T())
-	suite.repoID = GetRepoID(global.Org, suite.repoName, suite.T())
+	suite.repoID = GetRepoInnerID(global.Org, suite.repoName, suite.T())
 }
 
 func (suite *TagTestSuite) TearDownTest() {

--- a/cmd/kosli/tag_test.go
+++ b/cmd/kosli/tag_test.go
@@ -17,6 +17,8 @@ type TagTestSuite struct {
 	envName               string
 	envType               string
 	controlID             string
+	repoName              string
+	repoID                string
 }
 
 func (suite *TagTestSuite) SetupTest() {
@@ -24,6 +26,7 @@ func (suite *TagTestSuite) SetupTest() {
 	suite.envName = "tag-env"
 	suite.envType = "K8S"
 	suite.controlID = "tag-control"
+	suite.repoName = "kosli-dev/cli"
 	global = &GlobalOpts{
 		ApiToken: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6ImNkNzg4OTg5In0.e8i_lA_QrEhFncb05Xw6E_tkCHU9QfcY4OLTVUCHffY",
 		Org:      "docs-cmd-test-user",
@@ -34,6 +37,26 @@ func (suite *TagTestSuite) SetupTest() {
 	CreateFlow(suite.flowName, suite.T())
 	CreateEnv(global.Org, suite.envName, suite.envType, suite.T())
 	CreateControl(global.Org, suite.controlID, "Tag control", suite.T())
+
+	// repos are created implicitly when a trail is begun with git repo info
+	SetEnvVars(map[string]string{
+		"GITHUB_RUN_NUMBER":    "1234",
+		"GITHUB_SERVER_URL":    "https://github.com",
+		"GITHUB_REPOSITORY":    suite.repoName,
+		"GITHUB_REPOSITORY_ID": "1234567890",
+	}, suite.T())
+	CreateFlowWithTemplate("tag-repo-flow", "testdata/valid_template.yml", suite.T())
+	BeginTrail("tag-repo-trail", "tag-repo-flow", "", suite.T())
+	suite.repoID = GetRepoID(global.Org, suite.repoName, suite.T())
+}
+
+func (suite *TagTestSuite) TearDownTest() {
+	UnSetEnvVars(map[string]string{
+		"GITHUB_RUN_NUMBER":    "",
+		"GITHUB_SERVER_URL":    "",
+		"GITHUB_REPOSITORY":    "",
+		"GITHUB_REPOSITORY_ID": "",
+	}, suite.T())
 }
 
 func (suite *TagTestSuite) TestTagCmd() {
@@ -88,6 +111,33 @@ func (suite *TagTestSuite) TestTagCmd() {
 			name:        "tagging a non-existing control gives a clear error",
 			cmd:         fmt.Sprintf("tag control no-such-control --set foo=bar %s", suite.defaultKosliArguments),
 			goldenRegex: "^Error: \"Control 'no-such-control' does not exist in organization",
+		},
+		{
+			name:   "can tag a repo by its internal id",
+			cmd:    fmt.Sprintf("tag repo %s --set team=platform %s", suite.repoID, suite.defaultKosliArguments),
+			golden: fmt.Sprintf("Tag(s) [team] added for repo '%s'\n", suite.repoID),
+		},
+		{
+			name:   "can remove a tag from a repo",
+			cmd:    fmt.Sprintf("tag repo %s --unset team %s", suite.repoID, suite.defaultKosliArguments),
+			golden: fmt.Sprintf("Tag(s) [team] removed for repo '%s'\n", suite.repoID),
+		},
+		{
+			name:   "can tag a repo using the plural resource type",
+			cmd:    fmt.Sprintf("tag repos %s --set key=value %s", suite.repoID, suite.defaultKosliArguments),
+			golden: fmt.Sprintf("Tag(s) [key] added for repos '%s'\n", suite.repoID),
+		},
+		{
+			wantError:   true,
+			name:        "tagging a non-existing repo id gives a clear error",
+			cmd:         fmt.Sprintf("tag repo no-such-repo-id --set foo=bar %s", suite.defaultKosliArguments),
+			goldenRegex: "^Error: \"Repo 'no-such-repo-id' does not exist in organization",
+		},
+		{
+			wantError:   true,
+			name:        "an invalid resource type gives a clear error listing valid types",
+			cmd:         fmt.Sprintf("tag junk some-id --set foo=bar %s", suite.defaultKosliArguments),
+			goldenRegex: `^Error: junk is not a valid resource type\. Valid resource types are: \[flow flows env environment environments control controls repo repos\]`,
 		},
 	}
 	runTestCmd(suite.T(), tests)

--- a/cmd/kosli/testHelpers.go
+++ b/cmd/kosli/testHelpers.go
@@ -544,6 +544,29 @@ func CreateControl(org, identifier, name string, t *testing.T) {
 	require.NoError(t, err, "control should be created without error")
 }
 
+// GetRepoID fetches a repo's internal id via the get repo endpoint.
+func GetRepoID(org, repoName string, t *testing.T) string {
+	t.Helper()
+	u, err := url.JoinPath(global.Host, "api/v2/repos", org, repoName)
+	require.NoError(t, err, "repo URL should be constructed without error")
+
+	reqParams := &requests.RequestParams{
+		Method: http.MethodGet,
+		URL:    u,
+		Token:  global.ApiToken,
+	}
+	response, err := kosliClient.Do(reqParams)
+	require.NoError(t, err, "repo should be fetched without error")
+
+	var repo struct {
+		ID string `json:"id"`
+	}
+	err = json.Unmarshal([]byte(response.Body), &repo)
+	require.NoError(t, err, "repo response should be valid JSON")
+	require.NotEmpty(t, repo.ID, "repo response should contain an id")
+	return repo.ID
+}
+
 func ArchiveControl(org, identifier string, t *testing.T) {
 	t.Helper()
 	u, err := url.JoinPath(global.Host, "api/v2/controls", org, identifier, "archive")

--- a/cmd/kosli/testHelpers.go
+++ b/cmd/kosli/testHelpers.go
@@ -544,8 +544,9 @@ func CreateControl(org, identifier, name string, t *testing.T) {
 	require.NoError(t, err, "control should be created without error")
 }
 
-// GetRepoID fetches a repo's internal id via the get repo endpoint.
-func GetRepoID(org, repoName string, t *testing.T) string {
+// GetRepoInnerID fetches a repo by name and returns its Kosli inner id
+// (the `id` field), which is the identifier used to tag the repo.
+func GetRepoInnerID(org, repoName string, t *testing.T) string {
 	t.Helper()
 	u, err := url.JoinPath(global.Host, "api/v2/repos", org, repoName)
 	require.NoError(t, err, "repo URL should be constructed without error")


### PR DESCRIPTION
* The server now accepts `repo/repos` resource types on the generic `PATCH /api/v2/tags` endpoint (kosli-dev/server#6156). Repos are keyed by their internal id rather than name, since repo names are not unique across VCS providers. The help text points users at 'kosli get repo' to discover the `id`.
*Also unhide get repo and list repos commands.