### PR TITLE
fix(release): strip the tag signature from the release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,8 +172,10 @@ jobs:
           TAG="${GITHUB_REF#refs/tags/}"
           # %(contents), not %(contents:body): the latter drops the tag message's
           # first paragraph as a "subject", silently swallowing the first heading
-          # or bullet of the release notes.
-          BODY=$(git tag -l --format='%(contents)' "$TAG")
+          # or bullet of the release notes. Unlike %(contents:body), %(contents)
+          # keeps the signature of a signed tag, so cut it off at its marker.
+          BODY=$(git tag -l --format='%(contents)' "$TAG" \
+            | sed '/^-----BEGIN [A-Z ]*SIGNATURE-----$/,$d')
           # `make release tag=vX.Y.Z` with no dist/release_notes.md tags with the
           # version as the whole message; that is not release notes.
           if [ "$(printf '%s' "$BODY" | tr -d '[:space:]')" = "$TAG" ]; then


### PR DESCRIPTION
## What

Release notes are carried in the annotated tag message. Yesterday's #1046 switched the workflow from `%(contents:body)` to `%(contents)` so the first heading/bullet stops being swallowed as a "subject" — but `%(contents:body)` was also the atom that *excluded* a signed tag's signature. `v2.36.1` is a signed tag, so its armored PGP block was published as part of the release notes.

## Fix

Keep `%(contents)` and truncate at the signature marker:

```bash
BODY=$(git tag -l --format='%(contents)' "$TAG" \
  | sed '/^-----BEGIN [A-Z ]*SIGNATURE-----$/,$d')
```

The `[A-Z ]*` also covers SSH-signed tags. `%(contents:subject)` is not an option for recovering the first paragraph: git folds a multi-line subject onto one line, which would collapse the leading bullets.

## Verification

Ran the full step logic against the real tags:

| tag | result |
|---|---|
| `v2.36.1` (signed) | just the bullet — signature gone |
| `v2.36.0` | unchanged, all 3 bullets |
| `v2.35.0` | unchanged, headings + bullets intact |

The `$BODY == $TAG` guard for `make release tag=vX.Y.Z` still applies, since it runs after the strip.

The already-published `v2.36.1` notes are being cleaned up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)