### PR TITLE
test(docgen): swap deprecated-tag test's command name from report approval to report artifact

### DIFF
--- a/internal/docgen/mintlify_test.go
+++ b/internal/docgen/mintlify_test.go
@@ -46,7 +46,7 @@ func TestMintlifyFrontMatterBetaTag(t *testing.T) {
 
 func TestMintlifyFrontMatterDeprecatedTag(t *testing.T) {
 	f := MintlifyFormatter{}
-	got := f.FrontMatter(CommandMeta{Name: "kosli report approval", Deprecated: true})
+	got := f.FrontMatter(CommandMeta{Name: "kosli report artifact", Deprecated: true})
 	if !strings.Contains(got, `tag: "DEPRECATED"`) {
 		t.Errorf("expected DEPRECATED tag, got:\n%s", got)
 	}


### PR DESCRIPTION
kosli report approval was removed in #1036, leaving the sample name
in TestMintlifyFrontMatterDeprecatedTag stale.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
