### PR TITLE
feat: identify failing command with flow and trail in error output

### DIFF
--- a/cmd/kosli/main.go
+++ b/cmd/kosli/main.go
@@ -42,8 +42,27 @@ func main() {
 	}
 }
 
+// enrichError prefixes err with the failing command's identity so users
+// running scripts with several similar commands (e.g. two `kosli attest snyk`
+// calls) can tell which invocation failed. It prepends the command path and,
+// when present and non-empty, the --flow and --trail flag values. env-provided
+// values (KOSLI_FLOW/KOSLI_TRAIL) are included too, since bindFlags sets them
+// on the flag. Returns err unchanged when cmd or err is nil.
+func enrichError(cmd *cobra.Command, err error) error {
+	if cmd == nil || err == nil {
+		return err
+	}
+	parts := []string{cmd.CommandPath()}
+	for _, name := range []string{"flow", "trail"} {
+		if f := cmd.Flags().Lookup(name); f != nil && f.Value.String() != "" {
+			parts = append(parts, fmt.Sprintf("%s=%s", name, f.Value.String()))
+		}
+	}
+	return fmt.Errorf("[%s] %w", strings.Join(parts, " "), err)
+}
+
 func innerMain(cmd *cobra.Command, args []string) error {
-	err := cmd.Execute()
+	executedCmd, err := cmd.ExecuteC()
 	if err == nil {
 		// Cobra handles --version internally and bypasses all hooks, so we print
 		// the update notice here after the fact.
@@ -92,9 +111,9 @@ func innerMain(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if global.DryRun {
-		logger.Info("Error: %s", err.Error())
+		logger.Info("Error: %s", enrichError(executedCmd, err).Error())
 		logger.Warn("Encountered an error but --dry-run is enabled. Exiting with 0 exit code.")
 		return nil
 	}
-	return err
+	return enrichError(executedCmd, err)
 }

--- a/cmd/kosli/main.go
+++ b/cmd/kosli/main.go
@@ -108,6 +108,12 @@ func innerMain(cmd *cobra.Command, args []string) error {
 				}
 			}
 			logger.Error("%s\navailable subcommands are: %s", errMessage, strings.Join(availableSubcommands, " | "))
+			// logger.Error terminates the process (os.Exit), so the line below is
+			// not reached today. We return explicitly to keep this branch
+			// self-contained: the unknown-subcommand case is already reported in a
+			// friendly form, so it must not also fall through to the generic
+			// enriched-error print below.
+			return nil
 		}
 	}
 	if global.DryRun {

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -50,6 +50,22 @@ func (suite *RootCommandTestSuite) TestDebugWinsOverQuiet() {
 		"expected debug notice that --quiet was overridden, got: %q", stderr)
 }
 
+// TestInnerMainEnrichesError drives a failing command through innerMain (which
+// the golden-test harness bypasses) to lock in the wiring: that executedCmd
+// from ExecuteC() is the leaf command and that its --flow/--trail flags are
+// read into the enriched error. cmd.SetArgs is required because newRootCmd does
+// not set the command's args, so ExecuteC would otherwise fall back to os.Args.
+func (suite *RootCommandTestSuite) TestInnerMainEnrichesError() {
+	args := []string{"attest", "snyk", "--flow", "cyber-dojo", "--trail", "live-snyk-scan"}
+	cmd, err := newRootCmd(io.Discard, io.Discard, args)
+	suite.Require().NoError(err)
+	cmd.SetArgs(args)
+
+	err = innerMain(cmd, append([]string{"kosli"}, args...))
+	suite.Require().Error(err)
+	suite.ErrorContains(err, "[kosli attest snyk flow=cyber-dojo trail=live-snyk-scan]")
+}
+
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run
 func TestRootCommandTestSuite(t *testing.T) {

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -160,4 +160,13 @@ func TestEnrichError(t *testing.T) {
 		got := enrichError(leaf(true, "", ""), errors.New("boom"))
 		require.EqualError(t, got, `[kosli attest snyk] boom`)
 	})
+
+	t.Run("preserves the wrapped error for errors.Is", func(t *testing.T) {
+		// enrichError must wrap with %w so callers (and errors.Is/errors.As)
+		// can still unwrap the original error. This guards against an
+		// accidental switch to %v / %s.
+		sentinel := errors.New("server returned 404")
+		got := enrichError(leaf(true, "cyber-dojo", "live-snyk-scan"), sentinel)
+		require.ErrorIs(t, got, sentinel)
+	})
 }

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"testing"
 
 	"github.com/kosli-dev/cli/internal/version"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -109,4 +112,52 @@ func (suite *UpdateNoticeTestSuite) TestVersionNoticeNotShownOnRegularCommands()
 
 func TestUpdateNoticeTestSuite(t *testing.T) {
 	suite.Run(t, new(UpdateNoticeTestSuite))
+}
+
+func TestEnrichError(t *testing.T) {
+	// leaf builds kosli -> attest -> snyk and returns the snyk leaf command,
+	// optionally defining and setting the flow/trail flags on it.
+	leaf := func(withFlags bool, flow, trail string) *cobra.Command {
+		root := &cobra.Command{Use: "kosli"}
+		attest := &cobra.Command{Use: "attest"}
+		snyk := &cobra.Command{Use: "snyk"}
+		root.AddCommand(attest)
+		attest.AddCommand(snyk)
+		if withFlags {
+			snyk.Flags().String("flow", "", "")
+			snyk.Flags().String("trail", "", "")
+			if flow != "" {
+				require.NoError(t, snyk.Flags().Set("flow", flow))
+			}
+			if trail != "" {
+				require.NoError(t, snyk.Flags().Set("trail", trail))
+			}
+		}
+		return snyk
+	}
+
+	t.Run("nil error passes through unchanged", func(t *testing.T) {
+		require.NoError(t, enrichError(leaf(false, "", ""), nil))
+	})
+
+	t.Run("nil cmd passes error through unchanged", func(t *testing.T) {
+		e := errors.New("boom")
+		require.Equal(t, e, enrichError(nil, e))
+	})
+
+	t.Run("command path only when no flow/trail flags exist", func(t *testing.T) {
+		got := enrichError(leaf(false, "", ""), errors.New("server returned 404"))
+		require.EqualError(t, got, `[kosli attest snyk] server returned 404`)
+	})
+
+	t.Run("includes flow and trail when set", func(t *testing.T) {
+		got := enrichError(leaf(true, "cyber-dojo", "live-snyk-scan"), errors.New("server returned 404"))
+		require.EqualError(t, got,
+			`[kosli attest snyk flow=cyber-dojo trail=live-snyk-scan] server returned 404`)
+	})
+
+	t.Run("empty flag values are omitted", func(t *testing.T) {
+		got := enrichError(leaf(true, "", ""), errors.New("boom"))
+		require.EqualError(t, got, `[kosli attest snyk] boom`)
+	})
 }


### PR DESCRIPTION
When a CLI command fails, prefix the error with the command path and, when present, the `--flow` and `--trail` flag values. This lets users running scripts with several similar commands (e.g. two `kosli attest snyk` calls) tell which invocation failed without wrapping each call in custom error handling.

Example new output (also works for muti-host):
```
Error: [kosli attest snyk flow=cyber-dojo trail=live-snyk-scan] failed to parse Snyk sarif results file [...]
```

Closes #232