### PR TITLE
test(testHelpers): resolve repo path so InitializeGitRepo works on macOS

### DIFF
--- a/internal/testHelpers/testHelpers.go
+++ b/internal/testHelpers/testHelpers.go
@@ -62,10 +62,19 @@ func CloneGitRepo(url, cloneTo string) (*git.Repository, error) {
 }
 
 func InitializeGitRepo(repoPath string) (*git.Repository, *git.Worktree, billy.Filesystem, error) {
+	// osfs resolves symlinks in a base dir that exists, but leaves a
+	// non-existent one raw. repoPath exists and its ".git" does not yet, so
+	// resolving here keeps the two roots consistent. Without it go-git sees a
+	// relative path other than ".git", concludes the git dir is elsewhere, and
+	// fails trying to create a "gitdir:" file where ".git" already exists.
+	resolvedRepoPath, err := filepath.EvalSymlinks(repoPath)
+	if err != nil {
+		return nil, nil, nil, err
+	}
 	// the repo worktree filesystem. It has to be osfs so that we can give it a path
-	fs := osfs.New(repoPath)
+	fs := osfs.New(resolvedRepoPath)
 	// the filesystem for git database
-	storerFS := osfs.New(filepath.Join(repoPath, ".git"))
+	storerFS := osfs.New(filepath.Join(resolvedRepoPath, ".git"))
 	storer := filesystem.NewStorage(storerFS, cache.NewObjectLRUDefault())
 	// initialize the git repo at the filesystem "fs" and using "storer" as the git database
 	repo, err := git.Init(storer, fs)


### PR DESCRIPTION
  Two internal/gitview tests have failed for every macOS developer since the
  go-billy v5.9.0 bump in ed4e2a2a, with "/.git: is a directory". CI is
  ubuntu-only, so it never caught it. A permanently red local suite hides real
  regressions and trains developers to ignore failures.

  v5.9.0 made osfs EvalSymlinks its base dir when that dir exists, and keep it
  raw when it does not. InitializeGitRepo builds the worktree filesystem from
  repoPath (which exists, so it resolves) and the git database from
  repoPath/.git (which does not exist yet, so it stays raw). On macOS temp
  paths live under /var, a symlink to /private/var, so the two roots disagree.
  go-git then computes a relative path that is not ".git", concludes the git
  dir lives elsewhere, and tries to write a "gitdir:" file over the .git
  directory git.Init just created. Linux temp paths have no symlink, so both
  roots agree and the tests pass.

  Resolving repoPath once, before deriving either filesystem, keeps the roots
  consistent on every platform. Fixing the shared helper also covers the
  latent third call site in cmd/kosli/attestJira_test.go, which only escapes
  the bug today because it skips first when the Jira env vars are unset.

  Test-only: git.Init is never reached outside tests, so no production
  behaviour changes.

  Closes #1039