### PR TITLE
fix: drop the double slash from the boolean flags FAQ link

### DIFF
--- a/cmd/kosli/attestGeneric_test.go
+++ b/cmd/kosli/attestGeneric_test.go
@@ -71,7 +71,7 @@ func (suite *AttestGenericCommandTestSuite) TestAttestGenericCmd() {
 			wantError: true,
 			name:      "links to the boolean flags FAQ when a stray true|false argument remains",
 			cmd:       fmt.Sprintf("attest generic foo false --artifact-type file --name bar %s", suite.defaultKosliArguments),
-			golden:    "Error: accepts at most 1 arg(s), received 2 [foo false]\nSee https://docs.kosli.com//faq/#boolean-flags\n",
+			golden:    "Error: accepts at most 1 arg(s), received 2 [foo false]\nSee https://docs.kosli.com/faq/#boolean-flags\n",
 		},
 		{
 			wantError: true,

--- a/cmd/kosli/cli_utils.go
+++ b/cmd/kosli/cli_utils.go
@@ -775,7 +775,7 @@ func CustomMaximumNArgs(max int, args []string) error {
 
 func BooleanArgsMessageLink(args []string) string {
 	if slices.Contains(args, "true") || slices.Contains(args, "false") {
-		return "\nSee https://docs.kosli.com//faq/#boolean-flags"
+		return "\nSee https://docs.kosli.com/faq/#boolean-flags"
 	} else {
 		return ""
 	}


### PR DESCRIPTION
  BooleanArgsMessageLink pointed at https://docs.kosli.com//faq/#boolean-flags.
  The doubled slash is the only such link in the repo, and while the site does
  serve it, a URL a user is being told to visit should not look malformed.

  The golden it is asserted against carried the same typo, so the test moved
  with it.

<!-- What does this PR change and why? Link any related issue. -->

### Checklist

- [x] **Docs** are autogenerated from CLI help — make sure the help text reflects your changes
- [x] **Helm chart** (`charts/k8s-reporter/`) updated, if needed. Note: these changes live in a **separate PR**
- [x] **Terraform provider** and related changes ([terraform-provider-kosli](https://github.com/kosli-dev/terraform-provider-kosli), [terraform-aws-evidence-reporter](https://github.com/kosli-dev/terraform-aws-evidence-reporter), [terraform-aws-kosli-reporter](https://github.com/kosli-dev/terraform-aws-kosli-reporter)) updated, if needed
