### PR TITLE
docs: add issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Report a problem with the Kosli CLI
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to file a bug report!
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I searched existing issues and didn't find a duplicate.
+          required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including what you expected to happen instead.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: The exact `kosli` command(s) you ran and any relevant flags or config. Redact any tokens or secrets.
+      placeholder: |
+        1. Run `kosli ...`
+        2. ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: CLI version
+      description: Output of `kosli version`.
+      placeholder: v2.x.y
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, CI system, and how you installed the CLI (script, brew, Docker, etc.).
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / output
+      description: Relevant output, ideally with `--debug`. This will be rendered as code, so no need for backticks. Redact any tokens or secrets.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Kosli documentation
+    url: https://docs.kosli.com
+    about: Guides and reference for the Kosli CLI and platform.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,7 +7,6 @@ body:
     attributes:
       value: Thanks for taking the time to suggest an improvement!
   - type: checkboxes
-  - type: checkboxes
     id: preflight
     attributes:
       label: Preflight

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: Feature request
+description: Suggest an idea or enhancement for the Kosli CLI
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I searched existing issues and didn't find a duplicate.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the use case or pain point. What are you trying to achieve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like the CLI to do? Include example commands or flags if you have them in mind.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds or other approaches you've thought about.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,6 +3,10 @@ description: Suggest an idea or enhancement for the Kosli CLI
 title: "feat: "
 labels: ["enhancement"]
 body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to suggest an improvement!
+  - type: checkboxes
   - type: checkboxes
     id: preflight
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,6 @@
-## Description
-
 <!-- What does this PR change and why? Link any related issue. -->
 
-## Checklist
+### Checklist
 
 - [ ] **Helm chart** (`charts/k8s-reporter/`) updated, if needed. Note: these changes live in a **separate PR**
 - [ ] **Terraform provider** and related changes ([terraform-provider-kosli](https://github.com/kosli-dev/terraform-provider-kosli), [terraform-aws-evidence-reporter](https://github.com/kosli-dev/terraform-aws-evidence-reporter), [terraform-aws-kosli-reporter](https://github.com/kosli-dev/terraform-aws-kosli-reporter)) updated, if needed


### PR DESCRIPTION
Adds GitHub Issue Forms under .github/ISSUE_TEMPLATE/:
- bug_report.yml
- feature_request.yml
- config.yml linking to docs.kosli.com

Amend existing PR template.

<!-- What does this PR change and why? Link any related issue. -->

### Checklist

- [x] **Helm chart** (`charts/k8s-reporter/`) updated, if needed. Note: these changes live in a **separate PR**
- [x] **Terraform provider** and related changes ([terraform-provider-kosli](https://github.com/kosli-dev/terraform-provider-kosli), [terraform-aws-evidence-reporter](https://github.com/kosli-dev/terraform-aws-evidence-reporter), [terraform-aws-kosli-reporter](https://github.com/kosli-dev/terraform-aws-kosli-reporter)) updated, if needed
- [x] **Docs** are autogenerated from CLI help — make sure the help text reflects your changes
