### PR TITLE
test(aws): add S3 contract tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ test_integration_single: test_setup
 test_contract_aws: ensure_gotestsum ## Run AWS contract tests against real AWS (requires AWS creds)
 	@echo "Running AWS contract tests against real AWS..."
 	@echo "Requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY to be set"
-	@$(GOTESTSUM) -- -v -p=1 -run "LambdaContract_RealAWS|AWSTestSuite/TestGetLambdaPackageData|AWSTestSuite/TestGetEcsTasksData|AWSTestSuite/TestGetS3Data" ./internal/aws/
+	@$(GOTESTSUM) -- -v -p=1 -run "LambdaContract_RealAWS|S3Contract_RealAWS|AWSTestSuite/TestGetLambdaPackageData|AWSTestSuite/TestGetEcsTasksData|AWSTestSuite/TestGetS3Data" ./internal/aws/
 
 test_contract_github: ensure_gotestsum ## Run GitHub contract tests against real GitHub API (requires KOSLI_GITHUB_TOKEN)
 	@echo "Running GitHub contract tests against real GitHub API..."

--- a/cmd/kosli/snapshotS3_test.go
+++ b/cmd/kosli/snapshotS3_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kosli-dev/cli/internal/testHelpers"
+	"github.com/kosli-dev/cli/internal/aws"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -18,10 +18,6 @@ type SnapshotS3TestSuite struct {
 	bucketName            string
 }
 
-type snapshotS3TestConfig struct {
-	requireAuthToBeSet bool
-}
-
 func (suite *SnapshotS3TestSuite) SetupTest() {
 	suite.envName = "snapshot-s3-env"
 	suite.bucketName = "kosli-cli-public"
@@ -33,26 +29,37 @@ func (suite *SnapshotS3TestSuite) SetupTest() {
 	suite.defaultKosliArguments = fmt.Sprintf(" --host %s --org %s --api-token %s", global.Host, global.Org, global.ApiToken)
 
 	CreateEnv(global.Org, suite.envName, "S3", suite.T())
+
+	// Inject a fake S3 client so tests run without AWS credentials.
+	// The fake is seeded with the objects the test cases filter on.
+	bucketName := suite.bucketName
+	aws.NewS3ClientFunc = func(_ *aws.AWSStaticCreds) (aws.S3API, error) {
+		return &aws.FakeS3Client{
+			Bucket: bucketName,
+			Objects: map[string][]byte{
+				"README.md":                  []byte("# kosli cli public\n"),
+				"dummy/dummy_2/template.yml": []byte("key: value\n"),
+			},
+		}, nil
+	}
+}
+
+func (suite *SnapshotS3TestSuite) TearDownTest() {
+	aws.ResetS3ClientFactory()
 }
 
 func (suite *SnapshotS3TestSuite) TestSnapshotS3Cmd() {
 	tests := []cmdTestCase{
 		{
-			name: "snapshot s3 works with --bucket",
-			cmd:  fmt.Sprintf(`snapshot s3 %s %s --bucket %s`, suite.envName, suite.defaultKosliArguments, suite.bucketName),
-			additionalConfig: snapshotS3TestConfig{
-				requireAuthToBeSet: true,
-			},
+			name:   "snapshot s3 works with --bucket",
+			cmd:    fmt.Sprintf(`snapshot s3 %s %s --bucket %s`, suite.envName, suite.defaultKosliArguments, suite.bucketName),
 			golden: "bucket " + suite.bucketName + " was reported to environment " + suite.envName + "\n",
 		},
 		{
 			wantError: true,
 			name:      "snapshot s3 fails without --bucket",
 			cmd:       fmt.Sprintf(`snapshot s3 %s %s`, suite.envName, suite.defaultKosliArguments),
-			additionalConfig: snapshotS3TestConfig{
-				requireAuthToBeSet: true,
-			},
-			golden: "Error: required flag(s) \"bucket\" not set\n",
+			golden:    "Error: required flag(s) \"bucket\" not set\n",
 		},
 		{
 			wantError: true,
@@ -109,9 +116,6 @@ func (suite *SnapshotS3TestSuite) TestSnapshotS3Cmd() {
 	}
 
 	for _, t := range tests {
-		if t.additionalConfig != nil && t.additionalConfig.(snapshotS3TestConfig).requireAuthToBeSet {
-			testHelpers.SkipIfEnvVarUnset(suite.T(), []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"})
-		}
 		runTestCmd(suite.T(), []cmdTestCase{t})
 	}
 }

--- a/docs/adr/20260421-fakes-and-contract-tests.md
+++ b/docs/adr/20260421-fakes-and-contract-tests.md
@@ -21,7 +21,7 @@ This created three problems:
 2. **Test suite speed and scope**: Tests that depend on real external state can only verify a narrow set of scenarios. It is impractical to test error paths or edge cases against live services.
 3. **Who can run the tests**: Developers without credentials for a given external service could not run the tests for commands that depend on it. This limited who could contribute to those areas of the codebase.
 
-The pattern was first introduced for AWS Lambda (#763) and then extended to GitHub (#807).
+The pattern was first introduced for AWS Lambda (#763), then extended to GitHub (#807) and AWS S3 (#758).
 
 ## Decision
 
@@ -39,9 +39,15 @@ For each external service integration, we:
 
 ## The interface abstraction level
 
-We chose to fake at the **operation level** rather than the **SDK client level**. This means the interface speaks in domain terms (e.g. "get PR evidence for this commit") rather than SDK terms (individual HTTP, GraphQL, or SDK calls).
+An interface can sit at the **SDK client level** (individual SDK calls, e.g. `ListObjectsV2`) or the **operation level** (domain terms, e.g. "get PR evidence for this commit"). We use both, and pick per integration:
 
-This keeps fakes simple and free of SDK types, and the interface boundary is stable even if the underlying SDK or transport changes. In some cases (e.g. GraphQL clients that use Go reflection internally) SDK-level faking is impractical without reimplementing SDK machinery, which makes operation-level faking the only viable option.
+- **Prefer SDK-level** when the SDK client is an ordinary Go type whose methods a fake can implement directly, as with the AWS SDK v2 service clients. The real client then satisfies the interface implicitly, so there is no adapter to write and no adapter to keep correct. It also keeps behaviour like pagination in our own code, where a contract test can verify it against the real API rather than hiding it behind a wrapper we cannot exercise.
+
+- **Fall back to operation-level** when SDK-level faking would mean reimplementing SDK machinery. GitHub's GraphQL client uses Go reflection internally, so a fake at that level is impractical. The same applies to SDK helpers with substantial internals of their own — the S3 transfer manager's `DownloadObject` drives ranged `GetObject`/`HeadObject` calls, so a fake stands in for the download *operation* and writes bytes straight to the destination.
+
+Either way the interface stays **narrow**: only the operations this codebase actually calls. That is what bounds the contract test surface — we are testing our expectations of the dependency, not the dependency itself.
+
+A single seam may mix the two levels. AWS S3 does: `S3ListAPI` is SDK-level (`ListObjectsV2`, so the SDK paginator still runs against our interface and the continuation-token contract is verified against real S3), while `S3DownloadAPI` is operation-level (the transfer manager's `DownloadObject`).
 
 ## Contract tests vs the main integration suite
 

--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -131,6 +131,55 @@ func (staticCreds *AWSStaticCreds) NewS3Client() (*s3.Client, error) {
 	return s3.NewFromConfig(cfg), nil
 }
 
+// S3ListAPI is the S3 listing operation used by this package. The real
+// *s3.Client satisfies this implicitly, and the interface also satisfies
+// s3.ListObjectsV2APIClient so it can drive the SDK paginator.
+type S3ListAPI interface {
+	ListObjectsV2(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
+}
+
+// S3DownloadAPI downloads a single object from a bucket. The real
+// *transfermanager.Client satisfies this implicitly.
+//
+// This is the transfer manager's own operation rather than a raw S3 API call.
+// Faking at this level means a fake writes object bytes straight to the
+// WriterAt instead of having to reimplement the transfer manager's ranged
+// GetObject/HeadObject machinery.
+type S3DownloadAPI interface {
+	DownloadObject(ctx context.Context, params *transfermanager.DownloadObjectInput, optFns ...func(*transfermanager.Options)) (*transfermanager.DownloadObjectOutput, error)
+}
+
+// S3API is the combined S3 surface that GetS3Data depends on.
+type S3API interface {
+	S3ListAPI
+	S3DownloadAPI
+}
+
+// s3Client combines the two real AWS clients that back S3API: *s3.Client for
+// listing and *transfermanager.Client for downloading.
+type s3Client struct {
+	S3ListAPI
+	S3DownloadAPI
+}
+
+// defaultNewS3Client creates a real S3 client from credentials.
+func defaultNewS3Client(creds *AWSStaticCreds) (S3API, error) {
+	client, err := creds.NewS3Client()
+	if err != nil {
+		return nil, err
+	}
+	return &s3Client{S3ListAPI: client, S3DownloadAPI: transfermanager.New(client)}, nil
+}
+
+// NewS3ClientFunc is the factory used by GetS3Data to create an S3API client.
+// Tests can replace this to inject a FakeS3Client.
+var NewS3ClientFunc = defaultNewS3Client
+
+// ResetS3ClientFactory restores the default (real AWS) client factory.
+func ResetS3ClientFactory() {
+	NewS3ClientFunc = defaultNewS3Client
+}
+
 // NewLambdaClient returns a new Lambda API client
 func (staticCreds *AWSStaticCreds) NewLambdaClient() (*lambda.Client, error) {
 	cfg, err := staticCreds.NewAWSConfigFromEnvOrFlags()
@@ -413,6 +462,15 @@ func objectMatchesFilter(key string, paths []string, patterns []*regexp.Regexp) 
 // includeRegex / excludeRegex match object keys by Go regular expression.
 // Include and exclude filters are mutually exclusive (callers enforce this).
 func (staticCreds *AWSStaticCreds) GetS3Data(bucket string, includePaths, includeRegex, excludePaths, excludeRegex []string, logger *logger.Logger) ([]*S3Data, error) {
+	client, err := NewS3ClientFunc(staticCreds)
+	if err != nil {
+		return []*S3Data{}, err
+	}
+	return getS3DataFromClient(client, bucket, includePaths, includeRegex, excludePaths, excludeRegex, logger)
+}
+
+// getS3DataFromClient harvests bucket content using the provided S3API client.
+func getS3DataFromClient(client S3API, bucket string, includePaths, includeRegex, excludePaths, excludeRegex []string, logger *logger.Logger) ([]*S3Data, error) {
 	s3Data := []*S3Data{}
 
 	includeRegexCompiled, err := compilePathRegex(includeRegex)
@@ -434,16 +492,9 @@ func (staticCreds *AWSStaticCreds) GetS3Data(bucket string, includePaths, includ
 		}
 	}()
 
-	client, err := staticCreds.NewS3Client()
-	if err != nil {
-		return s3Data, err
-	}
-
 	params := &s3.ListObjectsV2Input{
 		Bucket: aws.String(bucket),
 	}
-
-	downloader := transfermanager.New(client)
 
 	var lastModifiedTime *time.Time
 	paginator := s3.NewListObjectsV2Paginator(client, params)
@@ -460,7 +511,7 @@ func (staticCreds *AWSStaticCreds) GetS3Data(bucket string, includePaths, includ
 			if shouldExcludePath(*object.Key, includePaths, includeRegexCompiled, excludePaths, excludeRegexCompiled) {
 				continue
 			}
-			err := downloadFileFromBucket(downloader, tempDirName, *object.Key, bucket, logger)
+			err := downloadFileFromBucket(client, tempDirName, *object.Key, bucket, logger)
 			if err != nil {
 				return s3Data, err
 			}
@@ -499,7 +550,7 @@ func (staticCreds *AWSStaticCreds) GetS3Data(bucket string, includePaths, includ
 	return s3Data, nil
 }
 
-func downloadFileFromBucket(downloader *transfermanager.Client, dirName, key, bucket string, logger *logger.Logger) error {
+func downloadFileFromBucket(downloader S3DownloadAPI, dirName, key, bucket string, logger *logger.Logger) error {
 	file, err := utils.CreateFile(filepath.Join(dirName, key))
 	if err != nil {
 		return err

--- a/internal/aws/aws_test.go
+++ b/internal/aws/aws_test.go
@@ -934,6 +934,335 @@ func (suite *AWSTestSuite) TestGetLambdaPackageDataFromClient() {
 	}
 }
 
+// Fixture object bodies for the fake-backed S3 tests, with the SHA-256 of each
+// body. digest.FileSha256 is a plain SHA-256 of the file content, so a
+// single-object bucket fingerprints to the digest of its body.
+const (
+	fakeReadmeBody       = "# readme\n"
+	fakeReadmeSha256     = "4b2b418bbeeb44157535c731f489f6e1dc506a2acd39171ca9afef9f5d17aa7d"
+	fakeTemplateBody     = "key: value\n"
+	fakeTemplateSha256   = "0ddd3d77338ca222ab064e214bbec3a4547e9d33801912eaacc7b4b4e27e1a91"
+	fakeNotesBody        = "some notes\n"
+	fakeS3TestBucketName = "test-bucket"
+)
+
+func (suite *AWSTestSuite) TestGetS3DataFromClient() {
+	earlier := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	later := time.Date(2024, 3, 20, 8, 0, 0, 0, time.UTC)
+	muchLater := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	for _, t := range []struct {
+		name             string
+		objects          map[string][]byte
+		lastModified     map[string]time.Time
+		pageSize         int
+		includePaths     []string
+		includeRegex     []string
+		excludePaths     []string
+		excludeRegex     []string
+		listErr          error
+		downloadErr      error
+		wantArtifactName string // defaults to the bucket name
+		wantFingerprint  string // only asserted when set
+		wantLastModified int64  // only asserted when non-zero
+		wantErr          bool
+		wantErrMsg       string
+	}{
+		{
+			name: "a single object is fingerprinted as a file and named after it",
+			objects: map[string][]byte{
+				"README.md": []byte(fakeReadmeBody),
+			},
+			wantArtifactName: "README.md",
+			wantFingerprint:  fakeReadmeSha256,
+		},
+		{
+			name: "a single nested object is still fingerprinted as a file",
+			objects: map[string][]byte{
+				"dummy/dummy_2/template.yml": []byte(fakeTemplateBody),
+			},
+			wantArtifactName: "template.yml",
+			wantFingerprint:  fakeTemplateSha256,
+		},
+		{
+			name: "multiple objects are fingerprinted as a directory named after the bucket",
+			objects: map[string][]byte{
+				"README.md": []byte(fakeReadmeBody),
+				"notes.txt": []byte(fakeNotesBody),
+				"a/b/c.yml": []byte(fakeTemplateBody),
+			},
+		},
+		{
+			name: "folder markers are skipped, leaving a single file",
+			objects: map[string][]byte{
+				"dummy/":          nil,
+				"dummy/dummy_2/":  nil,
+				"dummy/README.md": []byte(fakeReadmeBody),
+			},
+			wantArtifactName: "README.md",
+			wantFingerprint:  fakeReadmeSha256,
+		},
+		{
+			name: "objects spread over several pages are all downloaded",
+			objects: map[string][]byte{
+				"README.md": []byte(fakeReadmeBody),
+				"notes.txt": []byte(fakeNotesBody),
+				"other.yml": []byte(fakeTemplateBody),
+			},
+			pageSize: 1,
+		},
+		{
+			name: "includePaths selects a single object",
+			objects: map[string][]byte{
+				"README.md": []byte(fakeReadmeBody),
+				"notes.txt": []byte(fakeNotesBody),
+			},
+			includePaths:     []string{"README.md"},
+			wantArtifactName: "README.md",
+			wantFingerprint:  fakeReadmeSha256,
+		},
+		{
+			name: "includePaths matches a nested path by prefix",
+			objects: map[string][]byte{
+				"README.md":                  []byte(fakeReadmeBody),
+				"dummy/dummy_2/template.yml": []byte(fakeTemplateBody),
+			},
+			includePaths:     []string{"dummy/dummy_2"},
+			wantArtifactName: "template.yml",
+			wantFingerprint:  fakeTemplateSha256,
+		},
+		{
+			name: "a leading slash in includePaths is ignored",
+			objects: map[string][]byte{
+				"README.md":                  []byte(fakeReadmeBody),
+				"dummy/dummy_2/template.yml": []byte(fakeTemplateBody),
+			},
+			includePaths:     []string{"/dummy/dummy_2"},
+			wantArtifactName: "template.yml",
+			wantFingerprint:  fakeTemplateSha256,
+		},
+		{
+			name: "includeRegex selects matching objects",
+			objects: map[string][]byte{
+				"README.md": []byte(fakeReadmeBody),
+				"notes.txt": []byte(fakeNotesBody),
+			},
+			includeRegex:     []string{`.*\.md$`},
+			wantArtifactName: "README.md",
+			wantFingerprint:  fakeReadmeSha256,
+		},
+		{
+			name: "excludePaths removes matching objects",
+			objects: map[string][]byte{
+				"README.md": []byte(fakeReadmeBody),
+				"notes.txt": []byte(fakeNotesBody),
+			},
+			excludePaths:     []string{"notes.txt"},
+			wantArtifactName: "README.md",
+			wantFingerprint:  fakeReadmeSha256,
+		},
+		{
+			name: "excludeRegex removes matching objects",
+			objects: map[string][]byte{
+				"README.md": []byte(fakeReadmeBody),
+				"notes.txt": []byte(fakeNotesBody),
+			},
+			excludeRegex:     []string{`.*\.txt$`},
+			wantArtifactName: "README.md",
+			wantFingerprint:  fakeReadmeSha256,
+		},
+		{
+			name: "the reported timestamp is the newest matched object",
+			objects: map[string][]byte{
+				"README.md": []byte(fakeReadmeBody),
+				"notes.txt": []byte(fakeNotesBody),
+			},
+			lastModified: map[string]time.Time{
+				"README.md": earlier,
+				"notes.txt": later,
+			},
+			wantLastModified: later.Unix(),
+		},
+		{
+			name: "objects filtered out do not affect the reported timestamp",
+			objects: map[string][]byte{
+				"README.md": []byte(fakeReadmeBody),
+				"notes.txt": []byte(fakeNotesBody),
+				"skip.txt":  []byte(fakeNotesBody),
+			},
+			lastModified: map[string]time.Time{
+				"README.md": earlier,
+				"notes.txt": later,
+				"skip.txt":  muchLater,
+			},
+			excludePaths:     []string{"skip.txt"},
+			wantLastModified: later.Unix(),
+		},
+		{
+			name: "an empty bucket is an error",
+			objects: map[string][]byte{
+				"dummy/": nil,
+			},
+			wantErr:    true,
+			wantErrMsg: "no matching file or dirs in bucket: [" + fakeS3TestBucketName + "]",
+		},
+		{
+			name: "filtering everything out is an error",
+			objects: map[string][]byte{
+				"README.md": []byte(fakeReadmeBody),
+			},
+			includePaths: []string{"non-existing.md"},
+			wantErr:      true,
+			wantErrMsg:   "no matching file or dirs in bucket: [" + fakeS3TestBucketName + "]",
+		},
+		{
+			name: "an invalid include regex is an error",
+			objects: map[string][]byte{
+				"README.md": []byte(fakeReadmeBody),
+			},
+			includeRegex: []string{"invalid["},
+			wantErr:      true,
+			wantErrMsg:   "invalid path regex pattern",
+		},
+		{
+			name: "an invalid exclude regex is an error",
+			objects: map[string][]byte{
+				"README.md": []byte(fakeReadmeBody),
+			},
+			excludeRegex: []string{"invalid["},
+			wantErr:      true,
+			wantErrMsg:   "invalid path regex pattern",
+		},
+		{
+			name: "a listing error propagates",
+			objects: map[string][]byte{
+				"README.md": []byte(fakeReadmeBody),
+			},
+			listErr: fmt.Errorf("simulated AWS listing error"),
+			wantErr: true,
+		},
+		{
+			name: "a download error propagates",
+			objects: map[string][]byte{
+				"README.md": []byte(fakeReadmeBody),
+			},
+			downloadErr: fmt.Errorf("simulated AWS download error"),
+			wantErr:     true,
+		},
+	} {
+		suite.Run(t.name, func() {
+			client := &FakeS3Client{
+				Bucket:            fakeS3TestBucketName,
+				Objects:           t.objects,
+				LastModified:      t.lastModified,
+				PageSize:          t.pageSize,
+				ListObjectsV2Err:  t.listErr,
+				DownloadObjectErr: t.downloadErr,
+			}
+
+			data, err := getS3DataFromClient(client, fakeS3TestBucketName, t.includePaths,
+				t.includeRegex, t.excludePaths, t.excludeRegex, logger.NewStandardLogger())
+
+			if t.wantErr {
+				require.Error(suite.T(), err)
+				if t.wantErrMsg != "" {
+					require.Contains(suite.T(), err.Error(), t.wantErrMsg)
+				}
+				return
+			}
+			require.NoError(suite.T(), err)
+			require.Len(suite.T(), data, 1)
+
+			wantArtifactName := t.wantArtifactName
+			if wantArtifactName == "" {
+				wantArtifactName = fakeS3TestBucketName
+			}
+			require.Contains(suite.T(), data[0].Digests, wantArtifactName)
+			require.NotEmpty(suite.T(), data[0].Digests[wantArtifactName])
+			if t.wantFingerprint != "" {
+				require.Equal(suite.T(), t.wantFingerprint, data[0].Digests[wantArtifactName])
+			}
+			if t.wantLastModified != 0 {
+				require.Equal(suite.T(), t.wantLastModified, data[0].LastModifiedTimestamp)
+			}
+		})
+	}
+}
+
+// TestGetS3DataFromClientFilterEquivalence asserts that filtering a bucket down
+// to a subset produces the same fingerprint as a bucket that only ever held
+// that subset. This pins down what the filters select without hardcoding
+// directory digests, which the include/exclude cases in TestGetS3DataFromClient
+// cannot do once more than one object survives filtering.
+func (suite *AWSTestSuite) TestGetS3DataFromClientFilterEquivalence() {
+	allObjects := map[string][]byte{
+		"README.md":                  []byte(fakeReadmeBody),
+		"notes.txt":                  []byte(fakeNotesBody),
+		"dummy/dummy_2/template.yml": []byte(fakeTemplateBody),
+	}
+
+	fingerprint := func(objects map[string][]byte, includePaths, includeRegex, excludePaths, excludeRegex []string) string {
+		client := &FakeS3Client{Bucket: fakeS3TestBucketName, Objects: objects}
+		data, err := getS3DataFromClient(client, fakeS3TestBucketName, includePaths,
+			includeRegex, excludePaths, excludeRegex, logger.NewStandardLogger())
+		require.NoError(suite.T(), err)
+		require.Len(suite.T(), data, 1)
+		require.Len(suite.T(), data[0].Digests, 1)
+		for _, digest := range data[0].Digests {
+			return digest
+		}
+		return ""
+	}
+
+	for _, t := range []struct {
+		name           string
+		includePaths   []string
+		includeRegex   []string
+		excludePaths   []string
+		excludeRegex   []string
+		expectedSubset map[string][]byte
+	}{
+		{
+			name:         "includePaths keeps only the named prefix",
+			includePaths: []string{"dummy"},
+			expectedSubset: map[string][]byte{
+				"dummy/dummy_2/template.yml": []byte(fakeTemplateBody),
+			},
+		},
+		{
+			name:         "excludePaths drops only the named prefix",
+			excludePaths: []string{"dummy"},
+			expectedSubset: map[string][]byte{
+				"README.md": []byte(fakeReadmeBody),
+				"notes.txt": []byte(fakeNotesBody),
+			},
+		},
+		{
+			name:         "includeRegex keeps every matching key",
+			includeRegex: []string{`.*\.(md|txt)$`},
+			expectedSubset: map[string][]byte{
+				"README.md": []byte(fakeReadmeBody),
+				"notes.txt": []byte(fakeNotesBody),
+			},
+		},
+		{
+			name:         "excludeRegex drops every matching key",
+			excludeRegex: []string{`^dummy/.*`},
+			expectedSubset: map[string][]byte{
+				"README.md": []byte(fakeReadmeBody),
+				"notes.txt": []byte(fakeNotesBody),
+			},
+		},
+	} {
+		suite.Run(t.name, func() {
+			filtered := fingerprint(allObjects, t.includePaths, t.includeRegex, t.excludePaths, t.excludeRegex)
+			unfiltered := fingerprint(t.expectedSubset, nil, nil, nil, nil)
+			require.Equal(suite.T(), unfiltered, filtered,
+				"filtering the full bucket should fingerprint identically to a bucket holding only the expected subset")
+		})
+	}
+}
+
 func skipIfCredsUnset(T *testing.T, requireEnvVars bool, creds *AWSStaticCreds) {
 	if requireEnvVars {
 		// skips the test case if it requires env vars and they are not set

--- a/internal/aws/aws_test.go
+++ b/internal/aws/aws_test.go
@@ -322,6 +322,11 @@ func (suite *AWSTestSuite) TestGetLambdaPackageData() {
 	}
 }
 
+// TestGetS3Data is a smoke test for the real AWS integration.
+// Path and regex filtering, fingerprinting and naming, pagination and error
+// propagation are covered by fake-backed tests (TestGetS3DataFromClient,
+// TestGetS3DataFromClientFilterEquivalence). These cases prove the real SDK
+// wiring works.
 func (suite *AWSTestSuite) TestGetS3Data() {
 	for _, t := range []struct {
 		name             string
@@ -362,75 +367,12 @@ func (suite *AWSTestSuite) TestGetS3Data() {
 			requireEnvVars: true,
 		},
 		{
-			name: "can get S3 bucket data. includePaths is a sub-directory",
-			creds: &AWSStaticCreds{
-				Region: "eu-central-1",
-			},
-			bucketName:      "kosli-cli-public",
-			includePaths:    []string{"dummy"},
-			requireEnvVars:  true,
-			wantFingerprint: "1b7888b437ba378a9884a937552cb1f945f420c3f4201437b42e690f102ff698",
-		},
-		{
-			name: "when includePaths is not an absolute or relative paths",
-			creds: &AWSStaticCreds{
-				Region: "eu-central-1",
-			},
-			bucketName:     "kosli-cli-public",
-			includePaths:   []string{"dummy_2"},
-			requireEnvVars: true,
-			wantErr:        true,
-		},
-		{
-			name: "can get S3 bucket data. includePaths is a nested sub-directory",
-			creds: &AWSStaticCreds{
-				Region: "eu-central-1",
-			},
-			bucketName:       "kosli-cli-public",
-			includePaths:     []string{"dummy/dummy_2"},
-			requireEnvVars:   true,
-			wantFingerprint:  "02eb06f5778c69431b4b00489074b76f05814d8170949f965ebe13a211bf682a",
-			wantArtifactName: "template.yml",
-		},
-		{
-			name: "includePaths is a nested sub-directory starting with slash",
-			creds: &AWSStaticCreds{
-				Region: "eu-central-1",
-			},
-			bucketName:       "kosli-cli-public",
-			includePaths:     []string{"/dummy/dummy_2"},
-			requireEnvVars:   true,
-			wantFingerprint:  "02eb06f5778c69431b4b00489074b76f05814d8170949f965ebe13a211bf682a",
-			wantArtifactName: "template.yml",
-		},
-		{
 			name: "can get S3 bucket data. includePaths is a file",
 			creds: &AWSStaticCreds{
 				Region: "eu-central-1",
 			},
 			bucketName:       "kosli-cli-public",
 			includePaths:     []string{"README.md"},
-			requireEnvVars:   true,
-			wantFingerprint:  "77b1b4df1eb620e05ce365e9e84d37a7e04fde8a66251c121773d013dfba0ee6",
-			wantArtifactName: "README.md",
-		},
-		{
-			name: "can get S3 bucket data. excludePaths is a file",
-			creds: &AWSStaticCreds{
-				Region: "eu-central-1",
-			},
-			bucketName:      "kosli-cli-public",
-			excludePaths:    []string{"README.md"},
-			requireEnvVars:  true,
-			wantFingerprint: "1b7888b437ba378a9884a937552cb1f945f420c3f4201437b42e690f102ff698",
-		},
-		{
-			name: "can get S3 bucket data. excludePaths is a dir",
-			creds: &AWSStaticCreds{
-				Region: "eu-central-1",
-			},
-			bucketName:       "kosli-cli-public",
-			excludePaths:     []string{"dummy"},
 			requireEnvVars:   true,
 			wantFingerprint:  "77b1b4df1eb620e05ce365e9e84d37a7e04fde8a66251c121773d013dfba0ee6",
 			wantArtifactName: "README.md",

--- a/internal/aws/fake_s3.go
+++ b/internal/aws/fake_s3.go
@@ -68,7 +68,7 @@ func (f *FakeS3Client) lastModified(key string) time.Time {
 
 func (f *FakeS3Client) ListObjectsV2(_ context.Context, params *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
 	if params.Bucket == nil {
-		return nil, fmt.Errorf("Bucket is required")
+		return nil, fmt.Errorf("missing required field: Bucket")
 	}
 	if *params.Bucket != f.Bucket {
 		// Real S3 returns *types.NoSuchBucket.
@@ -125,7 +125,7 @@ func (f *FakeS3Client) ListObjectsV2(_ context.Context, params *s3.ListObjectsV2
 
 func (f *FakeS3Client) DownloadObject(_ context.Context, params *transfermanager.DownloadObjectInput, _ ...func(*transfermanager.Options)) (*transfermanager.DownloadObjectOutput, error) {
 	if params.Bucket == nil || params.Key == nil {
-		return nil, fmt.Errorf("Bucket and Key are required")
+		return nil, fmt.Errorf("missing required fields: Bucket and Key")
 	}
 	if *params.Bucket != f.Bucket {
 		// Real S3 returns *types.NoSuchBucket.
@@ -140,7 +140,7 @@ func (f *FakeS3Client) DownloadObject(_ context.Context, params *transfermanager
 		return nil, fmt.Errorf("object not found: %s", *params.Key)
 	}
 	if params.WriterAt == nil {
-		return nil, fmt.Errorf("WriterAt is required")
+		return nil, fmt.Errorf("missing required field: WriterAt")
 	}
 	written, err := params.WriterAt.WriteAt(content, 0)
 	if err != nil {

--- a/internal/aws/fake_s3.go
+++ b/internal/aws/fake_s3.go
@@ -139,6 +139,9 @@ func (f *FakeS3Client) DownloadObject(_ context.Context, params *transfermanager
 	if params.Bucket == nil || params.Key == nil {
 		return nil, fmt.Errorf("missing required fields: Bucket and Key")
 	}
+	if params.WriterAt == nil {
+		return nil, fmt.Errorf("missing required field: WriterAt")
+	}
 	if *params.Bucket != f.Bucket {
 		// Real S3 returns *types.NoSuchBucket.
 		return nil, fmt.Errorf("bucket not found: %s", *params.Bucket)
@@ -150,9 +153,6 @@ func (f *FakeS3Client) DownloadObject(_ context.Context, params *transfermanager
 	if !ok {
 		// Real S3 returns *types.NoSuchKey.
 		return nil, fmt.Errorf("object not found: %s", *params.Key)
-	}
-	if params.WriterAt == nil {
-		return nil, fmt.Errorf("missing required field: WriterAt")
 	}
 	written, err := params.WriterAt.WriteAt(content, 0)
 	if err != nil {

--- a/internal/aws/fake_s3.go
+++ b/internal/aws/fake_s3.go
@@ -1,0 +1,154 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3Types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// fakeS3LastModified is the modification time reported for objects that have no
+// entry in FakeS3Client.LastModified.
+var fakeS3LastModified = time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+
+// FakeS3Client is an in-memory implementation of S3API for testing.
+// It simulates continuation-token pagination and returns errors for unknown
+// buckets and missing objects.
+type FakeS3Client struct {
+	// Bucket is the bucket this fake serves. Requests for any other bucket
+	// return an error, as the real API does for a bucket that does not exist.
+	Bucket string
+	// Objects maps object key to object content. Keys ending in "/" represent
+	// the folder markers that real S3 returns for explicitly created folders.
+	Objects map[string][]byte
+	// LastModified maps object key to modification time. Keys without an entry
+	// report fakeS3LastModified.
+	LastModified map[string]time.Time
+	// PageSize controls how many objects are returned per ListObjectsV2 call.
+	// Defaults to 1000 (matching the AWS default) if zero.
+	PageSize int
+	// ListObjectsV2Err, if set, is returned by ListObjectsV2 for any request.
+	// Useful for testing error propagation.
+	ListObjectsV2Err error
+	// DownloadObjectErr, if set, is returned by DownloadObject for any object.
+	// Useful for testing error propagation.
+	DownloadObjectErr error
+}
+
+func (f *FakeS3Client) pageSize() int {
+	if f.PageSize > 0 {
+		return f.PageSize
+	}
+	return 1000
+}
+
+// sortedKeys returns the object keys in lexicographic order, which is the order
+// the real ListObjectsV2 returns them in.
+func (f *FakeS3Client) sortedKeys() []string {
+	keys := make([]string, 0, len(f.Objects))
+	for key := range f.Objects {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (f *FakeS3Client) lastModified(key string) time.Time {
+	if t, ok := f.LastModified[key]; ok {
+		return t
+	}
+	return fakeS3LastModified
+}
+
+func (f *FakeS3Client) ListObjectsV2(_ context.Context, params *s3.ListObjectsV2Input, _ ...func(*s3.Options)) (*s3.ListObjectsV2Output, error) {
+	if params.Bucket == nil {
+		return nil, fmt.Errorf("Bucket is required")
+	}
+	if *params.Bucket != f.Bucket {
+		// Real S3 returns *types.NoSuchBucket.
+		return nil, fmt.Errorf("bucket not found: %s", *params.Bucket)
+	}
+	if f.ListObjectsV2Err != nil {
+		return nil, f.ListObjectsV2Err
+	}
+
+	pageSize := f.pageSize()
+	if params.MaxKeys != nil {
+		if maxKeys := int(*params.MaxKeys); maxKeys < pageSize {
+			pageSize = maxKeys
+		}
+	}
+
+	start := 0
+	if params.ContinuationToken != nil {
+		parsed, err := strconv.Atoi(*params.ContinuationToken)
+		if err != nil {
+			return nil, fmt.Errorf("invalid continuation token: %s", *params.ContinuationToken)
+		}
+		start = parsed
+	}
+
+	keys := f.sortedKeys()
+	if start > len(keys) {
+		start = len(keys)
+	}
+	end := min(start+pageSize, len(keys))
+
+	contents := make([]s3Types.Object, 0, end-start)
+	for _, key := range keys[start:end] {
+		contents = append(contents, s3Types.Object{
+			Key:          aws.String(key),
+			LastModified: aws.Time(f.lastModified(key)),
+			Size:         aws.Int64(int64(len(f.Objects[key]))),
+		})
+	}
+
+	out := &s3.ListObjectsV2Output{
+		Contents:    contents,
+		KeyCount:    aws.Int32(int32(len(contents))),
+		IsTruncated: aws.Bool(end < len(keys)),
+	}
+	// The paginator only follows a page when IsTruncated is true and the token
+	// is non-empty, so the two are always set together.
+	if end < len(keys) {
+		out.NextContinuationToken = aws.String(strconv.Itoa(end))
+	}
+
+	return out, nil
+}
+
+func (f *FakeS3Client) DownloadObject(_ context.Context, params *transfermanager.DownloadObjectInput, _ ...func(*transfermanager.Options)) (*transfermanager.DownloadObjectOutput, error) {
+	if params.Bucket == nil || params.Key == nil {
+		return nil, fmt.Errorf("Bucket and Key are required")
+	}
+	if *params.Bucket != f.Bucket {
+		// Real S3 returns *types.NoSuchBucket.
+		return nil, fmt.Errorf("bucket not found: %s", *params.Bucket)
+	}
+	if f.DownloadObjectErr != nil {
+		return nil, f.DownloadObjectErr
+	}
+	content, ok := f.Objects[*params.Key]
+	if !ok {
+		// Real S3 returns *types.NoSuchKey.
+		return nil, fmt.Errorf("object not found: %s", *params.Key)
+	}
+	if params.WriterAt == nil {
+		return nil, fmt.Errorf("WriterAt is required")
+	}
+	written, err := params.WriterAt.WriteAt(content, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	return &transfermanager.DownloadObjectOutput{
+		ContentLength: aws.Int64(int64(written)),
+		LastModified:  aws.Time(f.lastModified(*params.Key)),
+	}, nil
+}

--- a/internal/aws/fake_s3.go
+++ b/internal/aws/fake_s3.go
@@ -78,17 +78,29 @@ func (f *FakeS3Client) ListObjectsV2(_ context.Context, params *s3.ListObjectsV2
 		return nil, f.ListObjectsV2Err
 	}
 
+	// Listing inputs outside the contract are rejected rather than guessed at.
+	// Nothing in this package sets MaxKeys (only the contract test does, with
+	// 1), so real S3's behaviour below 1 has never been verified — and silently
+	// substituting a different page size is the kind of fake/real divergence
+	// contract tests exist to catch. Rejecting also stops a MaxKeys of 0 from
+	// producing empty-but-truncated pages, which would spin
+	// s3.ListObjectsV2Paginator forever.
 	pageSize := f.pageSize()
 	if params.MaxKeys != nil {
-		if maxKeys := int(*params.MaxKeys); maxKeys < pageSize {
+		maxKeys := int(*params.MaxKeys)
+		if maxKeys < 1 {
+			return nil, fmt.Errorf("MaxKeys must be at least 1, got %d", maxKeys)
+		}
+		if maxKeys < pageSize {
 			pageSize = maxKeys
 		}
 	}
 
 	start := 0
 	if params.ContinuationToken != nil {
+		// A negative token parses as a number but would index keys out of range.
 		parsed, err := strconv.Atoi(*params.ContinuationToken)
-		if err != nil {
+		if err != nil || parsed < 0 {
 			return nil, fmt.Errorf("invalid continuation token: %s", *params.ContinuationToken)
 		}
 		start = parsed

--- a/internal/aws/s3_contract_test.go
+++ b/internal/aws/s3_contract_test.go
@@ -152,6 +152,29 @@ func TestS3Contract_Fake(t *testing.T) {
 		})
 		require.Error(t, err)
 	})
+
+	// The fake rejects listing inputs outside the contract. Real S3 accepts
+	// these without erroring, so they cannot live in runS3ContractTests — they
+	// exist so a future caller fails loudly instead of hanging or panicking.
+	t.Run("ListObjectsV2 rejects MaxKeys below 1", func(t *testing.T) {
+		// MaxKeys 0 would otherwise yield empty-but-truncated pages, spinning
+		// s3.ListObjectsV2Paginator forever.
+		_, err := client.ListObjectsV2(context.TODO(), &s3.ListObjectsV2Input{
+			Bucket:  aws.String(bucket),
+			MaxKeys: aws.Int32(0),
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("ListObjectsV2 rejects a negative continuation token", func(t *testing.T) {
+		// A negative token parses as a number but would index the key slice
+		// out of range.
+		_, err := client.ListObjectsV2(context.TODO(), &s3.ListObjectsV2Input{
+			Bucket:            aws.String(bucket),
+			ContinuationToken: aws.String("-1"),
+		})
+		require.Error(t, err)
+	})
 }
 
 func TestS3Contract_RealAWS(t *testing.T) {

--- a/internal/aws/s3_contract_test.go
+++ b/internal/aws/s3_contract_test.go
@@ -1,0 +1,165 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/kosli-dev/cli/internal/testHelpers"
+	"github.com/stretchr/testify/require"
+)
+
+// errInjected is the error tests inject into FakeS3Client to exercise error paths.
+var errInjected = errors.New("injected error")
+
+// runS3ContractTests exercises the S3API contract. It verifies the behaviours
+// we depend on — object listing, continuation-token pagination, object
+// download, and error responses for missing buckets and keys.
+//
+// Any implementation that passes this suite is a valid stand-in for the real
+// AWS S3 API as far as this codebase is concerned.
+//
+// bucket must name a bucket the client can see, holding at least two objects.
+// existingKey must name an object in that bucket with a non-empty body.
+func runS3ContractTests(t *testing.T, client S3API, bucket, existingKey string) {
+	t.Helper()
+
+	t.Run("ListObjectsV2 returns objects with keys and modification times", func(t *testing.T) {
+		out, err := client.ListObjectsV2(context.TODO(), &s3.ListObjectsV2Input{
+			Bucket: aws.String(bucket),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, out)
+		require.NotEmpty(t, out.Contents)
+		for _, object := range out.Contents {
+			require.NotNil(t, object.Key, "Key should be present")
+			require.NotEmpty(t, *object.Key)
+			require.NotNil(t, object.LastModified, "LastModified should be present")
+		}
+	})
+
+	t.Run("ListObjectsV2 with MaxKeys paginates via ContinuationToken", func(t *testing.T) {
+		// Request one object per page to force pagination. The paginator only
+		// follows a page when IsTruncated is true AND NextContinuationToken is
+		// non-empty, so both must be set together.
+		out, err := client.ListObjectsV2(context.TODO(), &s3.ListObjectsV2Input{
+			Bucket:  aws.String(bucket),
+			MaxKeys: aws.Int32(1),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, out)
+		require.Len(t, out.Contents, 1)
+
+		if out.IsTruncated == nil || !*out.IsTruncated {
+			t.Skip("only 1 object in bucket; pagination not exercisable")
+		}
+		require.NotNil(t, out.NextContinuationToken, "a truncated result must carry a continuation token")
+		require.NotEmpty(t, *out.NextContinuationToken)
+
+		out2, err := client.ListObjectsV2(context.TODO(), &s3.ListObjectsV2Input{
+			Bucket:            aws.String(bucket),
+			MaxKeys:           aws.Int32(1),
+			ContinuationToken: out.NextContinuationToken,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, out2)
+		require.Len(t, out2.Contents, 1)
+		require.NotEqual(t, *out.Contents[0].Key, *out2.Contents[0].Key,
+			"the second page should return a different object")
+	})
+
+	t.Run("ListObjectsV2 errors for a nonexistent bucket", func(t *testing.T) {
+		_, err := client.ListObjectsV2(context.TODO(), &s3.ListObjectsV2Input{
+			Bucket: aws.String("kosli-nonexistent-bucket-that-should-not-exist"),
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("DownloadObject writes the object body to the WriterAt", func(t *testing.T) {
+		file, err := os.Create(filepath.Join(t.TempDir(), "downloaded"))
+		require.NoError(t, err)
+		defer file.Close() //nolint:errcheck
+
+		out, err := client.DownloadObject(context.TODO(), &transfermanager.DownloadObjectInput{
+			Bucket:   aws.String(bucket),
+			Key:      aws.String(existingKey),
+			WriterAt: file,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, out)
+		require.NotNil(t, out.ContentLength, "ContentLength should be present")
+
+		content, err := os.ReadFile(file.Name())
+		require.NoError(t, err)
+		require.NotEmpty(t, content, "the object body should have been written")
+		require.Equal(t, *out.ContentLength, int64(len(content)),
+			"ContentLength should match the bytes written")
+	})
+
+	t.Run("DownloadObject errors for a missing key", func(t *testing.T) {
+		file, err := os.Create(filepath.Join(t.TempDir(), "downloaded"))
+		require.NoError(t, err)
+		defer file.Close() //nolint:errcheck
+
+		_, err = client.DownloadObject(context.TODO(), &transfermanager.DownloadObjectInput{
+			Bucket:   aws.String(bucket),
+			Key:      aws.String("nonexistent-key-that-should-not-exist"),
+			WriterAt: file,
+		})
+		require.Error(t, err)
+	})
+}
+
+func TestS3Contract_Fake(t *testing.T) {
+	bucket := "kosli-cli-public"
+	client := &FakeS3Client{
+		Bucket: bucket,
+		Objects: map[string][]byte{
+			"README.md":                  []byte("# readme\n"),
+			"dummy/dummy_2/template.yml": []byte("key: value\n"),
+		},
+		// One object per page so the pagination contract is genuinely exercised.
+		PageSize: 1,
+	}
+
+	runS3ContractTests(t, client, bucket, "README.md")
+
+	// Error injection is a fake-specific mechanism with no real-API equivalent.
+	// These tests verify the fake itself, not the contract.
+	t.Run("ListObjectsV2 returns error when ListObjectsV2Err is injected", func(t *testing.T) {
+		client.ListObjectsV2Err = errInjected
+		defer func() { client.ListObjectsV2Err = nil }()
+		_, err := client.ListObjectsV2(context.TODO(), &s3.ListObjectsV2Input{Bucket: aws.String(bucket)})
+		require.Error(t, err)
+	})
+
+	t.Run("DownloadObject returns error when DownloadObjectErr is injected", func(t *testing.T) {
+		client.DownloadObjectErr = errInjected
+		defer func() { client.DownloadObjectErr = nil }()
+		file, err := os.Create(filepath.Join(t.TempDir(), "downloaded"))
+		require.NoError(t, err)
+		defer file.Close() //nolint:errcheck
+
+		_, err = client.DownloadObject(context.TODO(), &transfermanager.DownloadObjectInput{
+			Bucket:   aws.String(bucket),
+			Key:      aws.String("README.md"),
+			WriterAt: file,
+		})
+		require.Error(t, err)
+	})
+}
+
+func TestS3Contract_RealAWS(t *testing.T) {
+	testHelpers.SkipIfEnvVarUnset(t, []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"})
+
+	creds := &AWSStaticCreds{Region: "eu-central-1"}
+	client, err := defaultNewS3Client(creds)
+	require.NoError(t, err)
+
+	runS3ContractTests(t, client, "kosli-cli-public", "README.md")
+}


### PR DESCRIPTION
<!-- What does this PR change and why? Link any related issue. -->

`runS3ContractTests` asserts the S3 behaviours this codebase depends on:
object listing, continuation-token pagination, object download, and the
error responses for unknown buckets and missing keys.

The suite runs against both `FakeS3Client` (always) and real AWS (gated on
credentials), so the fake cannot drift from the real API unnoticed.

Related #758 

### Checklist

- [x] **Docs** are autogenerated from CLI help — make sure the help text reflects your changes
- [x] **Helm chart** (`charts/k8s-reporter/`) updated, if needed. Note: these changes live in a **separate PR**
- [x] **Terraform provider** and related changes ([terraform-provider-kosli](https://github.com/kosli-dev/terraform-provider-kosli), [terraform-aws-evidence-reporter](https://github.com/kosli-dev/terraform-aws-evidence-reporter), [terraform-aws-kosli-reporter](https://github.com/kosli-dev/terraform-aws-kosli-reporter)) updated, if needed
