### PR TITLE
fix(config): report config values that cannot be applied to their flag

### DIFF
--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -535,7 +535,9 @@ func initialize(cmd *cobra.Command, out, errOut io.Writer) error {
 	v.AutomaticEnv()
 
 	// Bind the current command's flags to viper
-	bindFlags(cmd, v)
+	if err := bindFlags(cmd, v); err != nil {
+		return err
+	}
 
 	// re-assign debug after binding flags to config or env vars as it may have
 	// a different value now
@@ -556,10 +558,14 @@ func initialize(cmd *cobra.Command, out, errOut io.Writer) error {
 
 // Bind each cobra flag to its associated viper configuration
 // (coming either from environment variables or config file)
-func bindFlags(cmd *cobra.Command, v *viper.Viper) {
-	// for some reason, logger does not print errors at the point
-	// of calling this function, so we ensure to point errors to stderr
-	// logger.SetErrOut(errOut)
+func bindFlags(cmd *cobra.Command, v *viper.Viper) error {
+	// A value that cannot be applied to its flag is user input, so it is
+	// returned as an error rather than reported from inside the VisitAll
+	// closure. Reporting it here would reach nobody: the logger's error stream
+	// is not wired up at this point, and logger.Error is Fatalf, so the process
+	// would exit 1 with no output at all.
+	var bindErr error
+
 	// api token in config file is encrypted, so we have to decrypt it
 	// but if it is set via env variables, it is not encrypted
 	// A variable set to the empty string reports as present, but it carries no
@@ -606,10 +612,12 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) {
 			}
 
 			if err := cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val)); err != nil {
-				logger.Error("failed to set flag: %v", err)
+				bindErr = fmt.Errorf("failed to set flag '--%s' from [%s]: %v", f.Name, global.ConfigFile, err)
 			}
 		}
 	})
+
+	return bindErr
 }
 
 func isBeta(cmd *cobra.Command) bool {

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -533,6 +533,11 @@ func initialize(cmd *cobra.Command, out, errOut io.Writer) error {
 	// Bind viper config to environment variables
 	// Works great for simple config names, but needs help for names
 	// like --kube-config which we fix in the bindFlags function
+	//
+	// configValueSource derives the same variable names and the same precedence
+	// when it reports which source a value came from. Anything changed here -
+	// the prefix, a key replacer, AllowEmptyEnv - has to be changed there too,
+	// because nothing fails if the two drift apart.
 	v.AutomaticEnv()
 
 	// Bind the current command's flags to viper

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -556,6 +557,19 @@ func initialize(cmd *cobra.Command, out, errOut io.Writer) error {
 	return nil
 }
 
+// configValueSource names where a flag's value came from, so that a failure to
+// apply it points at the thing the user has to edit. viper reads a value from
+// the environment when the bound variable holds one, and from the config file
+// otherwise, so naming the config file unconditionally sends the user hunting
+// through a file that does not contain the offending value.
+func configValueSource(flagName string) string {
+	envVar := fmt.Sprintf("%s_%s", envPrefix, strings.ToUpper(strings.ReplaceAll(flagName, "-", "_")))
+	if value, exists := os.LookupEnv(envVar); exists && value != "" {
+		return envVar
+	}
+	return fmt.Sprintf("[%s]", global.ConfigFile)
+}
+
 // Bind each cobra flag to its associated viper configuration
 // (coming either from environment variables or config file)
 func bindFlags(cmd *cobra.Command, v *viper.Viper) error {
@@ -612,7 +626,7 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) error {
 			}
 
 			if err := cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val)); err != nil {
-				bindErr = fmt.Errorf("failed to set flag '--%s' from [%s]: %v", f.Name, global.ConfigFile, err)
+				bindErr = errors.Join(bindErr, fmt.Errorf("failed to set flag '--%s' from %s: %v", f.Name, configValueSource(f.Name), err))
 			}
 		}
 	})

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -562,6 +562,14 @@ func initialize(cmd *cobra.Command, out, errOut io.Writer) error {
 // the environment when the bound variable holds one, and from the config file
 // otherwise, so naming the config file unconditionally sends the user hunting
 // through a file that does not contain the offending value.
+//
+// viper exposes no query for which source a value came from - InConfig reports
+// only that a key exists in the file, not that the file won - so this mirrors
+// viper's precedence rather than asking it. Two things keep the mirror honest:
+// an environment variable is only consulted when it holds a value, matching
+// viper's default AllowEmptyEnv(false), and the caller only reaches here when
+// viper supplied the value at all. Enabling AllowEmptyEnv would let an empty
+// variable win over the config file and this must gain the same rule.
 func configValueSource(flagName string) string {
 	envVar := fmt.Sprintf("%s_%s", envPrefix, strings.ToUpper(strings.ReplaceAll(flagName, "-", "_")))
 	if value, exists := os.LookupEnv(envVar); exists && value != "" {

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -136,10 +136,9 @@ func (suite *RootCommandTestSuite) TestEmptyConfigFileEnvVarFallsBackToDefault()
 
 // TestConfigValueThatCannotBeAppliedIsReported pins that a config file value
 // the CLI cannot apply to its flag produces an error naming the flag, rather
-// than a bare exit 1 with no output at all.
-//
-// The failure has to be returned from bindFlags rather than logged there: the
-// logger's error stream is not wired up at that point, and logger.Error is
+// than a bare exit 1 with no output at all (the previous behavior, where the
+// failure was logged via logger.Error/Fatalf to an error stream that is not
+// wired up at that point, so the message reached nobody).
 // Fatalf, so logging it would end the process with nothing on stdout or stderr.
 func (suite *RootCommandTestSuite) TestConfigValueThatCannotBeAppliedIsReported() {
 	_, _, _, _, err := executeCommandC(

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -144,7 +144,10 @@ func (suite *RootCommandTestSuite) TestConfigValueThatCannotBeAppliedIsReported(
 		"update control ctl1 --config-file testdata/config/invalid-flag-value.yaml")
 
 	suite.Require().Error(err)
+	suite.Require().Error(err)
 	suite.ErrorContains(err, "link")
+	suite.ErrorContains(err, "invalid-flag-value.yaml",
+		"a value taken from the config file must name the config file")
 }
 
 // TestAllConfigValuesThatCannotBeAppliedAreReported pins that every flag whose

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -136,10 +136,11 @@ func (suite *RootCommandTestSuite) TestEmptyConfigFileEnvVarFallsBackToDefault()
 
 // TestConfigValueThatCannotBeAppliedIsReported pins that a config file value
 // the CLI cannot apply to its flag produces an error naming the flag, rather
-// than a bare exit 1 with no output at all. bindFlags reports the failure with
-// logger.Error, which is Fatalf, and its error stream is not wired up at that
-// point (root.go:557-559), so the message goes nowhere and the process dies
-// silently.
+// than a bare exit 1 with no output at all.
+//
+// The failure has to be returned from bindFlags rather than logged there: the
+// logger's error stream is not wired up at that point, and logger.Error is
+// Fatalf, so logging it would end the process with nothing on stdout or stderr.
 func (suite *RootCommandTestSuite) TestConfigValueThatCannotBeAppliedIsReported() {
 	_, _, _, _, err := executeCommandC(
 		"update control ctl1 --config-file testdata/config/invalid-flag-value.yaml")

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -134,6 +134,20 @@ func (suite *RootCommandTestSuite) TestEmptyConfigFileEnvVarFallsBackToDefault()
 		"an empty KOSLI_CONFIG_FILE must leave the default config path in place")
 }
 
+// TestConfigValueThatCannotBeAppliedIsReported pins that a config file value
+// the CLI cannot apply to its flag produces an error naming the flag, rather
+// than a bare exit 1 with no output at all. bindFlags reports the failure with
+// logger.Error, which is Fatalf, and its error stream is not wired up at that
+// point (root.go:557-559), so the message goes nowhere and the process dies
+// silently.
+func (suite *RootCommandTestSuite) TestConfigValueThatCannotBeAppliedIsReported() {
+	_, _, _, _, err := executeCommandC(
+		"update control ctl1 --config-file testdata/config/invalid-flag-value.yaml")
+
+	suite.Require().Error(err)
+	suite.ErrorContains(err, "link")
+}
+
 func (suite *RootCommandTestSuite) TestQuietFlagSuppressesWarnings() {
 	_, _, _, stderr, err := executeCommandC(
 		"version --config-file testdata/config/plain-text-token.yaml --quiet")

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -139,7 +139,6 @@ func (suite *RootCommandTestSuite) TestEmptyConfigFileEnvVarFallsBackToDefault()
 // than a bare exit 1 with no output at all (the previous behavior, where the
 // failure was logged via logger.Error/Fatalf to an error stream that is not
 // wired up at that point, so the message reached nobody).
-// Fatalf, so logging it would end the process with nothing on stdout or stderr.
 func (suite *RootCommandTestSuite) TestConfigValueThatCannotBeAppliedIsReported() {
 	_, _, _, _, err := executeCommandC(
 		"update control ctl1 --config-file testdata/config/invalid-flag-value.yaml")

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -148,6 +148,36 @@ func (suite *RootCommandTestSuite) TestConfigValueThatCannotBeAppliedIsReported(
 	suite.ErrorContains(err, "link")
 }
 
+// TestAllConfigValuesThatCannotBeAppliedAreReported pins that every flag whose
+// value cannot be applied is named, not just the last one. bindFlags applies
+// values inside a VisitAll closure, which cannot short-circuit, so the failures
+// have to be collected rather than overwritten - otherwise a user who fixes the
+// one reported key just meets the next one on the following run.
+func (suite *RootCommandTestSuite) TestAllConfigValuesThatCannotBeAppliedAreReported() {
+	_, _, _, _, err := executeCommandC(
+		"update control ctl1 --config-file testdata/config/two-invalid-flag-values.yaml")
+
+	suite.Require().Error(err)
+	suite.ErrorContains(err, "link")
+	suite.ErrorContains(err, "max-api-retries")
+}
+
+// TestUnappliableValueFromEnvNamesTheEnvVar pins that the failure message
+// points at the source the value actually came from. viper reads a flag's value
+// from the config file or from the environment, so a message that always names
+// the config file sends a user hunting through a file that does not contain the
+// offending value.
+func (suite *RootCommandTestSuite) TestUnappliableValueFromEnvNamesTheEnvVar() {
+	suite.T().Setenv("KOSLI_LINK", "notkeyvalue")
+
+	_, _, _, _, err := executeCommandC(
+		"update control ctl1 --org demo --api-token DRY_RUN")
+
+	suite.Require().Error(err)
+	suite.ErrorContains(err, "KOSLI_LINK",
+		"a value taken from the environment must name the environment variable")
+}
+
 func (suite *RootCommandTestSuite) TestQuietFlagSuppressesWarnings() {
 	_, _, _, stderr, err := executeCommandC(
 		"version --config-file testdata/config/plain-text-token.yaml --quiet")

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -144,7 +144,6 @@ func (suite *RootCommandTestSuite) TestConfigValueThatCannotBeAppliedIsReported(
 		"update control ctl1 --config-file testdata/config/invalid-flag-value.yaml")
 
 	suite.Require().Error(err)
-	suite.Require().Error(err)
 	suite.ErrorContains(err, "link")
 	suite.ErrorContains(err, "invalid-flag-value.yaml",
 		"a value taken from the config file must name the config file")

--- a/cmd/kosli/testdata/config/invalid-flag-value.yaml
+++ b/cmd/kosli/testdata/config/invalid-flag-value.yaml
@@ -1,0 +1,4 @@
+org: demo
+api-token: DRY_RUN
+link:
+  docs: https://example.com/docs

--- a/cmd/kosli/testdata/config/two-invalid-flag-values.yaml
+++ b/cmd/kosli/testdata/config/two-invalid-flag-values.yaml
@@ -1,0 +1,5 @@
+org: demo
+api-token: DRY_RUN
+link:
+  docs: https://example.com/docs
+max-api-retries: not-a-number


### PR DESCRIPTION
Closes the silent-exit half of #1086.

  A config file value that fails to apply to its flag was reported with `logger.Error` inside `bindFlags`. That is
  `Fatalf`, and the logger's error stream is not wired up there, so the process exited 1 with no output at all.

  `bindFlags` now returns the failure and `initialize` propagates it. The message names the flag, the config file, and
  the format pflag expected.
  
  The YAML list/map handling in #1086 is deliberately not addressed here.

  Stacked on #1087's branch; rebase onto main once that merges.