### PR TITLE
chore: update Makefile ensure_golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@
 export CGO_ENABLED=0
 export GO111MODULE=on
 
-LDFLAGS	:= -w -s
-BIN	:= kosli
+LDFLAGS    := -w -s
+BIN        := kosli
+GO_VERSION := $(shell awk '/^go /{print $$2}' go.mod)
 
 GIT_COMMIT = $(shell git rev-parse HEAD)
 GIT_SHA    = $(shell git rev-parse --short HEAD)
@@ -53,7 +54,16 @@ fmt: ## Reformat package sources
 	@go fmt ./...
 
 ensure_golangci-lint:
-	@HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade golangci-lint
+	@if command -v brew >/dev/null 2>&1; then \
+		HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade golangci-lint; \
+	elif command -v golangci-lint >/dev/null 2>&1; then \
+		echo "Homebrew not found; using the golangci-lint already on PATH."; \
+	else \
+		echo "golangci-lint not found, and Homebrew is unavailable to install it."; \
+		echo "Install a build that matches this repo's Go version with:"; \
+		echo "  GOTOOLCHAIN=go$(GO_VERSION) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest"; \
+		exit 1; \
+	fi
 
 lint: deps vet ensure_golangci-lint ## Run linting
 	@golangci-lint run --timeout=5m --color always  -v ./...

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,11 @@ fmt: ## Reformat package sources
 
 ensure_golangci-lint:
 	@if command -v brew >/dev/null 2>&1; then \
-		HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade golangci-lint; \
+		if brew ls --versions golangci-lint >/dev/null 2>&1; then \
+			HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade golangci-lint; \
+		else \
+			HOMEBREW_NO_AUTO_UPDATE=1 brew install golangci-lint; \
+		fi; \
 	elif command -v golangci-lint >/dev/null 2>&1; then \
 		echo "Homebrew not found; using the golangci-lint already on PATH."; \
 	else \


### PR DESCRIPTION
<!-- What does this PR change and why? Link any related issue. -->

Update Makefile ensure Go linting and make it more robust across platforms and environments. It might fail on non-brew ENVs.

### Checklist

- [x] **Docs** are autogenerated from CLI help — make sure the help text reflects your changes
- [x] **Helm chart** (`charts/k8s-reporter/`) updated, if needed. Note: these changes live in a **separate PR**
- [x] **Terraform provider** and related changes ([terraform-provider-kosli](https://github.com/kosli-dev/terraform-provider-kosli), [terraform-aws-evidence-reporter](https://github.com/kosli-dev/terraform-aws-evidence-reporter), [terraform-aws-kosli-reporter](https://github.com/kosli-dev/terraform-aws-kosli-reporter)) updated, if needed
