### PR TITLE
fix(docs): separate flag types into a column

### DIFF
--- a/cmd/kosli/testdata/output/docs/mintlify/artifact.md
+++ b/cmd/kosli/testdata/output/docs/mintlify/artifact.md
@@ -46,22 +46,22 @@ is set), registry credentials are resolved as follows:
 
 
 ## Flags
-| Flag | Description |
-| :--- | :--- |
-|    `-t`, `--artifact-type` string  |  The type of the artifact to calculate its SHA256 fingerprint. One of: [oci, docker, file, dir]. Only required if you want Kosli to calculate the fingerprint for you (i.e. when you don't specify '`--fingerprint`' on commands that allow it).  |
-|    `-b`, `--build-url` string  |  The url of CI pipeline that built the artifact. (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
-|    `-u`, `--commit-url` string  |  The url for the git commit that created the artifact. (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
-|    `-D`, `--dry-run`  |  [optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors.  |
-|    `-x`, `--exclude` strings  |  [optional] The comma separated list of directories and files to exclude from fingerprinting. Can take glob patterns. Only applicable for `--artifact-type` dir.  |
-|    `-F`, `--fingerprint` string  |  [conditional] The SHA256 fingerprint of the artifact. Only required if you don't specify '`--artifact-type`'.  |
-|    `-f`, `--flow` string  |  The Kosli flow name.  |
-|    `-g`, `--git-commit` string  |  [defaulted] The git commit from which the artifact was created. (defaulted in some CIs: [docs](/integrations/ci_cd), otherwise defaults to HEAD ).  |
-|    `-h`, `--help`  |  help for artifact  |
-|    `-n`, `--name` string  |  [optional] Artifact display name, if different from file, image or directory name.  |
-|        `--registry-password` string  |  [conditional] The container registry password or access token. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper.  |
-|        `--registry-provider` string  |  [deprecated] The docker registry provider or url. Only required if you want to read docker image SHA256 digest from a remote docker registry. (DEPRECATED: no longer used)  |
-|        `--registry-username` string  |  [conditional] The container registry username. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper.  |
-|        `--repo-root` string  |  [defaulted] The directory where the source git repository is available. (default ".")  |
+| Flag | Type | Description |
+| :--- | :--- | :--- |
+|   `-t`, `--artifact-type` | string | The type of the artifact to calculate its SHA256 fingerprint. One of: [oci, docker, file, dir]. Only required if you want Kosli to calculate the fingerprint for you (i.e. when you don't specify '`--fingerprint`' on commands that allow it). |
+|   `-b`, `--build-url` | string | The url of CI pipeline that built the artifact. (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
+|   `-u`, `--commit-url` | string | The url for the git commit that created the artifact. (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
+|   `-D`, `--dry-run` |  | [optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors. |
+|   `-x`, `--exclude` | strings | [optional] The comma separated list of directories and files to exclude from fingerprinting. Can take glob patterns. Only applicable for `--artifact-type` dir. |
+|   `-F`, `--fingerprint` | string | [conditional] The SHA256 fingerprint of the artifact. Only required if you don't specify '`--artifact-type`'. |
+|   `-f`, `--flow` | string | The Kosli flow name. |
+|   `-g`, `--git-commit` | string | [defaulted] The git commit from which the artifact was created. (defaulted in some CIs: [docs](/integrations/ci_cd), otherwise defaults to HEAD ). |
+|   `-h`, `--help` |  | help for artifact |
+|   `-n`, `--name` | string | [optional] Artifact display name, if different from file, image or directory name. |
+|       `--registry-password` | string | [conditional] The container registry password or access token. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper. |
+|       `--registry-provider` | string | [deprecated] The docker registry provider or url. Only required if you want to read docker image SHA256 digest from a remote docker registry. (DEPRECATED: no longer used) |
+|       `--registry-username` | string | [conditional] The container registry username. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper. |
+|       `--repo-root` | string | [defaulted] The directory where the source git repository is available. (default ".") |
 
 
 ## Examples Use Cases
@@ -89,4 +89,3 @@ kosli report artifact ANOTHER_FILE.txt
 ```
 </Accordion>
 </AccordionGroup>
-

--- a/cmd/kosli/testdata/output/docs/mintlify/artifact.md
+++ b/cmd/kosli/testdata/output/docs/mintlify/artifact.md
@@ -48,20 +48,20 @@ is set), registry credentials are resolved as follows:
 ## Flags
 | Flag | Type | Description |
 | :--- | :--- | :--- |
-|   `-t`, `--artifact-type` | string | The type of the artifact to calculate its SHA256 fingerprint. One of: [oci, docker, file, dir]. Only required if you want Kosli to calculate the fingerprint for you (i.e. when you don't specify '`--fingerprint`' on commands that allow it). |
-|   `-b`, `--build-url` | string | The url of CI pipeline that built the artifact. (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
-|   `-u`, `--commit-url` | string | The url for the git commit that created the artifact. (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
-|   `-D`, `--dry-run` |  | [optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors. |
-|   `-x`, `--exclude` | strings | [optional] The comma separated list of directories and files to exclude from fingerprinting. Can take glob patterns. Only applicable for `--artifact-type` dir. |
-|   `-F`, `--fingerprint` | string | [conditional] The SHA256 fingerprint of the artifact. Only required if you don't specify '`--artifact-type`'. |
-|   `-f`, `--flow` | string | The Kosli flow name. |
-|   `-g`, `--git-commit` | string | [defaulted] The git commit from which the artifact was created. (defaulted in some CIs: [docs](/integrations/ci_cd), otherwise defaults to HEAD ). |
-|   `-h`, `--help` |  | help for artifact |
-|   `-n`, `--name` | string | [optional] Artifact display name, if different from file, image or directory name. |
-|       `--registry-password` | string | [conditional] The container registry password or access token. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper. |
-|       `--registry-provider` | string | [deprecated] The docker registry provider or url. Only required if you want to read docker image SHA256 digest from a remote docker registry. (DEPRECATED: no longer used) |
-|       `--registry-username` | string | [conditional] The container registry username. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper. |
-|       `--repo-root` | string | [defaulted] The directory where the source git repository is available. (default ".") |
+| `-t`, `--artifact-type` | string | The type of the artifact to calculate its SHA256 fingerprint. One of: [oci, docker, file, dir]. Only required if you want Kosli to calculate the fingerprint for you (i.e. when you don't specify '`--fingerprint`' on commands that allow it). |
+| `-b`, `--build-url` | string | The url of CI pipeline that built the artifact. (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
+| `-u`, `--commit-url` | string | The url for the git commit that created the artifact. (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
+| `-D`, `--dry-run` |  | [optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors. |
+| `-x`, `--exclude` | strings | [optional] The comma separated list of directories and files to exclude from fingerprinting. Can take glob patterns. Only applicable for `--artifact-type` dir. |
+| `-F`, `--fingerprint` | string | [conditional] The SHA256 fingerprint of the artifact. Only required if you don't specify '`--artifact-type`'. |
+| `-f`, `--flow` | string | The Kosli flow name. |
+| `-g`, `--git-commit` | string | [defaulted] The git commit from which the artifact was created. (defaulted in some CIs: [docs](/integrations/ci_cd), otherwise defaults to HEAD ). |
+| `-h`, `--help` |  | help for artifact |
+| `-n`, `--name` | string | [optional] Artifact display name, if different from file, image or directory name. |
+| `--registry-password` | string | [conditional] The container registry password or access token. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper. |
+| `--registry-provider` | string | [deprecated] The docker registry provider or url. Only required if you want to read docker image SHA256 digest from a remote docker registry. (DEPRECATED: no longer used) |
+| `--registry-username` | string | [conditional] The container registry username. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper. |
+| `--repo-root` | string | [defaulted] The directory where the source git repository is available. (default ".") |
 
 
 ## Examples Use Cases
@@ -89,3 +89,4 @@ kosli report artifact ANOTHER_FILE.txt
 ```
 </Accordion>
 </AccordionGroup>
+

--- a/cmd/kosli/testdata/output/docs/mintlify/artifact.md
+++ b/cmd/kosli/testdata/output/docs/mintlify/artifact.md
@@ -51,12 +51,12 @@ is set), registry credentials are resolved as follows:
 | `-t`, `--artifact-type` | string | The type of the artifact to calculate its SHA256 fingerprint. One of: [oci, docker, file, dir]. Only required if you want Kosli to calculate the fingerprint for you (i.e. when you don't specify '`--fingerprint`' on commands that allow it). |
 | `-b`, `--build-url` | string | The url of CI pipeline that built the artifact. (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
 | `-u`, `--commit-url` | string | The url for the git commit that created the artifact. (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
-| `-D`, `--dry-run` |  | [optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors. |
+| `-D`, `--dry-run` | bool | [optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors. |
 | `-x`, `--exclude` | strings | [optional] The comma separated list of directories and files to exclude from fingerprinting. Can take glob patterns. Only applicable for `--artifact-type` dir. |
 | `-F`, `--fingerprint` | string | [conditional] The SHA256 fingerprint of the artifact. Only required if you don't specify '`--artifact-type`'. |
 | `-f`, `--flow` | string | The Kosli flow name. |
 | `-g`, `--git-commit` | string | [defaulted] The git commit from which the artifact was created. (defaulted in some CIs: [docs](/integrations/ci_cd), otherwise defaults to HEAD ). |
-| `-h`, `--help` |  | help for artifact |
+| `-h`, `--help` | bool | help for artifact |
 | `-n`, `--name` | string | [optional] Artifact display name, if different from file, image or directory name. |
 | `--registry-password` | string | [conditional] The container registry password or access token. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper. |
 | `--registry-provider` | string | [deprecated] The docker registry provider or url. Only required if you want to read docker image SHA256 digest from a remote docker registry. (DEPRECATED: no longer used) |

--- a/cmd/kosli/testdata/output/docs/mintlify/snyk.md
+++ b/cmd/kosli/testdata/output/docs/mintlify/snyk.md
@@ -33,35 +33,35 @@ These are automatically set in GitHub Actions, GitLab CI, Bitbucket Pipelines, a
 In other CI systems, set them explicitly to capture repository metadata.
 
 ## Flags
-| Flag | Description |
-| :--- | :--- |
-|        `--annotate` stringToString  |  [optional] Annotate the attestation with data using key=value.  |
-|    `-t`, `--artifact-type` string  |  The type of the artifact to calculate its SHA256 fingerprint. One of: [oci, docker, file, dir]. Only required if you want Kosli to calculate the fingerprint for you (i.e. when you don't specify '`--fingerprint`' on commands that allow it).  |
-|        `--attachments` strings  |  [optional] The comma-separated list of paths of attachments for the reported attestation. Attachments can be files or directories. All attachments are compressed and uploaded to Kosli's evidence vault.  |
-|    `-g`, `--commit` string  |  [conditional] The git commit for which the attestation is associated to. Becomes required when reporting an attestation for an artifact before reporting it to Kosli. (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
-|        `--description` string  |  [optional] attestation description  |
-|    `-D`, `--dry-run`  |  [optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors.  |
-|    `-x`, `--exclude` strings  |  [optional] The comma separated list of directories and files to exclude from fingerprinting. Can take glob patterns. Only applicable for `--artifact-type` dir.  |
-|        `--external-fingerprint` stringToString  |  [optional] A SHA256 fingerprint of an external attachment represented by `--external-url`. The format is label=fingerprint (labels cannot contain '.' or '='). This flag can be set multiple times. There must be an external url with a matching label for each external fingerprint.  |
-|        `--external-url` stringToString  |  [optional] Add labeled reference URL for an external resource. The format is label=url (labels cannot contain '.' or '='). This flag can be set multiple times. If the resource is a file or dir, you can optionally add its fingerprint via `--external-fingerprint`  |
-|    `-F`, `--fingerprint` string  |  [conditional] The SHA256 fingerprint of the artifact to attach the attestation to. Only required if the attestation is for an artifact and `--artifact-type` and artifact name/path are not used.  |
-|    `-f`, `--flow` string  |  The Kosli flow name.  |
-|    `-h`, `--help`  |  help for snyk  |
-|    `-n`, `--name` string  |  The name of the attestation as declared in the flow or trail yaml template.  |
-|    `-o`, `--origin-url` string  |  [optional] The url pointing to where the attestation came from or is related. (defaulted to the CI url in some CIs: [docs](/integrations/ci_cd/#defaulted-kosli-command-flags-from-ci-variables) ).  |
-|        `--redact-commit-info` strings  |  [optional] The list of commit info to be redacted before sending to Kosli. Allowed values are one or more of [author, message, branch].  |
-|        `--registry-password` string  |  [conditional] The container registry password or access token. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper.  |
-|        `--registry-provider` string  |  [deprecated] The docker registry provider or url. Only required if you want to read docker image SHA256 digest from a remote docker registry. (DEPRECATED: no longer used)  |
-|        `--registry-username` string  |  [conditional] The container registry username. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper.  |
-|        `--repo-id` string  |  [conditional] The stable, unique identifier for the repository in your VCS provider (e.g. a numeric ID). Do not use the repository name as it can change if the repo is renamed. All three of `--repo-id`, `--repo-url` and `--repository` must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
-|        `--repo-provider` string  |  [optional] The source code hosting provider. One of: github, gitlab, bitbucket, bitbucket_cloud, bitbucket_dc, azure-devops, azure_devops_services, azure_devops_server, git, subversion (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
-|        `--repo-root` string  |  [defaulted] The directory where the source git repository is available. Only used if `--commit` is used or defaulted in CI, see [docs](/integrations/ci_cd/#defaulted-kosli-command-flags-from-ci-variables) . (default ".")  |
-|        `--repo-url` string  |  [conditional] The URL of the repository. Must be a valid URL. All three of `--repo-id`, `--repo-url` and `--repository` must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
-|        `--repository` string  |  [conditional] The name of the repository (e.g. owner/repo-name). All three of `--repo-id`, `--repo-url` and `--repository` must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ).  |
-|    `-R`, `--scan-results` string  |  The path to Snyk scan SARIF results file from 'snyk test' and 'snyk container test'. By default, the Snyk results will be uploaded to Kosli's evidence vault.  |
-|    `-T`, `--trail` string  |  The Kosli trail name.  |
-|        `--upload-results`  |  [defaulted] Whether to upload the provided Snyk results file as an attachment to Kosli or not. (default true)  |
-|    `-u`, `--user-data` string  |  [optional] The path to a JSON file containing additional data you would like to attach to the attestation.  |
+| Flag | Type | Description |
+| :--- | :--- | :--- |
+|       `--annotate` | stringToString | [optional] Annotate the attestation with data using key=value. |
+|   `-t`, `--artifact-type` | string | The type of the artifact to calculate its SHA256 fingerprint. One of: [oci, docker, file, dir]. Only required if you want Kosli to calculate the fingerprint for you (i.e. when you don't specify '`--fingerprint`' on commands that allow it). |
+|       `--attachments` | strings | [optional] The comma-separated list of paths of attachments for the reported attestation. Attachments can be files or directories. All attachments are compressed and uploaded to Kosli's evidence vault. |
+|   `-g`, `--commit` | string | [conditional] The git commit for which the attestation is associated to. Becomes required when reporting an attestation for an artifact before reporting it to Kosli. (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
+|       `--description` | string | [optional] attestation description |
+|   `-D`, `--dry-run` |  | [optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors. |
+|   `-x`, `--exclude` | strings | [optional] The comma separated list of directories and files to exclude from fingerprinting. Can take glob patterns. Only applicable for `--artifact-type` dir. |
+|       `--external-fingerprint` | stringToString | [optional] A SHA256 fingerprint of an external attachment represented by `--external-url`. The format is label=fingerprint (labels cannot contain '.' or '='). This flag can be set multiple times. There must be an external url with a matching label for each external fingerprint. |
+|       `--external-url` | stringToString | [optional] Add labeled reference URL for an external resource. The format is label=url (labels cannot contain '.' or '='). This flag can be set multiple times. If the resource is a file or dir, you can optionally add its fingerprint via `--external-fingerprint` |
+|   `-F`, `--fingerprint` | string | [conditional] The SHA256 fingerprint of the artifact to attach the attestation to. Only required if the attestation is for an artifact and `--artifact-type` and artifact name/path are not used. |
+|   `-f`, `--flow` | string | The Kosli flow name. |
+|   `-h`, `--help` |  | help for snyk |
+|   `-n`, `--name` | string | The name of the attestation as declared in the flow or trail yaml template. |
+|   `-o`, `--origin-url` | string | [optional] The url pointing to where the attestation came from or is related. (defaulted to the CI url in some CIs: [docs](/integrations/ci_cd/#defaulted-kosli-command-flags-from-ci-variables) ). |
+|       `--redact-commit-info` | strings | [optional] The list of commit info to be redacted before sending to Kosli. Allowed values are one or more of [author, message, branch]. |
+|       `--registry-password` | string | [conditional] The container registry password or access token. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper. |
+|       `--registry-provider` | string | [deprecated] The docker registry provider or url. Only required if you want to read docker image SHA256 digest from a remote docker registry. (DEPRECATED: no longer used) |
+|       `--registry-username` | string | [conditional] The container registry username. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper. |
+|       `--repo-id` | string | [conditional] The stable, unique identifier for the repository in your VCS provider (e.g. a numeric ID). Do not use the repository name as it can change if the repo is renamed. All three of `--repo-id`, `--repo-url` and `--repository` must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
+|       `--repo-provider` | string | [optional] The source code hosting provider. One of: github, gitlab, bitbucket, bitbucket_cloud, bitbucket_dc, azure-devops, azure_devops_services, azure_devops_server, git, subversion (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
+|       `--repo-root` | string | [defaulted] The directory where the source git repository is available. Only used if `--commit` is used or defaulted in CI, see [docs](/integrations/ci_cd/#defaulted-kosli-command-flags-from-ci-variables) . (default ".") |
+|       `--repo-url` | string | [conditional] The URL of the repository. Must be a valid URL. All three of `--repo-id`, `--repo-url` and `--repository` must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
+|       `--repository` | string | [conditional] The name of the repository (e.g. owner/repo-name). All three of `--repo-id`, `--repo-url` and `--repository` must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
+|   `-R`, `--scan-results` | string | The path to Snyk scan SARIF results file from 'snyk test' and 'snyk container test'. By default, the Snyk results will be uploaded to Kosli's evidence vault. |
+|   `-T`, `--trail` | string | The Kosli trail name. |
+|       `--upload-results` |  | [defaulted] Whether to upload the provided Snyk results file as an attachment to Kosli or not. (default true) |
+|   `-u`, `--user-data` | string | [optional] The path to a JSON file containing additional data you would like to attach to the attestation. |
 
 
 ## Examples Use Cases
@@ -122,4 +122,3 @@ kosli attest snyk
 ```
 </Accordion>
 </AccordionGroup>
-

--- a/cmd/kosli/testdata/output/docs/mintlify/snyk.md
+++ b/cmd/kosli/testdata/output/docs/mintlify/snyk.md
@@ -40,13 +40,13 @@ In other CI systems, set them explicitly to capture repository metadata.
 | `--attachments` | strings | [optional] The comma-separated list of paths of attachments for the reported attestation. Attachments can be files or directories. All attachments are compressed and uploaded to Kosli's evidence vault. |
 | `-g`, `--commit` | string | [conditional] The git commit for which the attestation is associated to. Becomes required when reporting an attestation for an artifact before reporting it to Kosli. (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
 | `--description` | string | [optional] attestation description |
-| `-D`, `--dry-run` |  | [optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors. |
+| `-D`, `--dry-run` | bool | [optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors. |
 | `-x`, `--exclude` | strings | [optional] The comma separated list of directories and files to exclude from fingerprinting. Can take glob patterns. Only applicable for `--artifact-type` dir. |
 | `--external-fingerprint` | stringToString | [optional] A SHA256 fingerprint of an external attachment represented by `--external-url`. The format is label=fingerprint (labels cannot contain '.' or '='). This flag can be set multiple times. There must be an external url with a matching label for each external fingerprint. |
 | `--external-url` | stringToString | [optional] Add labeled reference URL for an external resource. The format is label=url (labels cannot contain '.' or '='). This flag can be set multiple times. If the resource is a file or dir, you can optionally add its fingerprint via `--external-fingerprint` |
 | `-F`, `--fingerprint` | string | [conditional] The SHA256 fingerprint of the artifact to attach the attestation to. Only required if the attestation is for an artifact and `--artifact-type` and artifact name/path are not used. |
 | `-f`, `--flow` | string | The Kosli flow name. |
-| `-h`, `--help` |  | help for snyk |
+| `-h`, `--help` | bool | help for snyk |
 | `-n`, `--name` | string | The name of the attestation as declared in the flow or trail yaml template. |
 | `-o`, `--origin-url` | string | [optional] The url pointing to where the attestation came from or is related. (defaulted to the CI url in some CIs: [docs](/integrations/ci_cd/#defaulted-kosli-command-flags-from-ci-variables) ). |
 | `--redact-commit-info` | strings | [optional] The list of commit info to be redacted before sending to Kosli. Allowed values are one or more of [author, message, branch]. |
@@ -60,7 +60,7 @@ In other CI systems, set them explicitly to capture repository metadata.
 | `--repository` | string | [conditional] The name of the repository (e.g. owner/repo-name). All three of `--repo-id`, `--repo-url` and `--repository` must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
 | `-R`, `--scan-results` | string | The path to Snyk scan SARIF results file from 'snyk test' and 'snyk container test'. By default, the Snyk results will be uploaded to Kosli's evidence vault. |
 | `-T`, `--trail` | string | The Kosli trail name. |
-| `--upload-results` |  | [defaulted] Whether to upload the provided Snyk results file as an attachment to Kosli or not. (default true) |
+| `--upload-results` | bool | [defaulted] Whether to upload the provided Snyk results file as an attachment to Kosli or not. (default true) |
 | `-u`, `--user-data` | string | [optional] The path to a JSON file containing additional data you would like to attach to the attestation. |
 
 

--- a/cmd/kosli/testdata/output/docs/mintlify/snyk.md
+++ b/cmd/kosli/testdata/output/docs/mintlify/snyk.md
@@ -35,33 +35,33 @@ In other CI systems, set them explicitly to capture repository metadata.
 ## Flags
 | Flag | Type | Description |
 | :--- | :--- | :--- |
-|       `--annotate` | stringToString | [optional] Annotate the attestation with data using key=value. |
-|   `-t`, `--artifact-type` | string | The type of the artifact to calculate its SHA256 fingerprint. One of: [oci, docker, file, dir]. Only required if you want Kosli to calculate the fingerprint for you (i.e. when you don't specify '`--fingerprint`' on commands that allow it). |
-|       `--attachments` | strings | [optional] The comma-separated list of paths of attachments for the reported attestation. Attachments can be files or directories. All attachments are compressed and uploaded to Kosli's evidence vault. |
-|   `-g`, `--commit` | string | [conditional] The git commit for which the attestation is associated to. Becomes required when reporting an attestation for an artifact before reporting it to Kosli. (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
-|       `--description` | string | [optional] attestation description |
-|   `-D`, `--dry-run` |  | [optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors. |
-|   `-x`, `--exclude` | strings | [optional] The comma separated list of directories and files to exclude from fingerprinting. Can take glob patterns. Only applicable for `--artifact-type` dir. |
-|       `--external-fingerprint` | stringToString | [optional] A SHA256 fingerprint of an external attachment represented by `--external-url`. The format is label=fingerprint (labels cannot contain '.' or '='). This flag can be set multiple times. There must be an external url with a matching label for each external fingerprint. |
-|       `--external-url` | stringToString | [optional] Add labeled reference URL for an external resource. The format is label=url (labels cannot contain '.' or '='). This flag can be set multiple times. If the resource is a file or dir, you can optionally add its fingerprint via `--external-fingerprint` |
-|   `-F`, `--fingerprint` | string | [conditional] The SHA256 fingerprint of the artifact to attach the attestation to. Only required if the attestation is for an artifact and `--artifact-type` and artifact name/path are not used. |
-|   `-f`, `--flow` | string | The Kosli flow name. |
-|   `-h`, `--help` |  | help for snyk |
-|   `-n`, `--name` | string | The name of the attestation as declared in the flow or trail yaml template. |
-|   `-o`, `--origin-url` | string | [optional] The url pointing to where the attestation came from or is related. (defaulted to the CI url in some CIs: [docs](/integrations/ci_cd/#defaulted-kosli-command-flags-from-ci-variables) ). |
-|       `--redact-commit-info` | strings | [optional] The list of commit info to be redacted before sending to Kosli. Allowed values are one or more of [author, message, branch]. |
-|       `--registry-password` | string | [conditional] The container registry password or access token. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper. |
-|       `--registry-provider` | string | [deprecated] The docker registry provider or url. Only required if you want to read docker image SHA256 digest from a remote docker registry. (DEPRECATED: no longer used) |
-|       `--registry-username` | string | [conditional] The container registry username. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper. |
-|       `--repo-id` | string | [conditional] The stable, unique identifier for the repository in your VCS provider (e.g. a numeric ID). Do not use the repository name as it can change if the repo is renamed. All three of `--repo-id`, `--repo-url` and `--repository` must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
-|       `--repo-provider` | string | [optional] The source code hosting provider. One of: github, gitlab, bitbucket, bitbucket_cloud, bitbucket_dc, azure-devops, azure_devops_services, azure_devops_server, git, subversion (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
-|       `--repo-root` | string | [defaulted] The directory where the source git repository is available. Only used if `--commit` is used or defaulted in CI, see [docs](/integrations/ci_cd/#defaulted-kosli-command-flags-from-ci-variables) . (default ".") |
-|       `--repo-url` | string | [conditional] The URL of the repository. Must be a valid URL. All three of `--repo-id`, `--repo-url` and `--repository` must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
-|       `--repository` | string | [conditional] The name of the repository (e.g. owner/repo-name). All three of `--repo-id`, `--repo-url` and `--repository` must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
-|   `-R`, `--scan-results` | string | The path to Snyk scan SARIF results file from 'snyk test' and 'snyk container test'. By default, the Snyk results will be uploaded to Kosli's evidence vault. |
-|   `-T`, `--trail` | string | The Kosli trail name. |
-|       `--upload-results` |  | [defaulted] Whether to upload the provided Snyk results file as an attachment to Kosli or not. (default true) |
-|   `-u`, `--user-data` | string | [optional] The path to a JSON file containing additional data you would like to attach to the attestation. |
+| `--annotate` | stringToString | [optional] Annotate the attestation with data using key=value. |
+| `-t`, `--artifact-type` | string | The type of the artifact to calculate its SHA256 fingerprint. One of: [oci, docker, file, dir]. Only required if you want Kosli to calculate the fingerprint for you (i.e. when you don't specify '`--fingerprint`' on commands that allow it). |
+| `--attachments` | strings | [optional] The comma-separated list of paths of attachments for the reported attestation. Attachments can be files or directories. All attachments are compressed and uploaded to Kosli's evidence vault. |
+| `-g`, `--commit` | string | [conditional] The git commit for which the attestation is associated to. Becomes required when reporting an attestation for an artifact before reporting it to Kosli. (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
+| `--description` | string | [optional] attestation description |
+| `-D`, `--dry-run` |  | [optional] Run in dry-run mode. When enabled, no data is sent to Kosli and the CLI exits with 0 exit code regardless of any errors. |
+| `-x`, `--exclude` | strings | [optional] The comma separated list of directories and files to exclude from fingerprinting. Can take glob patterns. Only applicable for `--artifact-type` dir. |
+| `--external-fingerprint` | stringToString | [optional] A SHA256 fingerprint of an external attachment represented by `--external-url`. The format is label=fingerprint (labels cannot contain '.' or '='). This flag can be set multiple times. There must be an external url with a matching label for each external fingerprint. |
+| `--external-url` | stringToString | [optional] Add labeled reference URL for an external resource. The format is label=url (labels cannot contain '.' or '='). This flag can be set multiple times. If the resource is a file or dir, you can optionally add its fingerprint via `--external-fingerprint` |
+| `-F`, `--fingerprint` | string | [conditional] The SHA256 fingerprint of the artifact to attach the attestation to. Only required if the attestation is for an artifact and `--artifact-type` and artifact name/path are not used. |
+| `-f`, `--flow` | string | The Kosli flow name. |
+| `-h`, `--help` |  | help for snyk |
+| `-n`, `--name` | string | The name of the attestation as declared in the flow or trail yaml template. |
+| `-o`, `--origin-url` | string | [optional] The url pointing to where the attestation came from or is related. (defaulted to the CI url in some CIs: [docs](/integrations/ci_cd/#defaulted-kosli-command-flags-from-ci-variables) ). |
+| `--redact-commit-info` | strings | [optional] The list of commit info to be redacted before sending to Kosli. Allowed values are one or more of [author, message, branch]. |
+| `--registry-password` | string | [conditional] The container registry password or access token. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper. |
+| `--registry-provider` | string | [deprecated] The docker registry provider or url. Only required if you want to read docker image SHA256 digest from a remote docker registry. (DEPRECATED: no longer used) |
+| `--registry-username` | string | [conditional] The container registry username. Only required if you want to read container image SHA256 digest from a remote container registry and it is not already accessible via Docker/Podman auth files or a credential helper. |
+| `--repo-id` | string | [conditional] The stable, unique identifier for the repository in your VCS provider (e.g. a numeric ID). Do not use the repository name as it can change if the repo is renamed. All three of `--repo-id`, `--repo-url` and `--repository` must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
+| `--repo-provider` | string | [optional] The source code hosting provider. One of: github, gitlab, bitbucket, bitbucket_cloud, bitbucket_dc, azure-devops, azure_devops_services, azure_devops_server, git, subversion (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
+| `--repo-root` | string | [defaulted] The directory where the source git repository is available. Only used if `--commit` is used or defaulted in CI, see [docs](/integrations/ci_cd/#defaulted-kosli-command-flags-from-ci-variables) . (default ".") |
+| `--repo-url` | string | [conditional] The URL of the repository. Must be a valid URL. All three of `--repo-id`, `--repo-url` and `--repository` must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
+| `--repository` | string | [conditional] The name of the repository (e.g. owner/repo-name). All three of `--repo-id`, `--repo-url` and `--repository` must be set to record repository information (defaulted in some CIs: [docs](/integrations/ci_cd) ). |
+| `-R`, `--scan-results` | string | The path to Snyk scan SARIF results file from 'snyk test' and 'snyk container test'. By default, the Snyk results will be uploaded to Kosli's evidence vault. |
+| `-T`, `--trail` | string | The Kosli trail name. |
+| `--upload-results` |  | [defaulted] Whether to upload the provided Snyk results file as an attachment to Kosli or not. (default true) |
+| `-u`, `--user-data` | string | [optional] The path to a JSON file containing additional data you would like to attach to the attestation. |
 
 
 ## Examples Use Cases
@@ -122,3 +122,4 @@ kosli attest snyk
 ```
 </Accordion>
 </AccordionGroup>
+

--- a/internal/docgen/helpers.go
+++ b/internal/docgen/helpers.go
@@ -19,10 +19,22 @@ const FlagTableHeader = "| Flag | Type | Description |\n| :--- | :--- | :--- |\n
 // documenting", so they are omitted from the description.
 var flagDefaultZeroValues = []string{"", "0", "[]", "<nil>", "0s", "false"}
 
+// escapeTableCell escapes the pipes in a cell's content so markdown cannot read
+// them as column separators. GFM unescapes \| in a table cell before inline
+// parsing, so this survives even inside a code span — which matters because
+// MintlifyFormatter later turns placeholders like <hours|days> into `hours|days`.
+// It is deliberately applied here rather than in escapeMintlifyProse: that
+// escaper also runs over prose, where a table row's \| would render as a
+// literal backslash.
+func escapeTableCell(s string) string {
+	return strings.ReplaceAll(s, "|", "\\|")
+}
+
 // CommandsInTable renders a pflag.FlagSet as the body of the table headed by
 // FlagTableHeader: one row per flag, with the flag name(s), the value type
 // (empty for booleans, which pflag leaves unnamed), and the description.
-// Defaults and deprecation notices are appended to the description.
+// Defaults and deprecation notices are appended to the description. Every cell
+// is pipe-escaped, so each row has exactly as many separators as the header.
 func CommandsInTable(f *pflag.FlagSet) string {
 	var b strings.Builder
 
@@ -76,7 +88,8 @@ func CommandsInTable(f *pflag.FlagSet) string {
 			usage += fmt.Sprintf(" (DEPRECATED: %s)", flag.Deprecated)
 		}
 
-		fmt.Fprintf(&b, "| %s | %s | %s |\n", flagName, varname, usage)
+		fmt.Fprintf(&b, "| %s | %s | %s |\n",
+			escapeTableCell(flagName), escapeTableCell(varname), escapeTableCell(usage))
 	})
 
 	return b.String()

--- a/internal/docgen/helpers.go
+++ b/internal/docgen/helpers.go
@@ -1,7 +1,6 @@
 package docgen
 
 import (
-	"bytes"
 	"fmt"
 	"slices"
 	"strings"
@@ -11,11 +10,21 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// CommandsInTable renders a pflag.FlagSet as markdown table rows.
-func CommandsInTable(f *pflag.FlagSet) string {
-	buf := new(bytes.Buffer)
+// FlagTableHeader is the markdown header row (plus alignment row) for the table
+// whose body CommandsInTable renders. It lives next to the row builder so the
+// column count cannot drift between the header and the rows.
+const FlagTableHeader = "| Flag | Type | Description |\n| :--- | :--- | :--- |\n"
 
-	lines := make([]string, 0, 100)
+// flagDefaultZeroValues are DefValue strings that represent "no default worth
+// documenting", so they are omitted from the description.
+var flagDefaultZeroValues = []string{"", "0", "[]", "<nil>", "0s", "false"}
+
+// CommandsInTable renders a pflag.FlagSet as the body of the table headed by
+// FlagTableHeader: one row per flag, with the flag name(s), the value type
+// (empty for booleans, which pflag leaves unnamed), and the description.
+// Defaults and deprecation notices are appended to the description.
+func CommandsInTable(f *pflag.FlagSet) string {
+	var b strings.Builder
 
 	f.VisitAll(func(flag *pflag.Flag) {
 		// pflag.MarkDeprecated sets Hidden as a side effect, which would keep
@@ -27,13 +36,18 @@ func CommandsInTable(f *pflag.FlagSet) string {
 			return
 		}
 
-		flagName := ""
+		// No alignment padding: markdown strips leading whitespace inside a
+		// table cell, so it would only add noise to the generated MDX.
+		var flagName string
 		if flag.Shorthand != "" && flag.ShorthandDeprecated == "" {
-			flagName = fmt.Sprintf("  -%s, --%s", flag.Shorthand, flag.Name)
+			flagName = fmt.Sprintf("-%s, --%s", flag.Shorthand, flag.Name)
 		} else {
-			flagName = fmt.Sprintf("      --%s", flag.Name)
+			flagName = "--" + flag.Name
 		}
 
+		// varname is the value type ("string", "strings", ...) and is empty for
+		// booleans. NoOptDefVal describes the optional-value syntax, so it is
+		// appended here rather than to the description.
 		varname, usage := pflag.UnquoteUsage(flag)
 		if flag.NoOptDefVal != "" {
 			switch flag.Value.Type() {
@@ -51,9 +65,7 @@ func CommandsInTable(f *pflag.FlagSet) string {
 				varname += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
 			}
 		}
-		defaultZero := []string{"", "0", "[]", "<nil>", "0s", "false"}
-
-		if !slices.Contains(defaultZero, flag.DefValue) {
+		if !slices.Contains(flagDefaultZeroValues, flag.DefValue) {
 			if flag.Value.Type() == "string" {
 				usage += fmt.Sprintf(" (default %q)", flag.DefValue)
 			} else {
@@ -64,14 +76,10 @@ func CommandsInTable(f *pflag.FlagSet) string {
 			usage += fmt.Sprintf(" (DEPRECATED: %s)", flag.Deprecated)
 		}
 
-		lines = append(lines, fmt.Sprintf("| %s | %s | %s |", flagName, varname, usage))
+		fmt.Fprintf(&b, "| %s | %s | %s |\n", flagName, varname, usage)
 	})
 
-	for _, line := range lines {
-		fmt.Fprintln(buf, line)
-	}
-
-	return buf.String()
+	return b.String()
 }
 
 // RenderFlagsTables returns the rendered flag tables for a command's own flags

--- a/internal/docgen/helpers.go
+++ b/internal/docgen/helpers.go
@@ -53,10 +53,15 @@ func CommandsInTable(f *pflag.FlagSet) string {
 			flagName = "--" + flag.Name
 		}
 
-		// varname is the value type ("string", "strings", ...) and is empty for
-		// booleans. NoOptDefVal describes the optional-value syntax, so it is
-		// appended here rather than to the description.
+		// varname is the value type ("string", "strings", ...). pflag leaves it
+		// empty for booleans, which reads as missing data in a column headed
+		// "Type" and leaves the reader to infer that the flag takes no value, so
+		// fall back to the underlying type name. Done before the NoOptDefVal
+		// block so an optional value reads as bool[=x], matching string[="x"].
 		varname, usage := pflag.UnquoteUsage(flag)
+		if varname == "" {
+			varname = flag.Value.Type()
+		}
 		if flag.NoOptDefVal != "" {
 			switch flag.Value.Type() {
 			case "string":

--- a/internal/docgen/helpers.go
+++ b/internal/docgen/helpers.go
@@ -15,10 +15,6 @@ import (
 // column count cannot drift between the header and the rows.
 const FlagTableHeader = "| Flag | Type | Description |\n| :--- | :--- | :--- |\n"
 
-// flagDefaultZeroValues are DefValue strings that represent "no default worth
-// documenting", so they are omitted from the description.
-var flagDefaultZeroValues = []string{"", "0", "[]", "<nil>", "0s", "false"}
-
 // escapeTableCell escapes the pipes in a cell's content so markdown cannot read
 // them as column separators. GFM unescapes \| in a table cell before inline
 // parsing, so this survives even inside a code span — which matters because
@@ -77,7 +73,9 @@ func CommandsInTable(f *pflag.FlagSet) string {
 				varname += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
 			}
 		}
-		if !slices.Contains(flagDefaultZeroValues, flag.DefValue) {
+		defaultZero := []string{"", "0", "[]", "<nil>", "0s", "false"}
+
+		if !slices.Contains(defaultZero, flag.DefValue) {
 			if flag.Value.Type() == "string" {
 				usage += fmt.Sprintf(" (default %q)", flag.DefValue)
 			} else {

--- a/internal/docgen/helpers.go
+++ b/internal/docgen/helpers.go
@@ -17,7 +17,6 @@ func CommandsInTable(f *pflag.FlagSet) string {
 
 	lines := make([]string, 0, 100)
 
-	maxlen := 0
 	f.VisitAll(func(flag *pflag.Flag) {
 		// pflag.MarkDeprecated sets Hidden as a side effect, which would keep
 		// deprecated-but-working flags out of the reference docs along with
@@ -28,59 +27,48 @@ func CommandsInTable(f *pflag.FlagSet) string {
 			return
 		}
 
-		line := ""
+		flagName := ""
 		if flag.Shorthand != "" && flag.ShorthandDeprecated == "" {
-			line = fmt.Sprintf("  -%s, --%s", flag.Shorthand, flag.Name)
+			flagName = fmt.Sprintf("  -%s, --%s", flag.Shorthand, flag.Name)
 		} else {
-			line = fmt.Sprintf("      --%s", flag.Name)
+			flagName = fmt.Sprintf("      --%s", flag.Name)
 		}
 
 		varname, usage := pflag.UnquoteUsage(flag)
-		if varname != "" {
-			line += " " + varname
-		}
 		if flag.NoOptDefVal != "" {
 			switch flag.Value.Type() {
 			case "string":
-				line += fmt.Sprintf("[=\"%s\"]", flag.NoOptDefVal)
+				varname += fmt.Sprintf("[=\"%s\"]", flag.NoOptDefVal)
 			case "bool":
 				if flag.NoOptDefVal != "true" {
-					line += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
+					varname += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
 				}
 			case "count":
 				if flag.NoOptDefVal != "+1" {
-					line += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
+					varname += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
 				}
 			default:
-				line += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
+				varname += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
 			}
 		}
-
-		line += "\x00"
-		if len(line) > maxlen {
-			maxlen = len(line)
-		}
-
-		line += usage
 		defaultZero := []string{"", "0", "[]", "<nil>", "0s", "false"}
 
 		if !slices.Contains(defaultZero, flag.DefValue) {
 			if flag.Value.Type() == "string" {
-				line += fmt.Sprintf(" (default %q)", flag.DefValue)
+				usage += fmt.Sprintf(" (default %q)", flag.DefValue)
 			} else {
-				line += fmt.Sprintf(" (default %s)", flag.DefValue)
+				usage += fmt.Sprintf(" (default %s)", flag.DefValue)
 			}
 		}
 		if len(flag.Deprecated) != 0 {
-			line += fmt.Sprintf(" (DEPRECATED: %s)", flag.Deprecated)
+			usage += fmt.Sprintf(" (DEPRECATED: %s)", flag.Deprecated)
 		}
 
-		lines = append(lines, line)
+		lines = append(lines, fmt.Sprintf("| %s | %s | %s |", flagName, varname, usage))
 	})
 
 	for _, line := range lines {
-		sidx := strings.Index(line, "\x00")
-		fmt.Fprintln(buf, "| ", line[:sidx], " | ", line[sidx+1:], " |")
+		fmt.Fprintln(buf, line)
 	}
 
 	return buf.String()

--- a/internal/docgen/helpers_test.go
+++ b/internal/docgen/helpers_test.go
@@ -16,8 +16,26 @@ func TestCommandsInTable(t *testing.T) {
 	if !strings.Contains(got, "| -n, --name | string | The name |") {
 		t.Errorf("expected string type in its own column, got:\n%s", got)
 	}
-	if !strings.Contains(got, "| --verbose |  | Enable verbose |") {
-		t.Errorf("expected empty type column for bool flag, got:\n%s", got)
+	// pflag leaves the type empty for booleans; the table names it anyway so a
+	// blank cell never leaves the reader guessing what the flag takes.
+	if !strings.Contains(got, "| --verbose | bool | Enable verbose |") {
+		t.Errorf("expected bool type column for bool flag, got:\n%s", got)
+	}
+	if strings.Contains(got, "|  |") {
+		t.Errorf("expected no empty type cell, got:\n%s", got)
+	}
+}
+
+// TestCommandsInTableBoolOptionalValue checks the bool naming lands before the
+// optional-value suffix, so it reads like the string case (string[="x"]).
+func TestCommandsInTableBoolOptionalValue(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.Bool("verbose", false, "Enable verbose")
+	fs.Lookup("verbose").NoOptDefVal = "maybe"
+
+	got := CommandsInTable(fs)
+	if !strings.Contains(got, `| --verbose | bool[=maybe] | Enable verbose |`) {
+		t.Errorf("expected bool[=maybe] in the type column, got:\n%s", got)
 	}
 }
 

--- a/internal/docgen/helpers_test.go
+++ b/internal/docgen/helpers_test.go
@@ -13,17 +13,11 @@ func TestCommandsInTable(t *testing.T) {
 	fs.Bool("verbose", false, "Enable verbose")
 
 	got := CommandsInTable(fs)
-	if !strings.Contains(got, "--name") {
-		t.Error("expected --name flag")
+	if !strings.Contains(got, "|   -n, --name | string | The name |") {
+		t.Errorf("expected string type in its own column, got:\n%s", got)
 	}
-	if !strings.Contains(got, "-n") {
-		t.Error("expected shorthand -n")
-	}
-	if !strings.Contains(got, "--verbose") {
-		t.Error("expected --verbose flag")
-	}
-	if !strings.Contains(got, "|") {
-		t.Error("expected table formatting")
+	if !strings.Contains(got, "|       --verbose |  | Enable verbose |") {
+		t.Errorf("expected empty type column for bool flag, got:\n%s", got)
 	}
 }
 

--- a/internal/docgen/helpers_test.go
+++ b/internal/docgen/helpers_test.go
@@ -21,19 +21,56 @@ func TestCommandsInTable(t *testing.T) {
 	}
 }
 
+// unescapedPipes counts only the pipes markdown reads as column separators,
+// i.e. those not escaped as \|.
+func unescapedPipes(s string) int {
+	n := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '|' && (i == 0 || s[i-1] != '\\') {
+			n++
+		}
+	}
+	return n
+}
+
 // TestCommandsInTableColumnCount guards the contract between the rows rendered
-// here and the header in FlagTableHeader: both must have three columns.
+// here and the header in FlagTableHeader: both must have three columns. The
+// pipe-carrying flags matter most — an unescaped pipe in a description or a
+// default would silently split the row into extra columns.
 func TestCommandsInTableColumnCount(t *testing.T) {
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	fs.StringP("name", "n", "", "The name")
 	fs.Bool("verbose", false, "Enable verbose")
 	fs.Int("count", 0, "How many")
+	fs.String("age", "", "One of <hours|days|weeks|months>")
+	fs.String("sep", "a|b", "The separator")
 
-	wantCells := strings.Count(strings.SplitN(FlagTableHeader, "\n", 2)[0], "|")
-	for _, row := range strings.Split(strings.TrimSpace(CommandsInTable(fs)), "\n") {
-		if got := strings.Count(row, "|"); got != wantCells {
-			t.Errorf("row %q has %d pipes, header has %d", row, got, wantCells)
+	wantCells := unescapedPipes(strings.SplitN(FlagTableHeader, "\n", 2)[0])
+	rows := strings.Split(strings.TrimSpace(CommandsInTable(fs)), "\n")
+	if len(rows) != 5 {
+		t.Fatalf("expected 5 rows, got %d:\n%s", len(rows), strings.Join(rows, "\n"))
+	}
+	for _, row := range rows {
+		if got := unescapedPipes(row); got != wantCells {
+			t.Errorf("row %q has %d separators, header has %d", row, got, wantCells)
 		}
+	}
+}
+
+// TestCommandsInTableEscapesPipes covers where the pipes can come from: the
+// description itself and a default value. No Kosli flag help contains a pipe
+// today, so this is the guard that keeps it that way.
+func TestCommandsInTableEscapesPipes(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.String("age", "", "One of <hours|days|weeks|months>")
+	fs.String("sep", "a|b", "The separator")
+
+	got := CommandsInTable(fs)
+	if !strings.Contains(got, `| --age | string | One of <hours\|days\|weeks\|months> |`) {
+		t.Errorf("expected pipes in the description to be escaped, got:\n%s", got)
+	}
+	if !strings.Contains(got, `| --sep | string | The separator (default "a\|b") |`) {
+		t.Errorf("expected pipes in the default to be escaped, got:\n%s", got)
 	}
 }
 

--- a/internal/docgen/helpers_test.go
+++ b/internal/docgen/helpers_test.go
@@ -13,11 +13,42 @@ func TestCommandsInTable(t *testing.T) {
 	fs.Bool("verbose", false, "Enable verbose")
 
 	got := CommandsInTable(fs)
-	if !strings.Contains(got, "|   -n, --name | string | The name |") {
+	if !strings.Contains(got, "| -n, --name | string | The name |") {
 		t.Errorf("expected string type in its own column, got:\n%s", got)
 	}
-	if !strings.Contains(got, "|       --verbose |  | Enable verbose |") {
+	if !strings.Contains(got, "| --verbose |  | Enable verbose |") {
 		t.Errorf("expected empty type column for bool flag, got:\n%s", got)
+	}
+}
+
+// TestCommandsInTableColumnCount guards the contract between the rows rendered
+// here and the header in FlagTableHeader: both must have three columns.
+func TestCommandsInTableColumnCount(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.StringP("name", "n", "", "The name")
+	fs.Bool("verbose", false, "Enable verbose")
+	fs.Int("count", 0, "How many")
+
+	wantCells := strings.Count(strings.SplitN(FlagTableHeader, "\n", 2)[0], "|")
+	for _, row := range strings.Split(strings.TrimSpace(CommandsInTable(fs)), "\n") {
+		if got := strings.Count(row, "|"); got != wantCells {
+			t.Errorf("row %q has %d pipes, header has %d", row, got, wantCells)
+		}
+	}
+}
+
+// TestCommandsInTableOptionalValue documents where the optional-value syntax
+// from NoOptDefVal lands: in the type column, next to the type it modifies.
+// No Kosli flag uses a non-bool NoOptDefVal today, so this pins the behaviour
+// before something starts relying on it.
+func TestCommandsInTableOptionalValue(t *testing.T) {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.String("colour", "", "When to colourise")
+	fs.Lookup("colour").NoOptDefVal = "always"
+
+	got := CommandsInTable(fs)
+	if !strings.Contains(got, `| --colour | string[="always"] | When to colourise |`) {
+		t.Errorf("expected optional-value syntax in the type column, got:\n%s", got)
 	}
 }
 
@@ -47,11 +78,10 @@ func TestCommandsInTableDeprecatedFlags(t *testing.T) {
 	_ = fs.MarkDeprecated("old", "use --new instead")
 
 	got := CommandsInTable(fs)
-	if !strings.Contains(got, "--old") {
-		t.Errorf("expected deprecated flag to be documented, got:\n%s", got)
-	}
-	if !strings.Contains(got, "(DEPRECATED: use --new instead)") {
-		t.Errorf("expected deprecation message, got:\n%s", got)
+	// Asserted as a whole row: the deprecation notice belongs in the
+	// description, not in the type column.
+	if !strings.Contains(got, "| --old | string | The superseded flag (DEPRECATED: use --new instead) |") {
+		t.Errorf("expected deprecation message in the description, got:\n%s", got)
 	}
 	if !strings.Contains(got, "--new") {
 		t.Errorf("expected replacement flag, got:\n%s", got)
@@ -63,8 +93,10 @@ func TestCommandsInTableDefaultValues(t *testing.T) {
 	fs.String("dir", "/tmp", "The directory")
 
 	got := CommandsInTable(fs)
-	if !strings.Contains(got, `(default "/tmp")`) {
-		t.Errorf("expected default value, got:\n%s", got)
+	// Asserted as a whole row: the default belongs in the description, not in
+	// the type column.
+	if !strings.Contains(got, `| --dir | string | The directory (default "/tmp") |`) {
+		t.Errorf("expected default value in the description, got:\n%s", got)
 	}
 }
 

--- a/internal/docgen/mintlify.go
+++ b/internal/docgen/mintlify.go
@@ -84,15 +84,15 @@ func (MintlifyFormatter) FlagsSection(flags, inherited string) string {
 	var b strings.Builder
 	if flags != "" {
 		b.WriteString("## Flags\n")
-		b.WriteString("| Flag | Description |\n")
-		b.WriteString("| :--- | :--- |\n")
+		b.WriteString("| Flag | Type | Description |\n")
+		b.WriteString("| :--- | :--- | :--- |\n")
 		b.WriteString(flags)
 		b.WriteString("\n\n")
 	}
 	if inherited != "" {
 		b.WriteString("## Flags inherited from parent commands\n")
-		b.WriteString("| Flag | Description |\n")
-		b.WriteString("| :--- | :--- |\n")
+		b.WriteString("| Flag | Type | Description |\n")
+		b.WriteString("| :--- | :--- | :--- |\n")
 		b.WriteString(inherited)
 		b.WriteString("\n\n")
 	}

--- a/internal/docgen/mintlify.go
+++ b/internal/docgen/mintlify.go
@@ -170,10 +170,13 @@ func linkifyKosliDocsURLs(s string) string {
 // would interpret as JSX tags. Matches:
 //   - uppercase placeholders like <IMAGE-NAME>
 //   - patterns with pipes like <hours|days|weeks|months> or <COMMIT_SHA1|FINGERPRINT>
+//   - the same with the pipes escaped as \| , which is how they arrive from a
+//     flag table cell (see escapeTableCell); without this the placeholder would
+//     stop matching and a raw <...> would reach the MDX build
 //   - lowercase placeholders like <fingerprint>, <commit_sha>
 //
 // Standard HTML tags like <a>, <br/>, <pre>, <code> are filtered out in escapeProseFragment.
-var angleBracketPattern = regexp.MustCompile(`<([a-zA-Z][a-zA-Z0-9_|-]*)>`)
+var angleBracketPattern = regexp.MustCompile(`<([a-zA-Z][a-zA-Z0-9_|\\-]*)>`)
 
 var htmlTags = map[string]bool{
 	"a": true, "br": true, "pre": true, "code": true, "em": true,

--- a/internal/docgen/mintlify.go
+++ b/internal/docgen/mintlify.go
@@ -84,15 +84,13 @@ func (MintlifyFormatter) FlagsSection(flags, inherited string) string {
 	var b strings.Builder
 	if flags != "" {
 		b.WriteString("## Flags\n")
-		b.WriteString("| Flag | Type | Description |\n")
-		b.WriteString("| :--- | :--- | :--- |\n")
+		b.WriteString(FlagTableHeader)
 		b.WriteString(flags)
 		b.WriteString("\n\n")
 	}
 	if inherited != "" {
 		b.WriteString("## Flags inherited from parent commands\n")
-		b.WriteString("| Flag | Type | Description |\n")
-		b.WriteString("| :--- | :--- | :--- |\n")
+		b.WriteString(FlagTableHeader)
 		b.WriteString(inherited)
 		b.WriteString("\n\n")
 	}

--- a/internal/docgen/mintlify.go
+++ b/internal/docgen/mintlify.go
@@ -175,6 +175,12 @@ func linkifyKosliDocsURLs(s string) string {
 //     stop matching and a raw <...> would reach the MDX build
 //   - lowercase placeholders like <fingerprint>, <commit_sha>
 //
+// The character class is deliberately permissive rather than a precise grammar
+// for "token, optionally pipe-separated": anything this does not match is left
+// as a raw <...> for the MDX build to choke on, so a loose class fails safe
+// while a strict one fails the build. That is why the backslash is allowed
+// anywhere and not just as part of an escaped pipe.
+//
 // Standard HTML tags like <a>, <br/>, <pre>, <code> are filtered out in escapeProseFragment.
 var angleBracketPattern = regexp.MustCompile(`<([a-zA-Z][a-zA-Z0-9_|\\-]*)>`)
 

--- a/internal/docgen/mintlify_test.go
+++ b/internal/docgen/mintlify_test.go
@@ -265,6 +265,16 @@ func TestEscapeMintlifyProse(t *testing.T) {
 			want:  "Use `hours\\|days\\|weeks\\|months` for time",
 		},
 		{
+			// angleBracketPattern is deliberately permissive: a placeholder it
+			// fails to match is left as a raw <...> for the MDX build to choke
+			// on, so malformed ones must still be escaped. Tightening the
+			// pattern to describe only well-formed placeholders would trade a
+			// cosmetically loose regex for a broken docs build.
+			name:  "malformed placeholder still escaped",
+			input: "Use <hours||days> and <hours|> here",
+			want:  "Use `hours||days` and `hours|` here",
+		},
+		{
 			name:  "lowercase single-word placeholders converted",
 			input: "flowName@<fingerprint> or flowName:<commit_sha>",
 			want:  "flowName@`fingerprint` or flowName:`commit_sha`",

--- a/internal/docgen/mintlify_test.go
+++ b/internal/docgen/mintlify_test.go
@@ -257,6 +257,14 @@ func TestEscapeMintlifyProse(t *testing.T) {
 			want:  "Format: `COMMIT_SHA1|ARTIFACT_FINGERPRINT`",
 		},
 		{
+			// A flag table cell arrives pipe-escaped (see escapeTableCell), and
+			// the placeholder must still be recognised: leaving a raw <...> here
+			// would reach the MDX build as a JSX tag.
+			name:  "angle brackets with escaped pipes converted",
+			input: `Use <hours\|days\|weeks\|months> for time`,
+			want:  "Use `hours\\|days\\|weeks\\|months` for time",
+		},
+		{
 			name:  "lowercase single-word placeholders converted",
 			input: "flowName@<fingerprint> or flowName:<commit_sha>",
 			want:  "flowName@`fingerprint` or flowName:`commit_sha`",

--- a/internal/docgen/mintlify_test.go
+++ b/internal/docgen/mintlify_test.go
@@ -386,12 +386,15 @@ func TestBacktickFlags(t *testing.T) {
 
 func TestMintlifyFlagsSectionBackticksFlags(t *testing.T) {
 	f := MintlifyFormatter{}
-	flags := "| --api-token string | required (default $KOSLI_API_TOKEN) |\n"
+	flags := "| --api-token | string | required (default $KOSLI_API_TOKEN) |\n"
 	got := f.FlagsSection(flags, "")
+	if !strings.Contains(got, "| Flag | Type | Description |") {
+		t.Errorf("expected type column header, got:\n%s", got)
+	}
 	if !strings.Contains(got, "`--api-token`") {
 		t.Errorf("expected --api-token to be backticked, got:\n%s", got)
 	}
-	if strings.Contains(got, "| --api-token string |") {
+	if strings.Contains(got, "| --api-token |") {
 		t.Errorf("expected bare --api-token to be replaced, got:\n%s", got)
 	}
 }


### PR DESCRIPTION
Follow-up review fixes on top of the flag type column change:

- Regenerate the mintlify goldens instead of editing them by hand. They had
  lost the trailing blank line the generator emits; the test only passed
  because compareFileBytes normalises with strings.TrimSpace, so the goldens
  no longer reproduced generator output byte for byte.
- Drop cobra's alignment padding from the flag cell. Markdown strips leading
  whitespace inside a table cell, so the padding only added noise to the
  generated MDX; the maxlen pass that used to need it is gone.
- Build the rows with a single `strings.Builder`. The intermediate slice, the
  bytes.Buffer and the second loop existed only to support that alignment
  pass, and the bytes import goes with them.
- Move the table header into `FlagTableHeader` next to the row builder, so the
  column count cannot drift between the header and the rows, and cover that
  contract with a test.
- Assert whole rows in the default and deprecation tests. Both previously
  matched on a substring that would have passed had the text leaked into the
  type column, which is the behaviour the change is about.
- Pin where the NoOptDefVal syntax lands. No Kosli flag uses a non-bool
  NoOptDefVal today, so that path moved into the type column untested.

Verified by regenerating all 94 command docs and checking that every flag row
is a well formed three column row.

Obsoletes #1067 

Closes #450 

<!-- What does this PR change and why? Link any related issue. -->

### Checklist

- [x] **Docs** are autogenerated from CLI help — make sure the help text reflects your changes
- [x] **Helm chart** (`charts/k8s-reporter/`) updated, if needed. Note: these changes live in a **separate PR**
- [x] **Terraform provider** and related changes ([terraform-provider-kosli](https://github.com/kosli-dev/terraform-provider-kosli), [terraform-aws-evidence-reporter](https://github.com/kosli-dev/terraform-aws-evidence-reporter), [terraform-aws-kosli-reporter](https://github.com/kosli-dev/terraform-aws-kosli-reporter)) updated, if needed
