### PR TITLE
chore: use same tag filtering for ENVs

### DIFF
--- a/cmd/kosli/lifecycle_test.go
+++ b/cmd/kosli/lifecycle_test.go
@@ -45,6 +45,7 @@ func TestLifecycleControlCommandsAreBeta(t *testing.T) {
 		"create control":    newCreateControlCmd(io.Discard),
 		"list controls":     newListControlsCmd(io.Discard),
 		"get control":       newGetControlCmd(io.Discard),
+		"update control":    newUpdateControlCmd(io.Discard),
 		"archive control":   newArchiveControlCmd(io.Discard),
 		"unarchive control": newUnarchiveControlCmd(io.Discard),
 	}

--- a/cmd/kosli/listEnvironments.go
+++ b/cmd/kosli/listEnvironments.go
@@ -107,7 +107,7 @@ func newListEnvironmentsCmd(out io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&o.name, "name", "", envSearchNameFlag)
 	cmd.Flags().StringSliceVar(&o.envTypes, "type", []string{}, envTypeFilterFlag)
 	cmd.Flags().StringSliceVar(&o.spaceIDs, "space-id", []string{}, envSpaceIDFilterFlag)
-	cmd.Flags().StringSliceVar(&o.tags, "tag", []string{}, envTagFilterFlag)
+	cmd.Flags().StringArrayVar(&o.tags, "tag", []string{}, envTagFilterFlag)
 	cmd.Flags().StringVar(&o.sort, "sort", "", envSortFlag)
 	cmd.Flags().StringVar(&o.sortDirection, "sort-direction", "", envSortDirectionFlag)
 	addListFlags(cmd, &o.listOptions)

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -316,7 +316,7 @@ The ^.kosli_ignore^ will be treated as part of the artifact like any other file,
 	controlDescriptionFlag          = "[optional] The control description."
 	controlLinkFlag                 = "[optional] A link for the control, given as 'name=url'. Can be repeated. Replaces all existing links."
 	controlSearchFlag               = "[optional] Only list controls whose name or identifier contains this substring (case-insensitive)."
-	controlTagFlag                  = "[optional] Filter by tag, given as 'key' or 'key:value'. Can be repeated."
+	controlTagFlag                  = "[optional] Filter by tag, given as 'key' or 'key:value'. Can be repeated to match more than one tag."
 	controlArchivedFlag             = "[optional] List archived controls instead of active ones."
 	controlSortDirectionFlag        = "[optional] The direction to sort controls in. Valid values are: [asc, desc]. (defaults to asc)"
 	envNameFlag                     = "The Kosli environment name to assert the artifact against."


### PR DESCRIPTION
Let's use same tag filetrs as we use for other commands, like Controls and Repos. This change also allows having commas in tag filters.

Also add missing update control test