### PR TITLE
fix: return non-zero exit for unrecognized commands

### DIFF
--- a/cmd/kosli/main.go
+++ b/cmd/kosli/main.go
@@ -64,19 +64,31 @@ func enrichError(cmd *cobra.Command, err error) error {
 
 // findUnknownCommand detects the unknown-command case that cobra's
 // TraverseChildren routing swallows (issue #1043). It resolves args exactly as
-// cobra will — on a throwaway command tree, so the real command's flag state is
-// left untouched — and returns an error when resolution lands on a command that
-// only groups subcommands (is not runnable) while an unconsumed non-flag token
-// remains. It returns nil, deferring to cobra/ExecuteC, when args reach a
-// runnable command, when nothing non-flag is left over (e.g. `kosli list`
-// printing its own group help), or when Traverse itself errors (an unknown
-// flag, --help, etc. — those paths are already handled downstream).
+// cobra will — on a throwaway command tree, restoring the package-level `global`
+// afterwards so the real command's flag state is left untouched — and returns an
+// error when resolution lands on a command that only groups subcommands (is not
+// runnable) while an unconsumed non-flag token remains. It returns nil,
+// deferring to cobra/ExecuteC, when args reach a runnable command, when nothing
+// non-flag is left over (e.g. `kosli list` printing its own group help), or when
+// Traverse itself errors (an unknown flag, --help, etc. — those paths are
+// already handled downstream).
 func findUnknownCommand(args []string) error {
+	// newRootCmd reassigns the package-level `global` and binds the *real*
+	// command's persistent-flag pointers to it. Building a probe here would
+	// orphan those bindings (cobra would parse the user's flags into the old
+	// struct while every RunE/initialize reads the new one), so save and restore
+	// `global` around the probe.
+	saved := global
+	defer func() { global = saved }()
+
 	probe, err := newRootCmd(io.Discard, io.Discard, args)
 	if err != nil {
 		return nil
 	}
-	c, leftover, err := probe.Traverse(args)
+	// Resolve against the same normalization innerMain applies before executing,
+	// so a space-form bool flag (e.g. `kosli list --debug false`) is not
+	// mistaken for a leftover positional and reported as an unknown command.
+	c, leftover, err := probe.Traverse(normalizeBoolFlagArgs(probe, args))
 	if err != nil || c.Runnable() {
 		return nil
 	}

--- a/cmd/kosli/main.go
+++ b/cmd/kosli/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -61,12 +62,72 @@ func enrichError(cmd *cobra.Command, err error) error {
 	return fmt.Errorf("[%s] %w", strings.Join(parts, " "), err)
 }
 
+// findUnknownCommand detects the unknown-command case that cobra's
+// TraverseChildren routing swallows (issue #1043). It resolves args exactly as
+// cobra will — on a throwaway command tree, so the real command's flag state is
+// left untouched — and returns an error when resolution lands on a command that
+// only groups subcommands (is not runnable) while an unconsumed non-flag token
+// remains. It returns nil, deferring to cobra/ExecuteC, when args reach a
+// runnable command, when nothing non-flag is left over (e.g. `kosli list`
+// printing its own group help), or when Traverse itself errors (an unknown
+// flag, --help, etc. — those paths are already handled downstream).
+func findUnknownCommand(args []string) error {
+	probe, err := newRootCmd(io.Discard, io.Discard, args)
+	if err != nil {
+		return nil
+	}
+	c, leftover, err := probe.Traverse(args)
+	if err != nil || c.Runnable() {
+		return nil
+	}
+	token := ""
+	for _, a := range leftover {
+		if !strings.HasPrefix(a, "-") {
+			token = a
+			break
+		}
+	}
+	if token == "" {
+		return nil
+	}
+	// If the leftover token names a real subcommand, traversal stopped for some
+	// other reason (e.g. an unparseable flag ahead of it), not because the
+	// command is unknown. Defer to cobra/ExecuteC so the existing flag
+	// diagnostics still fire.
+	for _, sc := range c.Commands() {
+		if sc.Name() == token {
+			return nil
+		}
+		for _, alias := range sc.Aliases {
+			if alias == token {
+				return nil
+			}
+		}
+	}
+	availableSubcommands := []string{}
+	for _, sc := range c.Commands() {
+		if !sc.Hidden {
+			availableSubcommands = append(availableSubcommands, strings.Split(sc.Use, " ")[0])
+		}
+	}
+	return fmt.Errorf("unknown command: %s\navailable subcommands are: %s",
+		token, strings.Join(availableSubcommands, " | "))
+}
+
 // innerMain runs cmd against args (args[0] being the program name) and turns
 // the outcome into the process-level error, printing the update notice on the
 // --version path and reporting errors in the friendliest available form.
 func innerMain(cmd *cobra.Command, args []string) error {
 	if len(args) > 1 {
 		cmd.SetArgs(normalizeBoolFlagArgs(cmd, args[1:]))
+		// cobra's TraverseChildren routing hands an unrecognized command token to
+		// the nearest group command with no error; that command then prints help
+		// and exits 0, so a typo'd command silently reports success (issue #1043).
+		// Catch it before executing so the process exits non-zero with a
+		// diagnostic instead.
+		if err := findUnknownCommand(args[1:]); err != nil {
+			return err
+		}
 	}
 	executedCmd, err := cmd.ExecuteC()
 	if err == nil {

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -36,6 +36,10 @@ func (suite *RootCommandTestSuite) TestFindUnknownCommand() {
 		{name: "runnable leaf command is fine", args: []string{"version"}, wantErr: false},
 		{name: "no args is fine", args: []string{}, wantErr: false},
 		{name: "unknown flag defers to cobra", args: []string{"--badflag", "list", "flows"}, wantErr: false},
+		// A space-form bool flag on a group command must be normalized the same
+		// way innerMain normalizes it, otherwise its value ("false") is mistaken
+		// for a leftover positional and wrongly reported as an unknown command.
+		{name: "space-form bool flag on a group command is fine", args: []string{"list", "--debug", "false"}, wantErr: false},
 	}
 	for _, tc := range cases {
 		suite.Run(tc.name, func() {
@@ -49,6 +53,32 @@ func (suite *RootCommandTestSuite) TestFindUnknownCommand() {
 			}
 		})
 	}
+}
+
+// TestInnerMainPreservesGlobalAfterProbe guards the regression the unknown-command
+// probe could introduce: findUnknownCommand builds a throwaway command tree via
+// newRootCmd, which reassigns the package-level `global`. If it is not restored,
+// the real command's persistent-flag pointers are orphaned and every global.*
+// read (ApiToken, Host, ...) sees the throwaway struct's defaults instead of the
+// user's flag values. Drive a successful real command with global flags through
+// innerMain (which the golden harness bypasses) and assert the values survive.
+func (suite *RootCommandTestSuite) TestInnerMainPreservesGlobalAfterProbe() {
+	args := []string{
+		"fingerprint", "testdata/person-schema.json",
+		"--artifact-type", "file",
+		"--host", "https://example.kosli.com",
+		"--api-token", "DRY_RUN",
+	}
+	cmd, err := newRootCmd(io.Discard, io.Discard, args)
+	suite.Require().NoError(err)
+
+	err = innerMain(cmd, append([]string{"kosli"}, args...))
+
+	suite.Require().NoError(err)
+	suite.Equal("https://example.kosli.com", global.Host,
+		"global.Host must reflect --host, not the probe's throwaway struct default")
+	suite.Equal("DRY_RUN", global.ApiToken,
+		"global.ApiToken must reflect --api-token, not the probe's throwaway struct default")
 }
 
 func (suite *RootCommandTestSuite) TestConfigProcessing() {

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -20,6 +20,37 @@ type RootCommandTestSuite struct {
 	suite.Suite
 }
 
+// TestFindUnknownCommand locks in the fix for issue #1043: an unrecognized
+// command token must be reported (so the process exits non-zero) while genuine
+// group commands invoked with no leftover positional keep resolving cleanly.
+func (suite *RootCommandTestSuite) TestFindUnknownCommand() {
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{name: "unknown top-level command", args: []string{"garbage"}, wantErr: true},
+		{name: "unknown command with trailing args", args: []string{"garbage", "list", "flows"}, wantErr: true},
+		{name: "unknown subcommand of a group", args: []string{"list", "garbage"}, wantErr: true},
+		{name: "group command with no leftover is fine", args: []string{"list"}, wantErr: false},
+		{name: "runnable leaf command is fine", args: []string{"version"}, wantErr: false},
+		{name: "no args is fine", args: []string{}, wantErr: false},
+		{name: "unknown flag defers to cobra", args: []string{"--badflag", "list", "flows"}, wantErr: false},
+	}
+	for _, tc := range cases {
+		suite.Run(tc.name, func() {
+			err := findUnknownCommand(tc.args)
+			if tc.wantErr {
+				suite.Require().Error(err)
+				suite.Contains(err.Error(), "unknown command:")
+				suite.Contains(err.Error(), "available subcommands are:")
+			} else {
+				suite.Require().NoError(err)
+			}
+		})
+	}
+}
+
 func (suite *RootCommandTestSuite) TestConfigProcessing() {
 	tests := []cmdTestCase{
 		{


### PR DESCRIPTION
Cobra's `TraverseChildren` routing (set on the root command) hands an unrecognized command token to the nearest group command with no error; that non-runnable command then prints help and returns nil, so the CLI exits 0. A typo'd command such as `kosli garbage list flows` therefore silently reports success (issue #1043).

Add `findUnknownCommand`, called from `innerMain` before `ExecuteC`. It resolves the args with cobra's `Traverse` on a throwaway command tree (so the real command's flag state is untouched) and returns an error when resolution lands on a non-runnable group command while an unconsumed non-flag token that names no subcommand remains. Real commands, group commands invoked with no leftover (e.g. `kosli list`), and the existing unknown-flag path are all left unchanged.

<!-- What does this PR change and why? Link any related issue. -->

Example output:
```
$ ./kosli garbage ls
Error: unknown command: garbage
available subcommands are: allow | archive | assert | attach-policy | attest | begin | completion | config | create | delete | detach-policy | diff | disable | enable | evaluate | fingerprint | get | join | list | log | rename | report | rotate | search | snapshot | status | tag | unarchive | update | version
```

Closes #1043 

### Checklist

- [x] **Helm chart** (`charts/k8s-reporter/`) updated, if needed. Note: these changes live in a **separate PR**
- [x] **Terraform provider** and related changes ([terraform-provider-kosli](https://github.com/kosli-dev/terraform-provider-kosli), [terraform-aws-evidence-reporter](https://github.com/kosli-dev/terraform-aws-evidence-reporter), [terraform-aws-kosli-reporter](https://github.com/kosli-dev/terraform-aws-kosli-reporter)) updated, if needed
- [x] **Docs** are autogenerated from CLI help — make sure the help text reflects your changes
