### PR TITLE
fix(lint): let make lint bootstrap golangci-lint on a fresh machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ fmt: ## Reformat package sources
 	@go fmt ./...
 
 ensure_golangci-lint:
-	@$HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade golangci-lint
+	@HOMEBREW_NO_AUTO_UPDATE=1 brew list golangci-lint >/dev/null 2>&1 \
+	  || HOMEBREW_NO_AUTO_UPDATE=1 brew install golangci-lint
 
 lint: deps vet ensure_golangci-lint ## Run linting
 	@golangci-lint run --timeout=5m --color always  -v ./...

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,7 @@ fmt: ## Reformat package sources
 	@go fmt ./...
 
 ensure_golangci-lint:
-	@HOMEBREW_NO_AUTO_UPDATE=1 brew list golangci-lint >/dev/null 2>&1 \
-	  || HOMEBREW_NO_AUTO_UPDATE=1 brew install golangci-lint
+	@HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade golangci-lint
 
 lint: deps vet ensure_golangci-lint ## Run linting
 	@golangci-lint run --timeout=5m --color always  -v ./...


### PR DESCRIPTION
  make lint could not run at all on a machine that had never installed
  golangci-lint: brew upgrade requires the formula to be present already, so
  the target died with "Error: golangci-lint not installed" before the linter
  ran. Checking for the formula and installing it when absent makes the target
  idempotent.

  The env var was also never reaching brew. Make expands $H (undefined) and
  leaves the literal OMEBREW_NO_AUTO_UPDATE, so every make lint triggered a
  full brew update, mutating the developer's brew installation as a side
  effect of linting. Dropping the $ passes the assignment to the shell.

  Presence-only, with no upgrade, also keeps local behaviour aligned with CI,
  which uses golangci-lint-action rather than brew.

  Closes #1038