### PR TITLE
fix(github): serialise empty PR author instead of omitting it 

### DIFF
--- a/cmd/kosli/assertPRGithub_test.go
+++ b/cmd/kosli/assertPRGithub_test.go
@@ -23,7 +23,16 @@ func (suite *AssertPRGithubCommandTestSuite) SetupTest() {
 	ghUtils.NewGithubRetrieverFunc = func(token, baseURL, org, repository string, debug bool) types.PRRetriever {
 		return &ghUtils.FakeGitHubClient{
 			PRsByCommit: map[string][]*types.PREvidence{
-				suite.commitWithPR: {{URL: "https://github.com/kosli-dev/cli/pull/1", State: "MERGED"}},
+				suite.commitWithPR: {{
+					URL:         "https://github.com/kosli-dev/cli/pull/1",
+					State:       "MERGED",
+					Author:      "test-user",
+					Title:       "test PR",
+					CreatedAt:   1234567890,
+					HeadRef:     "test-branch",
+					MergeCommit: suite.commitWithPR,
+					Commits:     []types.Commit{},
+				}},
 			},
 		}
 	}

--- a/cmd/kosli/assertPRGithub_test.go
+++ b/cmd/kosli/assertPRGithub_test.go
@@ -31,7 +31,13 @@ func (suite *AssertPRGithubCommandTestSuite) SetupTest() {
 					CreatedAt:   1234567890,
 					HeadRef:     "test-branch",
 					MergeCommit: suite.commitWithPR,
-					Commits:     []types.Commit{},
+					Commits: []types.Commit{{
+						SHA:       suite.commitWithPR,
+						Message:   "test commit",
+						Author:    "Test User <test@example.com>",
+						Timestamp: 1234567890,
+						Branch:    "test-branch",
+					}},
 				}},
 			},
 		}

--- a/cmd/kosli/attestPRGithub_test.go
+++ b/cmd/kosli/attestPRGithub_test.go
@@ -44,7 +44,13 @@ func (suite *AttestGithubPRCommandTestSuite) SetupTest() {
 					CreatedAt:   1234567890,
 					HeadRef:     "test-branch",
 					MergeCommit: suite.commitWithPR,
-					Commits:     []types.Commit{},
+					Commits: []types.Commit{{
+						SHA:       suite.commitWithPR,
+						Message:   "test commit",
+						Author:    "Test User <test@example.com>",
+						Timestamp: 1234567890,
+						Branch:    "test-branch",
+					}},
 				}},
 			},
 		}

--- a/cmd/kosli/attestPRGithub_test.go
+++ b/cmd/kosli/attestPRGithub_test.go
@@ -36,7 +36,16 @@ func (suite *AttestGithubPRCommandTestSuite) SetupTest() {
 	ghUtils.NewGithubRetrieverFunc = func(token, baseURL, org, repository string, debug bool) types.PRRetriever {
 		return &ghUtils.FakeGitHubClient{
 			PRsByCommit: map[string][]*types.PREvidence{
-				suite.commitWithPR: {{URL: "https://github.com/kosli-dev/cli/pull/1", State: "MERGED"}},
+				suite.commitWithPR: {{
+					URL:         "https://github.com/kosli-dev/cli/pull/1",
+					State:       "MERGED",
+					Author:      "test-user",
+					Title:       "test PR",
+					CreatedAt:   1234567890,
+					HeadRef:     "test-branch",
+					MergeCommit: suite.commitWithPR,
+					Commits:     []types.Commit{},
+				}},
 			},
 		}
 	}

--- a/internal/github/build_pr_evidence_test.go
+++ b/internal/github/build_pr_evidence_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -172,6 +173,11 @@ func TestBuildPREvidence_EmptyAuthorIsPreserved(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "", evidence.Author,
 		"empty PR author login must be preserved so it is serialised as an empty string, not omitted")
+
+	b, err := json.Marshal(evidence)
+	require.NoError(t, err)
+	require.Contains(t, string(b), `"author":""`,
+		"empty author must be serialised, not omitted")
 }
 
 // TestBuildPREvidence_UnsignedCommitHasNoSignatureFields verifies an unsigned

--- a/internal/github/build_pr_evidence_test.go
+++ b/internal/github/build_pr_evidence_test.go
@@ -152,6 +152,28 @@ func TestBuildPREvidence_RecordsCommitSignature(t *testing.T) {
 	require.Equal(t, "VALID", *c.SignatureState)
 }
 
+// TestBuildPREvidence_EmptyAuthorFallsBackToUnknown verifies that when the PR
+// creator's GitHub account has been deleted (Author.Login = ""), the author
+// field falls back to "unknown" so the server's required FoundPullRequestV2.author
+// field is satisfied and the attestation does not fail validation.
+func TestBuildPREvidence_EmptyAuthorFallsBackToUnknown(t *testing.T) {
+	evidence, err := buildPREvidence(
+		"https://github.com/kosli-dev/cli/pull/671",
+		"0e723254516c841126e81f76100be57258ff1386",
+		"MERGED",
+		"", // empty author — PR creator account deleted
+		"2026-03-01T09:00:00Z",
+		"2026-03-01T12:00:00Z",
+		"Fix something",
+		"fix-branch",
+		"main",
+		nil, nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "unknown", evidence.Author,
+		"empty PR author login must fall back to 'unknown' to satisfy FoundPullRequestV2.author required field")
+}
+
 // TestBuildPREvidence_UnsignedCommitHasNoSignatureFields verifies an unsigned
 // commit (no signature node) leaves verified/signature_state nil, so "unsigned"
 // stays distinct from "present-but-invalid" (verified=false).

--- a/internal/github/build_pr_evidence_test.go
+++ b/internal/github/build_pr_evidence_test.go
@@ -152,11 +152,11 @@ func TestBuildPREvidence_RecordsCommitSignature(t *testing.T) {
 	require.Equal(t, "VALID", *c.SignatureState)
 }
 
-// TestBuildPREvidence_EmptyAuthorFallsBackToUnknown verifies that when the PR
-// creator's GitHub account has been deleted (Author.Login = ""), the author
-// field falls back to "unknown" so the server's required FoundPullRequestV2.author
-// field is satisfied and the attestation does not fail validation.
-func TestBuildPREvidence_EmptyAuthorFallsBackToUnknown(t *testing.T) {
+// TestBuildPREvidence_EmptyAuthorIsPreserved verifies that when the PR
+// creator's GitHub account has been deleted (Author.Login = ""), the empty
+// string is preserved and serialised as "" rather than omitted, allowing the
+// server to accept it directly.
+func TestBuildPREvidence_EmptyAuthorIsPreserved(t *testing.T) {
 	evidence, err := buildPREvidence(
 		"https://github.com/kosli-dev/cli/pull/671",
 		"0e723254516c841126e81f76100be57258ff1386",
@@ -170,8 +170,8 @@ func TestBuildPREvidence_EmptyAuthorFallsBackToUnknown(t *testing.T) {
 		nil, nil,
 	)
 	require.NoError(t, err)
-	require.Equal(t, "unknown", evidence.Author,
-		"empty PR author login must fall back to 'unknown' to satisfy FoundPullRequestV2.author required field")
+	require.Equal(t, "", evidence.Author,
+		"empty PR author login must be preserved so it is serialised as an empty string, not omitted")
 }
 
 // TestBuildPREvidence_UnsignedCommitHasNoSignatureFields verifies an unsigned

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -309,13 +309,6 @@ func buildPREvidence(
 		mergedAt = mergedAtTime.Unix()
 	}
 
-	// author is empty when the PR creator's GitHub account has been deleted.
-	// FoundPullRequestV2.author is a required field on the server; since
-	// PREvidence.Author has omitempty, sending "" would omit it and fail validation.
-	if author == "" {
-		author = "unknown"
-	}
-
 	evidence := &types.PREvidence{
 		URL:         url,
 		MergeCommit: mergeCommit,

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -309,6 +309,13 @@ func buildPREvidence(
 		mergedAt = mergedAtTime.Unix()
 	}
 
+	// author is empty when the PR creator's GitHub account has been deleted.
+	// FoundPullRequestV2.author is a required field on the server; since
+	// PREvidence.Author has omitempty, sending "" would omit it and fail validation.
+	if author == "" {
+		author = "unknown"
+	}
+
 	evidence := &types.PREvidence{
 		URL:         url,
 		MergeCommit: mergeCommit,

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -5,7 +5,7 @@ type PREvidence struct {
 	URL         string   `json:"url"`
 	State       string   `json:"state"`
 	Approvers   []any    `json:"approvers"`
-	Author      string   `json:"author,omitempty"`
+	Author      string   `json:"author"`
 	CreatedAt   int64    `json:"created_at,omitempty"`
 	MergedAt    int64    `json:"merged_at,omitempty"`
 	Title       string   `json:"title,omitempty"`


### PR DESCRIPTION
## Summary

- When a PR creator's GitHub account is deleted, the GraphQL API returns `null` for the `Author` node, resulting in `author = ""` in Go
- `PREvidence.Author` has `omitempty`, so an empty string is omitted from the JSON payload entirely
- The server's `FoundPullRequestV2.author` is a required field — missing it causes validation to fail with `"input should be a string extra inputs are not permitted"`
- Fix: guard in `buildPREvidence` substitutes `"unknown"` when `author == ""`, covering both `PREvidenceForCommitV2` and `PREvidenceByPRNumber` call sites

## Test plan

- [ ] `TestBuildPREvidence_EmptyAuthorFallsBackToUnknown` added and passes
- [ ] All `internal/github` tests pass (`go test ./internal/github/...`)
- [ ] `go vet ./internal/github/...` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)