### PR TITLE
feat: add `--auto-environment` flag to kosli snapshot

### DIFF
--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -285,6 +285,7 @@ The ^.kosli_ignore^ will be treated as part of the artifact like any other file,
 	excludeScalingFlag              = "[optional] Exclude scaling events for snapshots. Snapshots with scaling changes will not result in new environment records."
 	includeScalingFlag              = "[optional] Include scaling events for snapshots. Snapshots with scaling changes will result in new environment records."
 	includedEnvironments            = "[optional] Comma separated list of environments to include in logical environment"
+	autoEnvironmentFlag             = "[optional] Create the environment (with the type inferred from the snapshot subcommand) if it does not already exist, before reporting the snapshot."
 	requireProvenanceFlag           = "[defaulted] Require provenance for all artifacts running in environment snapshots."
 	setTagsFlag                     = "[optional] The key-value pairs to tag the resource with. The format is: key=value"
 	unsetTagsFlag                   = "[optional] The list of tag keys to remove from the resource."

--- a/cmd/kosli/snapshot.go
+++ b/cmd/kosli/snapshot.go
@@ -15,6 +15,8 @@ func newSnapshotCmd(out io.Writer) *cobra.Command {
 		Long:  snapshotDesc,
 	}
 
+	addAutoEnvironmentFlags(cmd)
+
 	// Add subcommands
 	cmd.AddCommand(
 		newSnapshotDockerCmd(out),

--- a/cmd/kosli/snapshotAutoEnvironment.go
+++ b/cmd/kosli/snapshotAutoEnvironment.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/kosli-dev/cli/internal/requests"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// autoEnvOptions holds the values of the group-wide auto-environment flags that
+// are shared across all `kosli snapshot` subcommands.
+type autoEnvOptions struct {
+	autoEnvironment bool
+	description     string
+	includeScaling  bool
+	excludeScaling  bool
+}
+
+// snapshotAutoEnv is the shared destination for the auto-environment flags.
+// The flags are registered once as persistent flags on the parent `snapshot`
+// command, mirroring how --dry-run writes to the package-level `global`.
+var snapshotAutoEnv = &autoEnvOptions{}
+
+const defaultAutoEnvDescription = "Auto-created by kosli snapshot"
+
+// addAutoEnvironmentFlags registers the auto-environment flags on the snapshot
+// command group. It is called on the parent `snapshot` command so that every
+// subcommand inherits the flags. `--auto-env` is accepted as an alias for
+// `--auto-environment`.
+func addAutoEnvironmentFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().BoolVarP(&snapshotAutoEnv.autoEnvironment, "auto-environment", "A", false, autoEnvironmentFlag)
+	cmd.PersistentFlags().StringVar(&snapshotAutoEnv.description, "environment-description", "", envDescriptionFlag)
+	cmd.PersistentFlags().BoolVar(&snapshotAutoEnv.includeScaling, "include-scaling", false, includeScalingFlag)
+	cmd.PersistentFlags().BoolVar(&snapshotAutoEnv.excludeScaling, "exclude-scaling", false, excludeScalingFlag)
+
+	// Accept --auto-env as an alias for --auto-environment. SetGlobalNormalizationFunc
+	// propagates to all subcommands of the snapshot group.
+	cmd.SetGlobalNormalizationFunc(func(f *pflag.FlagSet, name string) pflag.NormalizedName {
+		if name == "auto-env" {
+			name = "auto-environment"
+		}
+		return pflag.NormalizedName(name)
+	})
+}
+
+// ensureEnvironment auto-creates the target environment before a snapshot is
+// reported, when --auto-environment is set. It is a no-op when the flag is not
+// set or when the environment already exists with a matching type. envType is
+// inferred from the snapshot subcommand (e.g. "docker", "K8S").
+func ensureEnvironment(envName, envType string) error {
+	o := snapshotAutoEnv
+	optionalFlagsSet := o.description != "" || o.includeScaling || o.excludeScaling
+
+	if !o.autoEnvironment {
+		if optionalFlagsSet {
+			logger.Warn("--environment-description, --include-scaling and --exclude-scaling are ignored unless --auto-environment is set")
+		}
+		return nil
+	}
+
+	if o.includeScaling && o.excludeScaling {
+		return fmt.Errorf("only one of --include-scaling, --exclude-scaling is allowed")
+	}
+
+	if global.DryRun {
+		logger.Info("dry-run: environment %s would be created with type %s if it does not exist", envName, envType)
+		return nil
+	}
+
+	exists, existingType, err := getEnvironmentTypeIfExists(envName)
+	if err != nil {
+		return err
+	}
+	if exists {
+		if strings.EqualFold(existingType, "logical") {
+			return fmt.Errorf("cannot report a snapshot to the logical environment %s", envName)
+		}
+		if !strings.EqualFold(existingType, envType) {
+			return fmt.Errorf("environment %s already exists with type %s, which does not match the snapshot type %s", envName, existingType, envType)
+		}
+		if optionalFlagsSet {
+			logger.Warn("environment %s already exists; --environment-description, --include-scaling and --exclude-scaling are ignored", envName)
+		}
+		return nil
+	}
+
+	return createEnvironmentForSnapshot(envName, envType)
+}
+
+// getEnvironmentTypeIfExists fetches the environment's metadata and returns
+// whether it exists along with its type. A failed GET (most commonly a 404 for
+// an environment that has not been created yet) is treated as "does not exist";
+// any genuine error (auth, network) resurfaces from the subsequent create or
+// report request.
+func getEnvironmentTypeIfExists(envName string) (bool, string, error) {
+	reqURL, err := url.JoinPath(global.Host, "api/v2/environments", global.Org, envName)
+	if err != nil {
+		return false, "", err
+	}
+
+	reqParams := &requests.RequestParams{
+		Method: http.MethodGet,
+		URL:    reqURL,
+		Token:  global.ApiToken,
+	}
+	response, err := kosliClient.Do(reqParams)
+	if err != nil {
+		logger.Debug("could not fetch environment %s, assuming it does not exist: %v", envName, err)
+		return false, "", nil
+	}
+
+	var env map[string]interface{}
+	if err := json.Unmarshal([]byte(response.Body), &env); err != nil {
+		return false, "", err
+	}
+	envType, _ := env["type"].(string)
+	return true, envType, nil
+}
+
+// createEnvironmentForSnapshot creates a physical environment of the inferred
+// type, applying the optional --environment-description and scaling flags. It
+// reuses the same payload and endpoint as `kosli create environment`.
+func createEnvironmentForSnapshot(envName, envType string) error {
+	reqURL, err := url.JoinPath(global.Host, "api/v2/environments", global.Org)
+	if err != nil {
+		return err
+	}
+
+	description := snapshotAutoEnv.description
+	if description == "" {
+		description = defaultAutoEnvDescription
+	}
+
+	payload := CreateEnvironmentPayload{
+		Name:        envName,
+		Type:        envType,
+		Description: description,
+	}
+	if snapshotAutoEnv.includeScaling {
+		myTrue := true
+		payload.IncludeScaling = &myTrue
+	}
+	if snapshotAutoEnv.excludeScaling {
+		myFalse := false
+		payload.IncludeScaling = &myFalse
+	}
+
+	reqParams := &requests.RequestParams{
+		Method:  http.MethodPut,
+		URL:     reqURL,
+		Payload: payload,
+		Token:   global.ApiToken,
+	}
+	if _, err := kosliClient.Do(reqParams); err != nil {
+		return fmt.Errorf("failed to auto-create environment %s: %v", envName, err)
+	}
+	logger.Info("environment %s was created", envName)
+	return nil
+}

--- a/cmd/kosli/snapshotAutoEnvironment.go
+++ b/cmd/kosli/snapshotAutoEnvironment.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -54,6 +55,14 @@ func addAutoEnvironmentFlags(cmd *cobra.Command) {
 // inferred from the snapshot subcommand (e.g. "docker", "K8S").
 func ensureEnvironment(envName, envType string) error {
 	o := snapshotAutoEnv
+
+	// Enforce the scaling-flag mutual exclusion unconditionally, mirroring
+	// `kosli create environment`, so the behaviour is consistent whether or not
+	// --auto-environment is set.
+	if o.includeScaling && o.excludeScaling {
+		return fmt.Errorf("only one of --include-scaling, --exclude-scaling is allowed")
+	}
+
 	optionalFlagsSet := o.description != "" || o.includeScaling || o.excludeScaling
 
 	if !o.autoEnvironment {
@@ -61,10 +70,6 @@ func ensureEnvironment(envName, envType string) error {
 			logger.Warn("--environment-description, --include-scaling and --exclude-scaling are ignored unless --auto-environment is set")
 		}
 		return nil
-	}
-
-	if o.includeScaling && o.excludeScaling {
-		return fmt.Errorf("only one of --include-scaling, --exclude-scaling is allowed")
 	}
 
 	if global.DryRun {
@@ -110,8 +115,16 @@ func getEnvironmentTypeIfExists(envName string) (bool, string, error) {
 	}
 	response, err := kosliClient.Do(reqParams)
 	if err != nil {
-		logger.Debug("could not fetch environment %s, assuming it does not exist: %v", envName, err)
-		return false, "", nil
+		// Only a genuine 404 means the environment does not exist yet. Any other
+		// error (auth, network, 5xx after retries) is propagated so we never fall
+		// through to a create-or-update PUT that could overwrite an existing
+		// environment or bypass the type/logical safety checks.
+		var apiErr *requests.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound {
+			logger.Debug("environment %s does not exist yet", envName)
+			return false, "", nil
+		}
+		return false, "", err
 	}
 
 	var env map[string]interface{}

--- a/cmd/kosli/snapshotAutoEnvironment.go
+++ b/cmd/kosli/snapshotAutoEnvironment.go
@@ -98,10 +98,10 @@ func ensureEnvironment(envName, envType string) error {
 }
 
 // getEnvironmentTypeIfExists fetches the environment's metadata and returns
-// whether it exists along with its type. A failed GET (most commonly a 404 for
-// an environment that has not been created yet) is treated as "does not exist";
-// any genuine error (auth, network) resurfaces from the subsequent create or
-// report request.
+// whether it exists along with its type. Only a genuine HTTP 404 is treated as
+// "does not exist" (exists=false, nil error); any other error (auth, network,
+// 5xx after retries) is returned to the caller so it is never mistaken for a
+// missing environment.
 func getEnvironmentTypeIfExists(envName string) (bool, string, error) {
 	reqURL, err := url.JoinPath(global.Host, "api/v2/environments", global.Org, envName)
 	if err != nil {

--- a/cmd/kosli/snapshotAutoEnvironment_test.go
+++ b/cmd/kosli/snapshotAutoEnvironment_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// SnapshotAutoEnvironmentTestSuite exercises the group-wide --auto-environment
+// flag shared across all `kosli snapshot` subcommands. The `snapshot paths`
+// subcommand is used as a representative because its output is deterministic.
+type SnapshotAutoEnvironmentTestSuite struct {
+	suite.Suite
+	defaultKosliArguments string
+	pathsFileArg          string
+	// pre-existing environments
+	existingServerEnv string
+	existingDockerEnv string
+	logicalEnv        string
+	// unique per-process names for the auto-creation cases
+	newEnv   string
+	aliasEnv string
+}
+
+func (suite *SnapshotAutoEnvironmentTestSuite) SetupSuite() {
+	global = &GlobalOpts{
+		ApiToken: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6ImNkNzg4OTg5In0.e8i_lA_QrEhFncb05Xw6E_tkCHU9QfcY4OLTVUCHffY",
+		Org:      "docs-cmd-test-user",
+		Host:     "http://localhost:8001",
+	}
+	suite.defaultKosliArguments = fmt.Sprintf(" --host %s --org %s --api-token %s", global.Host, global.Org, global.ApiToken)
+	suite.pathsFileArg = "--paths-file testdata/paths-files/valid-pathsfile.yml"
+
+	// Unique-per-process names so re-running against a long-lived server still
+	// exercises the "does not exist yet" creation path.
+	pid := os.Getpid()
+	suite.existingServerEnv = fmt.Sprintf("autoenv-existing-server-%d", pid)
+	suite.existingDockerEnv = fmt.Sprintf("autoenv-existing-docker-%d", pid)
+	suite.logicalEnv = fmt.Sprintf("autoenv-logical-%d", pid)
+	suite.newEnv = fmt.Sprintf("autoenv-new-%d", pid)
+	suite.aliasEnv = fmt.Sprintf("autoenv-alias-%d", pid)
+
+	CreateEnv(global.Org, suite.existingServerEnv, "server", suite.T())
+	CreateEnv(global.Org, suite.existingDockerEnv, "docker", suite.T())
+	suite.createLogicalEnv(suite.logicalEnv, []string{suite.existingServerEnv})
+}
+
+func (suite *SnapshotAutoEnvironmentTestSuite) createLogicalEnv(name string, included []string) {
+	suite.T().Helper()
+	o := &createEnvOptions{
+		payload: CreateEnvironmentPayload{
+			Name:                 name,
+			Type:                 "logical",
+			Description:          "test logical env",
+			IncludedEnvironments: included,
+		},
+	}
+	require.NoError(suite.T(), o.run([]string{name}), "logical env should be created without error")
+}
+
+func (suite *SnapshotAutoEnvironmentTestSuite) TestSnapshotAutoEnvironment() {
+	tests := []cmdTestCase{
+		{
+			name:   "auto-creates the environment with the inferred type when it does not exist",
+			cmd:    fmt.Sprintf(`snapshot paths %s --auto-environment %s %s`, suite.newEnv, suite.pathsFileArg, suite.defaultKosliArguments),
+			golden: fmt.Sprintf("environment %s was created\n[1] artifacts were reported to environment %s\n", suite.newEnv, suite.newEnv),
+		},
+		{
+			name:   "--auto-env alias auto-creates the environment",
+			cmd:    fmt.Sprintf(`snapshot paths %s --auto-env %s %s`, suite.aliasEnv, suite.pathsFileArg, suite.defaultKosliArguments),
+			golden: fmt.Sprintf("environment %s was created\n[1] artifacts were reported to environment %s\n", suite.aliasEnv, suite.aliasEnv),
+		},
+		{
+			name:   "is idempotent (no-op) when the environment already exists",
+			cmd:    fmt.Sprintf(`snapshot paths %s --auto-environment %s %s`, suite.existingServerEnv, suite.pathsFileArg, suite.defaultKosliArguments),
+			golden: fmt.Sprintf("[1] artifacts were reported to environment %s\n", suite.existingServerEnv),
+		},
+		{
+			wantError: true,
+			name:      "errors when the existing environment has a different type",
+			cmd:       fmt.Sprintf(`snapshot paths %s --auto-environment %s %s`, suite.existingDockerEnv, suite.pathsFileArg, suite.defaultKosliArguments),
+			golden:    fmt.Sprintf("Error: environment %s already exists with type docker, which does not match the snapshot type server\n", suite.existingDockerEnv),
+		},
+		{
+			wantError: true,
+			name:      "errors when targeting a logical environment",
+			cmd:       fmt.Sprintf(`snapshot paths %s --auto-environment %s %s`, suite.logicalEnv, suite.pathsFileArg, suite.defaultKosliArguments),
+			golden:    fmt.Sprintf("Error: cannot report a snapshot to the logical environment %s\n", suite.logicalEnv),
+		},
+		{
+			wantError: true,
+			name:      "errors when both scaling flags are set",
+			cmd:       fmt.Sprintf(`snapshot paths %s --auto-environment --include-scaling --exclude-scaling %s %s`, suite.newEnv, suite.pathsFileArg, suite.defaultKosliArguments),
+			golden:    "Error: only one of --include-scaling, --exclude-scaling is allowed\n",
+		},
+		{
+			name:   "warns and ignores optional flags when --auto-environment is not set",
+			cmd:    fmt.Sprintf(`snapshot paths %s --environment-description "ignored" %s %s`, suite.existingServerEnv, suite.pathsFileArg, suite.defaultKosliArguments),
+			golden: fmt.Sprintf("[warning] --environment-description, --include-scaling and --exclude-scaling are ignored unless --auto-environment is set\n[1] artifacts were reported to environment %s\n", suite.existingServerEnv),
+		},
+	}
+
+	runTestCmd(suite.T(), tests)
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestSnapshotAutoEnvironmentTestSuite(t *testing.T) {
+	suite.Run(t, new(SnapshotAutoEnvironmentTestSuite))
+}

--- a/cmd/kosli/snapshotAutoEnvironment_test.go
+++ b/cmd/kosli/snapshotAutoEnvironment_test.go
@@ -21,8 +21,9 @@ type SnapshotAutoEnvironmentTestSuite struct {
 	existingDockerEnv string
 	logicalEnv        string
 	// unique per-process names for the auto-creation cases
-	newEnv   string
-	aliasEnv string
+	newEnv    string
+	aliasEnv  string
+	dryRunEnv string
 }
 
 func (suite *SnapshotAutoEnvironmentTestSuite) SetupSuite() {
@@ -42,6 +43,7 @@ func (suite *SnapshotAutoEnvironmentTestSuite) SetupSuite() {
 	suite.logicalEnv = fmt.Sprintf("autoenv-logical-%d", pid)
 	suite.newEnv = fmt.Sprintf("autoenv-new-%d", pid)
 	suite.aliasEnv = fmt.Sprintf("autoenv-alias-%d", pid)
+	suite.dryRunEnv = fmt.Sprintf("autoenv-dryrun-%d", pid)
 
 	CreateEnv(global.Org, suite.existingServerEnv, "server", suite.T())
 	CreateEnv(global.Org, suite.existingDockerEnv, "docker", suite.T())
@@ -92,14 +94,36 @@ func (suite *SnapshotAutoEnvironmentTestSuite) TestSnapshotAutoEnvironment() {
 		},
 		{
 			wantError: true,
+			name:      "infers the type from the subcommand (docker) for the mismatch check",
+			cmd:       fmt.Sprintf(`snapshot docker %s --auto-environment %s`, suite.existingServerEnv, suite.defaultKosliArguments),
+			golden:    fmt.Sprintf("Error: environment %s already exists with type server, which does not match the snapshot type docker\n", suite.existingServerEnv),
+		},
+		{
+			wantError: true,
 			name:      "errors when both scaling flags are set",
 			cmd:       fmt.Sprintf(`snapshot paths %s --auto-environment --include-scaling --exclude-scaling %s %s`, suite.newEnv, suite.pathsFileArg, suite.defaultKosliArguments),
+			golden:    "Error: only one of --include-scaling, --exclude-scaling is allowed\n",
+		},
+		{
+			wantError: true,
+			name:      "errors when both scaling flags are set even without --auto-environment",
+			cmd:       fmt.Sprintf(`snapshot paths %s --include-scaling --exclude-scaling %s %s`, suite.existingServerEnv, suite.pathsFileArg, suite.defaultKosliArguments),
 			golden:    "Error: only one of --include-scaling, --exclude-scaling is allowed\n",
 		},
 		{
 			name:   "warns and ignores optional flags when --auto-environment is not set",
 			cmd:    fmt.Sprintf(`snapshot paths %s --environment-description "ignored" %s %s`, suite.existingServerEnv, suite.pathsFileArg, suite.defaultKosliArguments),
 			golden: fmt.Sprintf("[warning] --environment-description, --include-scaling and --exclude-scaling are ignored unless --auto-environment is set\n[1] artifacts were reported to environment %s\n", suite.existingServerEnv),
+		},
+		{
+			name:   "warns that optional flags are ignored when the environment already exists",
+			cmd:    fmt.Sprintf(`snapshot paths %s --auto-environment --environment-description "ignored" %s %s`, suite.existingServerEnv, suite.pathsFileArg, suite.defaultKosliArguments),
+			golden: fmt.Sprintf("[warning] environment %s already exists; --environment-description, --include-scaling and --exclude-scaling are ignored\n[1] artifacts were reported to environment %s\n", suite.existingServerEnv, suite.existingServerEnv),
+		},
+		{
+			name:        "dry-run reports what would be created without creating anything",
+			cmd:         fmt.Sprintf(`snapshot paths %s --auto-environment --dry-run %s %s`, suite.dryRunEnv, suite.pathsFileArg, suite.defaultKosliArguments),
+			goldenRegex: fmt.Sprintf("dry-run: environment %s would be created with type server if it does not exist", suite.dryRunEnv),
 		},
 	}
 

--- a/cmd/kosli/snapshotAzureApps.go
+++ b/cmd/kosli/snapshotAzureApps.go
@@ -109,6 +109,11 @@ func newSnapshotAzureAppsCmd(out io.Writer) *cobra.Command {
 
 func (o *snapshotAzureAppsOptions) run(args []string) error {
 	envName := args[0]
+
+	if err := ensureEnvironment(envName, "azure-apps"); err != nil {
+		return err
+	}
+
 	url, err := url.JoinPath(global.Host, "api/v2/environments", global.Org, envName, "report/azure-apps")
 	if err != nil {
 		return err

--- a/cmd/kosli/snapshotCloudRun.go
+++ b/cmd/kosli/snapshotCloudRun.go
@@ -148,6 +148,11 @@ func newSnapshotCloudRunCmd(out io.Writer) *cobra.Command {
 
 func (o *snapshotCloudRunOptions) run(args []string) error {
 	envName := args[0]
+
+	if err := ensureEnvironment(envName, "cloud-run"); err != nil {
+		return err
+	}
+
 	reportURL, err := url.JoinPath(global.Host, "api/v2/environments", global.Org, envName, "report/cloud-run")
 	if err != nil {
 		return err

--- a/cmd/kosli/snapshotDocker.go
+++ b/cmd/kosli/snapshotDocker.go
@@ -29,6 +29,13 @@ const snapshotDockerExample = `
 # report what is running in a docker host:
 kosli snapshot docker yourEnvironmentName \
 	--api-token yourAPIToken \
+	--org yourOrgName
+
+# report a docker snapshot, creating the environment first if it does not exist:
+kosli snapshot docker yourEnvironmentName \
+	--auto-environment \
+	--environment-description "Production docker host" \
+	--api-token yourAPIToken \
 	--org yourOrgName`
 
 type snapshotDockerOptions struct{}
@@ -59,6 +66,10 @@ func newSnapshotDockerCmd(out io.Writer) *cobra.Command {
 
 func (o *snapshotDockerOptions) run(args []string) error {
 	envName := args[0]
+
+	if err := ensureEnvironment(envName, "docker"); err != nil {
+		return err
+	}
 
 	url, err := url.JoinPath(global.Host, "api/v2/environments", global.Org, envName, "report/docker")
 	if err != nil {

--- a/cmd/kosli/snapshotECS.go
+++ b/cmd/kosli/snapshotECS.go
@@ -194,6 +194,11 @@ func newSnapshotECSCmd(out io.Writer) *cobra.Command {
 
 func (o *snapshotECSOptions) run(args []string) error {
 	envName := args[0]
+
+	if err := ensureEnvironment(envName, "ECS"); err != nil {
+		return err
+	}
+
 	url, err := url.JoinPath(global.Host, "api/v2/environments", global.Org, envName, "report/ECS")
 	if err != nil {
 		return err

--- a/cmd/kosli/snapshotK8S.go
+++ b/cmd/kosli/snapshotK8S.go
@@ -266,6 +266,10 @@ func (o *snapshotK8SOptions) runMultiEnv() error {
 }
 
 func (o *snapshotK8SOptions) reportEnvironment(clientset *kube.K8SConnection, envName string, filter *filters.ResourceFilterOptions) error {
+	if err := ensureEnvironment(envName, "K8S"); err != nil {
+		return err
+	}
+
 	podsData, err := clientset.GetPodsData(filter, logger)
 	if err != nil {
 		return err

--- a/cmd/kosli/snapshotLambda.go
+++ b/cmd/kosli/snapshotLambda.go
@@ -149,6 +149,10 @@ func newSnapshotLambdaCmd(out io.Writer) *cobra.Command {
 func (o *snapshotLambdaOptions) run(args []string) error {
 	envName := args[0]
 
+	if err := ensureEnvironment(envName, "lambda"); err != nil {
+		return err
+	}
+
 	url, err := url.JoinPath(global.Host, "api/v2/environments", global.Org, envName, "report/lambda")
 	if err != nil {
 		return err

--- a/cmd/kosli/snapshotPath.go
+++ b/cmd/kosli/snapshotPath.go
@@ -86,6 +86,11 @@ func newSnapshotPathCmd(out io.Writer) *cobra.Command {
 
 func (o *snapshotPathOptions) run(args []string) error {
 	envName := args[0]
+
+	if err := ensureEnvironment(envName, "server"); err != nil {
+		return err
+	}
+
 	// load path spec from flags
 	ps := &server.PathsSpec{
 		Version: 1,

--- a/cmd/kosli/snapshotPaths.go
+++ b/cmd/kosli/snapshotPaths.go
@@ -90,6 +90,10 @@ func newSnapshotPathsCmd(out io.Writer) *cobra.Command {
 func (o *snapshotPathsOptions) run(args []string) error {
 	envName := args[0]
 
+	if err := ensureEnvironment(envName, "server"); err != nil {
+		return err
+	}
+
 	// load path spec from file
 	ps, err := processPathSpecFile(o.pathSpecFile)
 	if err != nil {

--- a/cmd/kosli/snapshotS3.go
+++ b/cmd/kosli/snapshotS3.go
@@ -131,6 +131,11 @@ func newSnapshotS3Cmd(out io.Writer) *cobra.Command {
 
 func (o *snapshotS3Options) run(args []string) error {
 	envName := args[0]
+
+	if err := ensureEnvironment(envName, "S3"); err != nil {
+		return err
+	}
+
 	url, err := url.JoinPath(global.Host, "api/v2/environments", global.Org, envName, "report/S3")
 	if err != nil {
 		return err

--- a/cmd/kosli/snapshotServer.go
+++ b/cmd/kosli/snapshotServer.go
@@ -97,6 +97,10 @@ func newSnapshotServerCmd(out io.Writer) *cobra.Command {
 func (o *snapshotServerOptions) run(args []string) error {
 	envName := args[0]
 
+	if err := ensureEnvironment(envName, "server"); err != nil {
+		return err
+	}
+
 	url, err := url.JoinPath(global.Host, "api/v2/environments", global.Org, envName, "report/server")
 	if err != nil {
 		return err

--- a/internal/requests/requests.go
+++ b/internal/requests/requests.go
@@ -32,6 +32,19 @@ type HTTPResponse struct {
 	Resp *http.Response
 }
 
+// APIError is returned by Do for a non-2xx HTTP response. It carries the HTTP
+// status code so callers can distinguish, for example, a 404 from an auth or
+// server failure. Its Error() preserves the cleaned server error message, so
+// callers that only print the error keep the same behaviour as before.
+type APIError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *APIError) Error() string {
+	return e.Message
+}
+
 type Client struct {
 	MaxAPIRetries int
 	Debug         bool
@@ -303,7 +316,7 @@ func (c *Client) Do(p *RequestParams) (*HTTPResponse, error) {
 					cleanedErrorMessage = fmt.Sprintf("%s", respBodyMap)
 				}
 			}
-			return nil, fmt.Errorf("%s", cleanedErrorMessage)
+			return nil, &APIError{StatusCode: resp.StatusCode, Message: cleanedErrorMessage}
 		}
 		return &HTTPResponse{string(body), resp}, nil
 	}

--- a/internal/requests/requests.go
+++ b/internal/requests/requests.go
@@ -294,7 +294,10 @@ func (c *Client) Do(p *RequestParams) (*HTTPResponse, error) {
 			err := json.Unmarshal([]byte(body), &respBody)
 			if err != nil {
 				c.Logger.Debug("response body from %s (status %d):\n%s", req.URL, resp.StatusCode, string(body))
-				return &HTTPResponse{}, err
+				// Still carry the status code so callers can distinguish e.g. a 404
+				// with an empty or non-JSON body (a proxy/CDN page). Keep the
+				// (JSON parse) error text as the message.
+				return nil, &APIError{StatusCode: resp.StatusCode, Message: err.Error()}
 			}
 			cleanedErrorMessage := ""
 			if reflect.ValueOf(respBody).Kind() == reflect.String {


### PR DESCRIPTION
Add a group-wide `--auto-environment` (`-A`, alias `--auto-env`) flag to all `kosli snapshot` subcommands that creates the target environment on the fly if it does not already exist, then reports the snapshot. The environment type is inferred from the subcommand (docker, K8S, ECS, S3, lambda, server, azure-apps, cloud-run), so no separate `--type` is required.

Optional pass-through flags configure the auto-created environment:
- `--environment-description` (defaults to "Auto-created by kosli snapshot")
- `--include-scaling` / `--exclude-scaling` (mutually exclusive)

Behavior:
- Idempotent no-op when the environment already exists with a matching type.
- Clear error on type mismatch or when targeting a logical environment.
- Optional flags are ignored with a warning when no environment is created.

Closes #1026 