### PR TITLE
fix(release): stop dropping release-notes headings and first bullet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,15 @@ jobs:
         id: get-tag-notes
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
-          BODY=$(git tag -l --format='%(contents:body)' "$TAG")
+          # %(contents), not %(contents:body): the latter drops the tag message's
+          # first paragraph as a "subject", silently swallowing the first heading
+          # or bullet of the release notes.
+          BODY=$(git tag -l --format='%(contents)' "$TAG")
+          # `make release tag=vX.Y.Z` with no dist/release_notes.md tags with the
+          # version as the whole message; that is not release notes.
+          if [ "$(printf '%s' "$BODY" | tr -d '[:space:]')" = "$TAG" ]; then
+            BODY=""
+          fi
           if [ -n "$BODY" ]; then
             printf '%s' "$BODY" > release_notes.md
             echo "args=--release-notes=release_notes.md" >> $GITHUB_OUTPUT

--- a/Makefile
+++ b/Makefile
@@ -218,6 +218,6 @@ release: ## Cut a new release and push next tag
 	else \
 	  git remote update; \
 	  git status -uno | grep --silent "Your branch is up to date" || (echo "ERROR: your branch is NOT up to date with remote" && exit 1); \
-	  ([ -f dist/release_notes.md ] && git tag -a $(tag) -F dist/release_notes.md) || git tag -a $(tag) -m"$(tag)"; \
+	  ([ -f dist/release_notes.md ] && git tag -a $(tag) --cleanup=verbatim -F dist/release_notes.md) || git tag -a $(tag) -m"$(tag)"; \
 	  git push origin $(tag); \
 	fi

--- a/bin/release-interactive.sh
+++ b/bin/release-interactive.sh
@@ -52,6 +52,8 @@ if ! git status -uno | grep -q "Your branch is up to date"; then
   exit 1
 fi
 
-git tag -a "$VER" -F "$RELEASE_NOTES_FILE"
+# --cleanup=verbatim: git's default cleanup strips lines starting with '#' as
+# commentary, which would eat the markdown headings in the release notes.
+git tag -a "$VER" --cleanup=verbatim -F "$RELEASE_NOTES_FILE"
 git push origin "$VER"
 echo "Pushed tag $VER. Release workflow will run on GitHub."


### PR DESCRIPTION
Release notes are carried in the annotated tag message. Two defects combined to truncate them — `v2.35.0` published with only its **last** bullet, losing the `# Breaking changes` heading, the breaking-change bullet, and the `# Improvements` heading.

## Root cause

1. **`git tag -a -F` stripped the headings.** Both tag-creation paths (`bin/release-interactive.sh`, `Makefile` `release` target) omitted `--cleanup`, so git's default cleanup removed every line starting with `#` as commentary.
2. **`%(contents:body)` then ate the first bullet.** The workflow read the tag body with `%(contents:body)`, which omits the message's first paragraph as a "subject". With the headings already gone, that paragraph was the first bullet.

Defect 2 was latent on its own: had the headings survived, `%(contents:body)` would have swallowed `# Breaking changes` instead.

## Changes

- `bin/release-interactive.sh` and `Makefile` — pass `--cleanup=verbatim` to `git tag -a`.
- `.github/workflows/release.yml` — read `%(contents)` instead of `%(contents:body)`.
- Added a guard for the `make release tag=vX.Y.Z` fallback path, which tags with the version as the entire message. `%(contents)` is non-empty there, so without the guard GoReleaser would receive `vX.Y.Z` as the whole release body instead of falling back to its default changelog.

## Verification

Defect 2 is confirmed against the real `v2.35.0` tag: `%(contents)` returns both bullets where `%(contents:body)` returns only the second.

The `--cleanup=verbatim` behaviour is **not** empirically verified here — it rests on git's documented default (`--cleanup=strip` removes commentary) plus the observed symptom (headings present in `dist/release_notes.md`, absent from the pushed tag). The next release exercises it for real; worth a look at the tag message before the workflow runs.

The already-published `v2.35.0` release body has been corrected by hand. Its annotated tag still carries the stripped message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)