### PR TITLE
chore: add a security policy and reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Supported Versions
+
+Only v2 2of CLI is currently supported! Please try and use the latest release before reporting an issue.
+
+## Reporting a Vulnerability
+
+Please send all reports to security@kosli.com and include:
+* Clear description of the vulnerability
+* Steps to reproduce
+* Potential impact assessment
+* Any supporting evidence (screenshots, logs, PoC)
+
+## Our Commitment
+Integrity is a core value at Kosli. We have a strong track record of working fairly and openly with security researchers, and we're committed to transparent communication throughout the disclosure process. We will acknowledge receipt, assess the finding, and respond with our determination. If we classify the vulnerability differently than reported, we'll explain our reasoning.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-Only v2 2of CLI is currently supported! Please try and use the latest release before reporting an issue.
+Only `v2` of the Kosli CLI is currently supported! Please try and use the latest release before reporting an issue.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Updated the security policy to reflect supported versions and reporting procedures.

<!-- What does this PR change and why? Link any related issue. -->

### Checklist

- [x] **Helm chart** (`charts/k8s-reporter/`) updated, if needed. Note: these changes live in a **separate PR**
- [x] **Terraform provider** and related changes ([terraform-provider-kosli](https://github.com/kosli-dev/terraform-provider-kosli), [terraform-aws-evidence-reporter](https://github.com/kosli-dev/terraform-aws-evidence-reporter), [terraform-aws-kosli-reporter](https://github.com/kosli-dev/terraform-aws-kosli-reporter)) updated, if needed
- [x] **Docs** are autogenerated from CLI help — make sure the help text reflects your changes
