### PR TITLE
Fixed make setup_test_to_use_local_image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,8 @@ test_setup_restart_server: ensure_gotestsum
 	export KOSLI_SERVER_IMAGE=$$(cat /tmp/server-image.txt) && ./bin/reset-or-start-server.sh force
 
 setup_test_to_use_local_image:
-	@echo merkely > /tmp/server-image.txt
-	@KOSLI_SERVER_IMAGE=merkely docker compose down -v
+	@echo merkely-test > /tmp/server-image.txt
+	@KOSLI_SERVER_IMAGE=merkely-test docker compose down -v
 	@echo "Run make build in the server repo you want to use"
 	@echo "Then run make test_integration"
 	@echo "To look at the logs from local kosli server run: make follow_integration_test_server"

--- a/bin/reset-or-start-server.sh
+++ b/bin/reset-or-start-server.sh
@@ -25,7 +25,7 @@ restart_server()
 {
     echo restarting server ...
     # Only remote (digest-pinned) images need an AWS login and pull. The local-image
-    # flow uses the plain "merkely" tag, which is built locally — skip both.
+    # flow uses the plain "merkely-test" tag, which is built locally — skip both.
     if [[ "$KOSLI_SERVER_IMAGE" == *"@sha256:"* ]]; then
         ./bin/docker_login_aws.sh staging
         docker pull "${KOSLI_SERVER_IMAGE}" || true


### PR DESCRIPTION
## Description

<!-- What does this PR change and why? Link any related issue. -->

## Checklist

- [ ] **Helm chart** (`charts/k8s-reporter/`) updated, if needed. Note: these changes live in a **separate PR**
- [ ] **Terraform provider** and related changes ([terraform-provider-kosli](https://github.com/kosli-dev/terraform-provider-kosli), [terraform-aws-evidence-reporter](https://github.com/kosli-dev/terraform-aws-evidence-reporter), [terraform-aws-kosli-reporter](https://github.com/kosli-dev/terraform-aws-kosli-reporter)) updated, if needed
- [ ] **Docs** are autogenerated from CLI help — make sure the help text reflects your changes
