### PR TITLE
fix(config): treat empty KOSLI_* env vars as unset, not as set

### DIFF
--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -491,7 +491,10 @@ func initialize(cmd *cobra.Command, out, errOut io.Writer) error {
 	// so we check for the config file env var separately here
 	configFlag := cmd.Flags().Lookup("config-file")
 	if !configFlag.Changed {
-		if path, exists := os.LookupEnv("KOSLI_CONFIG_FILE"); exists {
+		// A variable set to the empty string reports as present, but it names no
+		// file. Overriding the default with it loads no config file at all,
+		// silently dropping org, api-token and every other configured default.
+		if path, exists := os.LookupEnv("KOSLI_CONFIG_FILE"); exists && path != "" {
 			global.ConfigFile = path
 		}
 	}
@@ -559,7 +562,13 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) {
 	// logger.SetErrOut(errOut)
 	// api token in config file is encrypted, so we have to decrypt it
 	// but if it is set via env variables, it is not encrypted
-	_, apiTokenSetInEnv := os.LookupEnv("KOSLI_API_TOKEN")
+	// A variable set to the empty string reports as present, but it carries no
+	// token, so it must not be taken as evidence that the token came from the
+	// environment. Treating it that way skips decryption and applies the config
+	// file value verbatim, sending ciphertext for anyone whose token was stored
+	// by `kosli config --api-token`.
+	apiTokenFromEnv, apiTokenPresentInEnv := os.LookupEnv("KOSLI_API_TOKEN")
+	apiTokenSetInEnv := apiTokenPresentInEnv && apiTokenFromEnv != ""
 
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
 		// Environment variables can't have dashes in them, so bind them to their equivalent

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -93,6 +93,47 @@ func (suite *RootCommandTestSuite) TestConfigProcessing() {
 	runTestCmd(suite.T(), tests)
 }
 
+// TestEmptyApiTokenEnvVarStillDecryptsConfigToken pins that KOSLI_API_TOKEN set
+// to an empty string does not suppress decryption of a config-file token.
+// bindFlags decides the token came from the environment with os.LookupEnv, where
+// a variable set to "" reports as present, so it skips decryption and applies
+// the config value verbatim - which sends ciphertext for anyone who stored their
+// token with `kosli config --api-token`.
+//
+// The fixture's token is not valid ciphertext, so decryption fails and falls
+// through to the plain-text warning whether or not an encryption key exists in
+// the credentials store. That makes the warning a stable marker for "the
+// decryption branch was entered".
+func (suite *RootCommandTestSuite) TestEmptyApiTokenEnvVarStillDecryptsConfigToken() {
+	suite.T().Setenv("KOSLI_API_TOKEN", "")
+
+	_, _, _, stderr, err := executeCommandC(
+		"version --config-file testdata/config/plain-text-token.yaml")
+
+	suite.Require().NoError(err)
+	suite.Contains(stderr, "as plain text",
+		"decryption must be attempted even when KOSLI_API_TOKEN is set but empty")
+}
+
+// TestEmptyConfigFileEnvVarFallsBackToDefault pins that KOSLI_CONFIG_FILE set
+// to an empty string does not discard the config file. initialize reads it with
+// os.LookupEnv, where a variable set to "" reports as present, so the config
+// path becomes "" and no config file is loaded at all - taking org, api-token
+// and every other configured default with it.
+//
+// Treating the empty value as unset is deliberate here. Making an empty KOSLI_*
+// variable an outright error is the wider change tracked in
+// kosli-dev/server#6070.
+func (suite *RootCommandTestSuite) TestEmptyConfigFileEnvVarFallsBackToDefault() {
+	suite.T().Setenv("KOSLI_CONFIG_FILE", "")
+
+	_, _, _, _, err := executeCommandC("version")
+
+	suite.Require().NoError(err)
+	suite.Equal(getConfigFileFlagDefault(), global.ConfigFile,
+		"an empty KOSLI_CONFIG_FILE must leave the default config path in place")
+}
+
 func (suite *RootCommandTestSuite) TestQuietFlagSuppressesWarnings() {
 	_, _, _, stderr, err := executeCommandC(
 		"version --config-file testdata/config/plain-text-token.yaml --quiet")


### PR DESCRIPTION
  An environment variable set to the empty string reports as present via
  os.LookupEnv, and two hand-rolled reads took that as evidence the user had
  supplied a value.

  KOSLI_CONFIG_FILE="" replaced the default config path with "", so no config
  file was loaded at all and org, api-token and every other configured default
  vanished silently.

  KOSLI_API_TOKEN="" was read as "the token came from the environment, so it is
  plaintext", which skipped decryption of the config-file token. Anyone who
  stored their token with `kosli config --api-token` holds ciphertext, so the
  ciphertext was sent as the API token and authentication failed with nothing
  pointing at the skipped decryption step.

  Both now require a non-empty value, matching how viper already treats every
  other bound KOSLI_* variable. Making an empty variable an error is left to the
  wider AllowEmptyEnv work, so they all change together rather than two of them
  diverging again.

<!-- What does this PR change and why? Link any related issue. -->

### Checklist

- [ ] **Docs** are autogenerated from CLI help — make sure the help text reflects your changes
- [ ] **Helm chart** (`charts/k8s-reporter/`) updated, if needed. Note: these changes live in a **separate PR**
- [ ] **Terraform provider** and related changes ([terraform-provider-kosli](https://github.com/kosli-dev/terraform-provider-kosli), [terraform-aws-evidence-reporter](https://github.com/kosli-dev/terraform-aws-evidence-reporter), [terraform-aws-kosli-reporter](https://github.com/kosli-dev/terraform-aws-kosli-reporter)) updated, if needed
