### PR TITLE
chore: add cmd aliases

### DIFF
--- a/cmd/kosli/assertPR.go
+++ b/cmd/kosli/assertPR.go
@@ -11,7 +11,7 @@ const assertPRDesc = `All Kosli pullrequests assertion commands. Return non-zero
 func newAssertPRCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "pullrequest",
-		Aliases: []string{"pr", "mergerequest", "mr"},
+		Aliases: []string{"pr", "pull_request", "mr", "mergerequest", "merge_request"},
 		Short:   assertPRDesc,
 		Long:    assertPRDesc,
 	}

--- a/cmd/kosli/attestPR.go
+++ b/cmd/kosli/attestPR.go
@@ -11,7 +11,7 @@ const attestPRDesc = `All Kosli commands to attest pull/merge request.`
 func newAttestPRCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "pullrequest",
-		Aliases: []string{"pr", "mr", "mergerequest"},
+		Aliases: []string{"pr", "pull_request", "mr", "mergerequest", "merge_request"},
 		Short:   attestPRDesc,
 		Long:    attestPRDesc,
 	}


### PR DESCRIPTION
<!-- What does this PR change and why? Link any related issue. -->
* Following customer request adding PR commands aliases to match attestation records.
* Use same file name patterns


### Checklist

- [x] **Docs** are autogenerated from CLI help — make sure the help text reflects your changes
- [x] **Helm chart** (`charts/k8s-reporter/`) updated, if needed. Note: these changes live in a **separate PR**
- [x] **Terraform provider** and related changes ([terraform-provider-kosli](https://github.com/kosli-dev/terraform-provider-kosli), [terraform-aws-evidence-reporter](https://github.com/kosli-dev/terraform-aws-evidence-reporter), [terraform-aws-kosli-reporter](https://github.com/kosli-dev/terraform-aws-kosli-reporter)) updated, if needed
