### PR TITLE
feat: tag repos via `kosli tag repo` and unhide repo commands

### DIFF
--- a/cmd/kosli/getRepo.go
+++ b/cmd/kosli/getRepo.go
@@ -41,7 +41,6 @@ func newGetRepoCmd(out io.Writer) *cobra.Command {
 	o := new(getRepoOptions)
 	cmd := &cobra.Command{
 		Use:     "repo REPO-NAME",
-		Hidden:  true,
 		Short:   getRepoShortDesc,
 		Long:    getRepoLongDesc,
 		Example: getRepoExample,

--- a/cmd/kosli/lifecycle_test.go
+++ b/cmd/kosli/lifecycle_test.go
@@ -55,6 +55,22 @@ func TestLifecycleControlCommandsAreBeta(t *testing.T) {
 	}
 }
 
+func TestLifecycleRepoCommandsAreVisible(t *testing.T) {
+	global = &GlobalOpts{}
+	cmds := map[string]*cobra.Command{
+		"get repo":   newGetRepoCmd(io.Discard),
+		"list repos": newListReposCmd(io.Discard),
+	}
+	for name, cmd := range cmds {
+		if cmd.Hidden {
+			t.Errorf("expected %q to be visible (not Hidden)", name)
+		}
+		if isDocHidden(cmd) {
+			t.Errorf("expected %q to not be doc-hidden", name)
+		}
+	}
+}
+
 func TestDeprecationHint(t *testing.T) {
 	generic := &cobra.Command{Use: "x", Deprecated: deprecatedCommandMsg}
 	if got := deprecationHint(generic); got != "" {

--- a/cmd/kosli/listRepos.go
+++ b/cmd/kosli/listRepos.go
@@ -24,11 +24,10 @@ type listReposOptions struct {
 func newListReposCmd(out io.Writer) *cobra.Command {
 	o := new(listReposOptions)
 	cmd := &cobra.Command{
-		Use:    "repos",
-		Hidden: true,
-		Short:  listReposDesc,
-		Long:   listReposDesc,
-		Args:   cobra.NoArgs,
+		Use:   "repos",
+		Short: listReposDesc,
+		Long:  listReposDesc,
+		Args:  cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			err := RequireGlobalFlags(global, []string{"Org", "ApiToken"})
 			if err != nil {

--- a/cmd/kosli/tag.go
+++ b/cmd/kosli/tag.go
@@ -62,6 +62,12 @@ kosli tag control yourControlIdentifier \
 	--set key1=value1 \
 	--api-token yourApiToken \
 	--org yourOrgName
+
+# tag a repo (the repo ID is the 'id' field returned by 'kosli get repo')
+kosli tag repo yourRepoID \
+	--set key1=value1 \
+	--api-token yourApiToken \
+	--org yourOrgName
 `
 
 func newTagCmd(out io.Writer) *cobra.Command {
@@ -149,7 +155,7 @@ func (o *tagOptions) run(args []string) error {
 }
 
 func validateResourceType(resourceType string) error {
-	options := []string{"flow", "flows", "env", "environment", "environments", "control", "controls"}
+	options := []string{"flow", "flows", "env", "environment", "environments", "control", "controls", "repo", "repos"}
 	match := false
 	for _, opt := range options {
 		if resourceType == opt {

--- a/cmd/kosli/tag_test.go
+++ b/cmd/kosli/tag_test.go
@@ -17,6 +17,7 @@ type TagTestSuite struct {
 	envName               string
 	envType               string
 	controlID             string
+	repoID                string
 }
 
 func (suite *TagTestSuite) SetupTest() {
@@ -34,6 +35,10 @@ func (suite *TagTestSuite) SetupTest() {
 	CreateFlow(suite.flowName, suite.T())
 	CreateEnv(global.Org, suite.envName, suite.envType, suite.T())
 	CreateControl(global.Org, suite.controlID, "Tag control", suite.T())
+
+	// A repo is created implicitly when a trail records its git repo info.
+	BeginTrail("tag-trail", suite.flowName, "", suite.T())
+	suite.repoID = GetRepoInnerID(global.Org, "kosli-dev/cli", suite.T())
 }
 
 func (suite *TagTestSuite) TestTagCmd() {
@@ -88,6 +93,27 @@ func (suite *TagTestSuite) TestTagCmd() {
 			name:        "tagging a non-existing control gives a clear error",
 			cmd:         fmt.Sprintf("tag control no-such-control --set foo=bar %s", suite.defaultKosliArguments),
 			goldenRegex: "^Error: \"Control 'no-such-control' does not exist in organization",
+		},
+		{
+			name:   "can tag a repo",
+			cmd:    fmt.Sprintf("tag repo %s --set foo=bar %s", suite.repoID, suite.defaultKosliArguments),
+			golden: fmt.Sprintf("Tag(s) [foo] added for repo '%s'\n", suite.repoID),
+		},
+		{
+			name:   "can remove a tag from a repo",
+			cmd:    fmt.Sprintf("tag repo %s --unset foo %s", suite.repoID, suite.defaultKosliArguments),
+			golden: fmt.Sprintf("Tag(s) [foo] removed for repo '%s'\n", suite.repoID),
+		},
+		{
+			name:   "can tag a repo using the plural resource type",
+			cmd:    fmt.Sprintf("tag repos %s --set key=value %s", suite.repoID, suite.defaultKosliArguments),
+			golden: fmt.Sprintf("Tag(s) [key] added for repos '%s'\n", suite.repoID),
+		},
+		{
+			wantError:   true,
+			name:        "tagging a non-existing repo gives a clear error",
+			cmd:         fmt.Sprintf("tag repo no-such-repo --set foo=bar %s", suite.defaultKosliArguments),
+			goldenRegex: "^Error: \"Repo 'no-such-repo' does not exist in organization",
 		},
 	}
 	runTestCmd(suite.T(), tests)

--- a/cmd/kosli/testHelpers.go
+++ b/cmd/kosli/testHelpers.go
@@ -573,6 +573,33 @@ func TagControl(org, identifier string, tags map[string]string, t *testing.T) {
 	require.NoError(t, err, "control should be tagged without error")
 }
 
+// GetRepoInnerID fetches a repo by name and returns its Kosli inner id
+// (the `id` field), which is the identifier used to tag the repo.
+func GetRepoInnerID(org, repoName string, t *testing.T) string {
+	t.Helper()
+	params := url.Values{}
+	params.Set("name", repoName)
+	base, err := url.JoinPath(global.Host, "api/v2/repos", org)
+	require.NoError(t, err, "repo URL should be constructed without error")
+
+	reqParams := &requests.RequestParams{
+		Method: http.MethodGet,
+		URL:    base + "?" + params.Encode(),
+		Token:  global.ApiToken,
+	}
+	response, err := kosliClient.Do(reqParams)
+	require.NoError(t, err, "repo should be fetched without error")
+
+	var parsed struct {
+		Repos []struct {
+			ID string `json:"id"`
+		} `json:"repos"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(response.Body), &parsed), "repo response should be valid JSON")
+	require.NotEmpty(t, parsed.Repos, "repo %q should exist", repoName)
+	return parsed.Repos[0].ID
+}
+
 // CreatePolicy creates a policy on the server
 func CreatePolicy(org, policyName string, t *testing.T) {
 	t.Helper()


### PR DESCRIPTION
## What

Adds support for tagging repos from the CLI and makes the repo commands visible.

- **`kosli tag repo <repo-id>`** — extends the generic `tag` command to accept `repo`/`repos` as a resource type, wiring it to the existing tags endpoint (`PATCH /api/v2/tags/{org}/repo/{id}`). The repo ID is the Kosli inner id (the `id` field returned by `kosli get repo`).
- **Unhides `kosli get repo` and `kosli list repos`** — removes `Hidden: true` so they show in `--help` and the generated CLI reference docs.

Implements the CLI portion of kosli-dev/server#6147 (server side merged in #6156).

## Tests

- `tag_test.go`: happy paths (set / unset / plural `repos`) against a repo created via a trail, plus the not-found error case. New `GetRepoInnerID` test helper resolves a repo's inner id.
- `lifecycle_test.go`: `TestLifecycleRepoCommandsAreVisible` locks in that `get repo` / `list repos` are neither `Hidden` nor doc-hidden.

Full `TestTagTestSuite` passes against the local server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)