### PR TITLE
fix(docs): separate flag types into their own column

### DIFF
--- a/cmd/kosli/testdata/output/docs/mintlify/artifact.md
+++ b/cmd/kosli/testdata/output/docs/mintlify/artifact.md
@@ -46,22 +46,22 @@ is set), registry credentials are resolved as follows:
 
 
 ## Flags
-| Flag | Description |
-| :--- | :--- |
-|    `-t`, `--artifact-type` string  |  The type of the artifact to calculate its SHA256 fingerprint. One of: [oci, docker, file, dir]. Only required if you want Kosli to calculate the fingerprint for you (i.e. when you don't specify '`--fingerprint`' on commands that allow it).  |
-|    `-b`, `--build-url` string  |  The url of CI pipeline that built the artifact. (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
-|    `-u`, `--commit-url` string  |  The url for the git commit that created the artifact. (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
-|    `-D`, `--dry-run`  |  [optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors.  |
-|    `-x`, `--exclude` strings  |  [optional] The comma separated list of directories and files to exclude from fingerprinting. Can take glob patterns. Only applicable for `--artifact-type` dir.  |
-|    `-F`, `--fingerprint` string  |  [conditional] The SHA256 fingerprint of the artifact. Only required if you don't specify '`--artifact-type`'.  |
-|    `-f`, `--flow` string  |  The Kosli flow name.  |
-|    `-g`, `--git-commit` string  |  [defaulted] The git commit from which the artifact was created. (defaulted in some CIs: [docs](/integrations/ci_cd), otherwise defaults to HEAD ).  |
-|    `-h`, `--help`  |  help for artifact  |
-|    `-n`, `--name` string  |  [optional] Artifact display name, if different from file, image or directory name.  |
-|        `--registry-password` string  |  [conditional] The container registry password or access token. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper.  |
-|        `--registry-provider` string  |  [deprecated] The docker registry provider or url. Only required if you want to read docker image SHA256 digest from a remote docker registry. (DEPRECATED: no longer used)  |
-|        `--registry-username` string  |  [conditional] The container registry username. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper.  |
-|        `--repo-root` string  |  [defaulted] The directory where the source git repository is available. (default ".")  |
+| Flag | Type | Description |
+| :--- | :--- | :--- |
+|   `-t`, `--artifact-type` | string | The type of the artifact to calculate its SHA256 fingerprint. One of: [oci, docker, file, dir]. Only required if you want Kosli to calculate the fingerprint for you (i.e. when you don't specify '`--fingerprint`' on commands that allow it). |
+|   `-b`, `--build-url` | string | The url of CI pipeline that built the artifact. (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
+|   `-u`, `--commit-url` | string | The url for the git commit that created the artifact. (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
+|   `-D`, `--dry-run` |  | [optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors. |
+|   `-x`, `--exclude` | strings | [optional] The comma separated list of directories and files to exclude from fingerprinting. Can take glob patterns. Only applicable for `--artifact-type` dir. |
+|   `-F`, `--fingerprint` | string | [conditional] The SHA256 fingerprint of the artifact. Only required if you don't specify '`--artifact-type`'. |
+|   `-f`, `--flow` | string | The Kosli flow name. |
+|   `-g`, `--git-commit` | string | [defaulted] The git commit from which the artifact was created. (defaulted in some CIs: [docs](/integrations/ci_cd), otherwise defaults to HEAD ). |
+|   `-h`, `--help` |  | help for artifact |
+|   `-n`, `--name` | string | [optional] Artifact display name, if different from file, image or directory name. |
+|       `--registry-password` | string | [conditional] The container registry password or access token. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper. |
+|       `--registry-provider` | string | [deprecated] The docker registry provider or url. Only required if you want to read docker image SHA256 digest from a remote docker registry. (DEPRECATED: no longer used) |
+|       `--registry-username` | string | [conditional] The container registry username. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper. |
+|       `--repo-root` | string | [defaulted] The directory where the source git repository is available. (default ".") |
 
 
 ## Examples Use Cases
@@ -89,4 +89,3 @@ kosli report artifact ANOTHER_FILE.txt
 ```
 </Accordion>
 </AccordionGroup>
-

--- a/cmd/kosli/testdata/output/docs/mintlify/snyk.md
+++ b/cmd/kosli/testdata/output/docs/mintlify/snyk.md
@@ -33,35 +33,35 @@ These are automatically set in GitHub Actions, GitLab CI, Bitbucket Pipelines, a
 In other CI systems, set them explicitly to capture repository metadata.
 
 ## Flags
-| Flag | Description |
-| :--- | :--- |
-|        `--annotate` stringToString  |  [optional] Annotate the attestation with data using key=value.  |
-|    `-t`, `--artifact-type` string  |  The type of the artifact to calculate its SHA256 fingerprint. One of: [oci, docker, file, dir]. Only required if you want Kosli to calculate the fingerprint for you (i.e. when you don't specify '`--fingerprint`' on commands that allow it).  |
-|        `--attachments` strings  |  [optional] The comma-separated list of paths of attachments for the reported attestation. Attachments can be files or directories. All attachments are compressed and uploaded to Kosli's evidence vault.  |
-|    `-g`, `--commit` string  |  [conditional] The git commit for which the attestation is associated to. Becomes required when reporting an attestation for an artifact before reporting it to Kosli. (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
-|        `--description` string  |  [optional] attestation description  |
-|    `-D`, `--dry-run`  |  [optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors.  |
-|    `-x`, `--exclude` strings  |  [optional] The comma separated list of directories and files to exclude from fingerprinting. Can take glob patterns. Only applicable for `--artifact-type` dir.  |
-|        `--external-fingerprint` stringToString  |  [optional] A SHA256 fingerprint of an external attachment represented by `--external-url`. The format is label=fingerprint (labels cannot contain '.' or '='). This flag can be set multiple times. There must be an external url with a matching label for each external fingerprint.  |
-|        `--external-url` stringToString  |  [optional] Add labeled reference URL for an external resource. The format is label=url (labels cannot contain '.' or '='). This flag can be set multiple times. If the resource is a file or dir, you can optionally add its fingerprint via `--external-fingerprint`  |
-|    `-F`, `--fingerprint` string  |  [conditional] The SHA256 fingerprint of the artifact to attach the attestation to. Only required if the attestation is for an artifact and `--artifact-type` and artifact name/path are not used.  |
-|    `-f`, `--flow` string  |  The Kosli flow name.  |
-|    `-h`, `--help`  |  help for snyk  |
-|    `-n`, `--name` string  |  The name of the attestation as declared in the flow or trail yaml template.  |
-|    `-o`, `--origin-url` string  |  [optional] The url pointing to where the attestation came from or is related. (defaulted to the CI url in some CIs: [docs](/integrations/ci_cd/#defaulted-kosli-command-flags-from-ci-variables) ).  |
-|        `--redact-commit-info` strings  |  [optional] The list of commit info to be redacted before sending to Kosli. Allowed values are one or more of [author, message, branch].  |
-|        `--registry-password` string  |  [conditional] The container registry password or access token. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper.  |
-|        `--registry-provider` string  |  [deprecated] The docker registry provider or url. Only required if you want to read docker image SHA256 digest from a remote docker registry. (DEPRECATED: no longer used)  |
-|        `--registry-username` string  |  [conditional] The container registry username. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper.  |
-|        `--repo-id` string  |  [conditional] The stable, unique identifier for the repository in your VCS provider (e.g. a numeric ID). Do not use the repository name as it can change if the repo is renamed. All three of `--repo-id`, `--repo-url` and `--repository` must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
-|        `--repo-provider` string  |  [optional] The source code hosting provider. One of: github, gitlab, bitbucket, bitbucket_cloud, bitbucket_dc, azure-devops, azure_devops_services, azure_devops_server, git, subversion (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
-|        `--repo-root` string  |  [defaulted] The directory where the source git repository is available. Only used if `--commit` is used or defaulted in CI, see [docs](/integrations/ci_cd/#defaulted-kosli-command-flags-from-ci-variables) . (default ".")  |
-|        `--repo-url` string  |  [conditional] The URL of the repository. Must be a valid URL. All three of `--repo-id`, `--repo-url` and `--repository` must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
-|        `--repository` string  |  [conditional] The name of the repository (e.g. owner/repo-name). All three of `--repo-id`, `--repo-url` and `--repository` must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
-|    `-R`, `--scan-results` string  |  The path to Snyk scan SARIF results file from 'snyk test' and 'snyk container test'. By default, the Snyk results will be uploaded to Kosli's evidence vault.  |
-|    `-T`, `--trail` string  |  The Kosli trail name.  |
-|        `--upload-results`  |  [defaulted] Whether to upload the provided Snyk results file as an attachment to Kosli or not. (default true)  |
-|    `-u`, `--user-data` string  |  [optional] The path to a JSON file containing additional data you would like to attach to the attestation.  |
+| Flag | Type | Description |
+| :--- | :--- | :--- |
+|       `--annotate` | stringToString | [optional] Annotate the attestation with data using key=value. |
+|   `-t`, `--artifact-type` | string | The type of the artifact to calculate its SHA256 fingerprint. One of: [oci, docker, file, dir]. Only required if you want Kosli to calculate the fingerprint for you (i.e. when you don't specify '`--fingerprint`' on commands that allow it). |
+|       `--attachments` | strings | [optional] The comma-separated list of paths of attachments for the reported attestation. Attachments can be files or directories. All attachments are compressed and uploaded to Kosli's evidence vault. |
+|   `-g`, `--commit` | string | [conditional] The git commit for which the attestation is associated to. Becomes required when reporting an attestation for an artifact before reporting it to Kosli. (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
+|       `--description` | string | [optional] attestation description |
+|   `-D`, `--dry-run` |  | [optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors. |
+|   `-x`, `--exclude` | strings | [optional] The comma separated list of directories and files to exclude from fingerprinting. Can take glob patterns. Only applicable for `--artifact-type` dir. |
+|       `--external-fingerprint` | stringToString | [optional] A SHA256 fingerprint of an external attachment represented by `--external-url`. The format is label=fingerprint (labels cannot contain '.' or '='). This flag can be set multiple times. There must be an external url with a matching label for each external fingerprint. |
+|       `--external-url` | stringToString | [optional] Add labeled reference URL for an external resource. The format is label=url (labels cannot contain '.' or '='). This flag can be set multiple times. If the resource is a file or dir, you can optionally add its fingerprint via `--external-fingerprint` |
+|   `-F`, `--fingerprint` | string | [conditional] The SHA256 fingerprint of the artifact to attach the attestation to. Only required if the attestation is for an artifact and `--artifact-type` and artifact name/path are not used. |
+|   `-f`, `--flow` | string | The Kosli flow name. |
+|   `-h`, `--help` |  | help for snyk |
+|   `-n`, `--name` | string | The name of the attestation as declared in the flow or trail yaml template. |
+|   `-o`, `--origin-url` | string | [optional] The url pointing to where the attestation came from or is related. (defaulted to the CI url in some CIs: [docs](/integrations/ci_cd/#defaulted-kosli-command-flags-from-ci-variables) ). |
+|       `--redact-commit-info` | strings | [optional] The list of commit info to be redacted before sending to Kosli. Allowed values are one or more of [author, message, branch]. |
+|       `--registry-password` | string | [conditional] The container registry password or access token. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper. |
+|       `--registry-provider` | string | [deprecated] The docker registry provider or url. Only required if you want to read docker image SHA256 digest from a remote docker registry. (DEPRECATED: no longer used) |
+|       `--registry-username` | string | [conditional] The container registry username. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper. |
+|       `--repo-id` | string | [conditional] The stable, unique identifier for the repository in your VCS provider (e.g. a numeric ID). Do not use the repository name as it can change if the repo is renamed. All three of `--repo-id`, `--repo-url` and `--repository` must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
+|       `--repo-provider` | string | [optional] The source code hosting provider. One of: github, gitlab, bitbucket, bitbucket_cloud, bitbucket_dc, azure-devops, azure_devops_services, azure_devops_server, git, subversion (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
+|       `--repo-root` | string | [defaulted] The directory where the source git repository is available. Only used if `--commit` is used or defaulted in CI, see [docs](/integrations/ci_cd/#defaulted-kosli-command-flags-from-ci-variables) . (default ".") |
+|       `--repo-url` | string | [conditional] The URL of the repository. Must be a valid URL. All three of `--repo-id`, `--repo-url` and `--repository` must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
+|       `--repository` | string | [conditional] The name of the repository (e.g. owner/repo-name). All three of `--repo-id`, `--repo-url` and `--repository` must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
+|   `-R`, `--scan-results` | string | The path to Snyk scan SARIF results file from 'snyk test' and 'snyk container test'. By default, the Snyk results will be uploaded to Kosli's evidence vault. |
+|   `-T`, `--trail` | string | The Kosli trail name. |
+|       `--upload-results` |  | [defaulted] Whether to upload the provided Snyk results file as an attachment to Kosli or not. (default true) |
+|   `-u`, `--user-data` | string | [optional] The path to a JSON file containing additional data you would like to attach to the attestation. |
 
 
 ## Examples Use Cases
@@ -122,4 +122,3 @@ kosli attest snyk
 ```
 </Accordion>
 </AccordionGroup>
-

--- a/internal/docgen/helpers.go
+++ b/internal/docgen/helpers.go
@@ -17,7 +17,6 @@ func CommandsInTable(f *pflag.FlagSet) string {
 
 	lines := make([]string, 0, 100)
 
-	maxlen := 0
 	f.VisitAll(func(flag *pflag.Flag) {
 		// pflag.MarkDeprecated sets Hidden as a side effect, which would keep
 		// deprecated-but-working flags out of the reference docs along with
@@ -28,59 +27,48 @@ func CommandsInTable(f *pflag.FlagSet) string {
 			return
 		}
 
-		line := ""
+		flagName := ""
 		if flag.Shorthand != "" && flag.ShorthandDeprecated == "" {
-			line = fmt.Sprintf("  -%s, --%s", flag.Shorthand, flag.Name)
+			flagName = fmt.Sprintf("  -%s, --%s", flag.Shorthand, flag.Name)
 		} else {
-			line = fmt.Sprintf("      --%s", flag.Name)
+			flagName = fmt.Sprintf("      --%s", flag.Name)
 		}
 
 		varname, usage := pflag.UnquoteUsage(flag)
-		if varname != "" {
-			line += " " + varname
-		}
 		if flag.NoOptDefVal != "" {
 			switch flag.Value.Type() {
 			case "string":
-				line += fmt.Sprintf("[=\"%s\"]", flag.NoOptDefVal)
+				varname += fmt.Sprintf("[=\"%s\"]", flag.NoOptDefVal)
 			case "bool":
 				if flag.NoOptDefVal != "true" {
-					line += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
+					varname += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
 				}
 			case "count":
 				if flag.NoOptDefVal != "+1" {
-					line += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
+					varname += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
 				}
 			default:
-				line += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
+				varname += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
 			}
 		}
-
-		line += "\x00"
-		if len(line) > maxlen {
-			maxlen = len(line)
-		}
-
-		line += usage
 		defaultZero := []string{"", "0", "[]", "<nil>", "0s", "false"}
 
 		if !slices.Contains(defaultZero, flag.DefValue) {
 			if flag.Value.Type() == "string" {
-				line += fmt.Sprintf(" (default %q)", flag.DefValue)
+				usage += fmt.Sprintf(" (default %q)", flag.DefValue)
 			} else {
-				line += fmt.Sprintf(" (default %s)", flag.DefValue)
+				usage += fmt.Sprintf(" (default %s)", flag.DefValue)
 			}
 		}
 		if len(flag.Deprecated) != 0 {
-			line += fmt.Sprintf(" (DEPRECATED: %s)", flag.Deprecated)
+			usage += fmt.Sprintf(" (DEPRECATED: %s)", flag.Deprecated)
 		}
 
-		lines = append(lines, line)
+		lines = append(lines, fmt.Sprintf("| %s | %s | %s |", flagName, varname, usage))
 	})
 
 	for _, line := range lines {
-		sidx := strings.Index(line, "\x00")
-		fmt.Fprintln(buf, "| ", line[:sidx], " | ", line[sidx+1:], " |")
+		fmt.Fprintln(buf, line)
 	}
 
 	return buf.String()

--- a/internal/docgen/helpers_test.go
+++ b/internal/docgen/helpers_test.go
@@ -13,17 +13,11 @@ func TestCommandsInTable(t *testing.T) {
 	fs.Bool("verbose", false, "Enable verbose")
 
 	got := CommandsInTable(fs)
-	if !strings.Contains(got, "--name") {
-		t.Error("expected --name flag")
+	if !strings.Contains(got, "|   -n, --name | string | The name |") {
+		t.Errorf("expected string type in its own column, got:\n%s", got)
 	}
-	if !strings.Contains(got, "-n") {
-		t.Error("expected shorthand -n")
-	}
-	if !strings.Contains(got, "--verbose") {
-		t.Error("expected --verbose flag")
-	}
-	if !strings.Contains(got, "|") {
-		t.Error("expected table formatting")
+	if !strings.Contains(got, "|       --verbose |  | Enable verbose |") {
+		t.Errorf("expected empty type column for bool flag, got:\n%s", got)
 	}
 }
 

--- a/internal/docgen/mintlify.go
+++ b/internal/docgen/mintlify.go
@@ -84,15 +84,15 @@ func (MintlifyFormatter) FlagsSection(flags, inherited string) string {
 	var b strings.Builder
 	if flags != "" {
 		b.WriteString("## Flags\n")
-		b.WriteString("| Flag | Description |\n")
-		b.WriteString("| :--- | :--- |\n")
+		b.WriteString("| Flag | Type | Description |\n")
+		b.WriteString("| :--- | :--- | :--- |\n")
 		b.WriteString(flags)
 		b.WriteString("\n\n")
 	}
 	if inherited != "" {
 		b.WriteString("## Flags inherited from parent commands\n")
-		b.WriteString("| Flag | Description |\n")
-		b.WriteString("| :--- | :--- |\n")
+		b.WriteString("| Flag | Type | Description |\n")
+		b.WriteString("| :--- | :--- | :--- |\n")
 		b.WriteString(inherited)
 		b.WriteString("\n\n")
 	}

--- a/internal/docgen/mintlify_test.go
+++ b/internal/docgen/mintlify_test.go
@@ -386,12 +386,15 @@ func TestBacktickFlags(t *testing.T) {
 
 func TestMintlifyFlagsSectionBackticksFlags(t *testing.T) {
 	f := MintlifyFormatter{}
-	flags := "| --api-token string | required (default $KOSLI_API_TOKEN) |\n"
+	flags := "| --api-token | string | required (default $KOSLI_API_TOKEN) |\n"
 	got := f.FlagsSection(flags, "")
+	if !strings.Contains(got, "| Flag | Type | Description |") {
+		t.Errorf("expected type column header, got:\n%s", got)
+	}
 	if !strings.Contains(got, "`--api-token`") {
 		t.Errorf("expected --api-token to be backticked, got:\n%s", got)
 	}
-	if strings.Contains(got, "| --api-token string |") {
+	if strings.Contains(got, "| --api-token |") {
 		t.Errorf("expected bare --api-token to be replaced, got:\n%s", got)
 	}
 }


### PR DESCRIPTION
Separates each CLI flag's value type from the flag name in generated Mintlify tables. Boolean flags keep an empty type cell, while defaults and deprecation notices remain in the description. This makes wide flag lists such as `kosli snapshot azure` easier to scan.

The change was AI-assisted and manually verified against the generated Azure command reference and focused tests.

Closes #450

### Verification

- `go test ./internal/docgen`
- `go test ./cmd/kosli -run TestDocsCommandTestSuite -count=1`
- `go vet ./internal/docgen`
- generated `kosli snapshot azure` docs and inspected both local and inherited flag tables
- `gofmt -d internal/docgen/helpers.go internal/docgen/helpers_test.go internal/docgen/mintlify.go internal/docgen/mintlify_test.go`
- `git diff --check`

### Checklist

- [x] **Docs** are autogenerated from CLI help — make sure the help text reflects your changes
- [ ] **Helm chart** (`charts/k8s-reporter/`) updated, if needed. Note: these changes live in a **separate PR**
- [ ] **Terraform provider** and related changes ([terraform-provider-kosli](https://github.com/kosli-dev/terraform-provider-kosli), [terraform-aws-evidence-reporter](https://github.com/kosli-dev/terraform-aws-evidence-reporter), [terraform-aws-kosli-reporter](https://github.com/kosli-dev/terraform-aws-kosli-reporter)) updated, if needed