### PR TITLE
fix(flags): reject an empty value written after a boolean flag

### DIFF
--- a/cmd/kosli/main.go
+++ b/cmd/kosli/main.go
@@ -131,13 +131,17 @@ func findUnknownCommand(args []string) error {
 // --version path and reporting errors in the friendliest available form.
 func innerMain(cmd *cobra.Command, args []string) error {
 	if len(args) > 1 {
-		cmd.SetArgs(normalizeBoolFlagArgs(cmd, args[1:]))
+		normalized := normalizeBoolFlagArgs(cmd, args[1:])
+		cmd.SetArgs(normalized)
 		// cobra's TraverseChildren routing hands an unrecognized command token to
 		// the nearest group command with no error; that command then prints help
 		// and exits 0, so a typo'd command silently reports success (issue #1043).
 		// Catch it before executing so the process exits non-zero with a
 		// diagnostic instead.
 		if err := findUnknownCommand(args[1:]); err != nil {
+			return err
+		}
+		if err := rejectEmptyBoolFlagValues(cmd, normalized); err != nil {
 			return err
 		}
 	}

--- a/cmd/kosli/normalizeBoolFlagArgs.go
+++ b/cmd/kosli/normalizeBoolFlagArgs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -33,6 +34,12 @@ func rejectEmptyBoolFlagValues(root *cobra.Command, args []string) error {
 		}
 		if boolFlags[args[i]] && i+1 < len(args) && args[i+1] == "" {
 			return fmt.Errorf("flag '%s' was given an empty value", args[i])
+		}
+		// The "=" spelling of the same mistake. pflag refuses it too, but with a
+		// message naming strconv.ParseBool, which describes the parser rather
+		// than what the user got wrong.
+		if name, value, found := strings.Cut(args[i], "="); found && value == "" && boolFlags[name] {
+			return fmt.Errorf("flag '%s' was given an empty value", name)
 		}
 	}
 

--- a/cmd/kosli/normalizeBoolFlagArgs.go
+++ b/cmd/kosli/normalizeBoolFlagArgs.go
@@ -1,9 +1,43 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
+
+// rejectEmptyBoolFlagValues reports an empty token written after a boolean
+// flag, naming the flag.
+//
+// A boolean flag takes a value only in the "--flag=value" form, so the space
+// form survives only because normalizeBoolFlagArgs rewrites it, and that
+// rewrite needs a boolean literal. An empty token is not one, so pflag sets the
+// flag to true from its presence and leaves the "" as a positional argument.
+// Rejecting it is what keeps a flag that carries a compliance verdict from
+// being set to the opposite of what the user wrote.
+//
+// This runs on the already-normalized args so root.Find can resolve the
+// subcommand, which is the same reason normalizeBoolFlagArgs needs its second
+// pass. It stops at a "--" terminator, as that rewrite does.
+func rejectEmptyBoolFlagValues(root *cobra.Command, args []string) error {
+	cmd, _, err := root.Find(args)
+	if err != nil {
+		cmd = root
+	}
+	boolFlags := boolFlagTokens(cmd.Flags())
+
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--" {
+			break
+		}
+		if boolFlags[args[i]] && i+1 < len(args) && args[i+1] == "" {
+			return fmt.Errorf("flag '%s' was given an empty value", args[i])
+		}
+	}
+
+	return nil
+}
 
 // normalizeBoolFlagArgs rewrites boolean flags written in the space form
 // ("--compliant false") into the "=" form ("--compliant=false"), which is the

--- a/cmd/kosli/normalizeBoolFlagArgs_test.go
+++ b/cmd/kosli/normalizeBoolFlagArgs_test.go
@@ -194,3 +194,66 @@ func TestNormalizeBoolFlagArgsJoinsSpaceSeparatedBoolValue(t *testing.T) {
 		"--trail", "my-trail",
 	}, normalized)
 }
+
+// TestRejectEmptyBoolFlagValueNamesTheFlag pins that an empty token following a
+// boolean flag is an error naming that flag.
+//
+// A boolean flag takes a value only in the "--flag=value" form; it never
+// consumes the following token. "--compliant false" works in this CLI solely
+// because normalizeBoolFlagArgs rewrites it to "--compliant=false" before pflag
+// sees it, and that rewrite requires a boolean literal. An empty token is not
+// one, so it is left alone: pflag then sets the flag to true from its presence
+// and treats the "" as a positional argument. Without this rejection
+// `--compliant "$UNSET"` would record a compliant attestation, and
+// `--new-compliance-status "$UNSET"` would override an artifact to compliant
+// even though that flag is declared false.
+func TestRejectEmptyBoolFlagValueNamesTheFlag(t *testing.T) {
+	args := []string{
+		"attest", "generic", "Dockerfile",
+		"--artifact-type", "file",
+		"--compliant", "",
+		"--flow", "my-flow",
+	}
+	root, err := newRootCmd(io.Discard, io.Discard, args)
+	require.NoError(t, err)
+
+	err = rejectEmptyBoolFlagValues(root, args)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "--compliant")
+}
+
+// TestRejectEmptyBoolFlagValuesAcceptsEveryLegitimateForm draws the boundary of
+// the rejection: only an empty token is refused, and every way of writing a
+// boolean flag that pflag or normalizeBoolFlagArgs accepts still passes. It
+// covers the gate flags by name, since rejecting one of those wrongly would
+// break a pipeline rather than a payload.
+//
+// These cases pass as soon as the rejection exists, so they are here to pin the
+// boundary rather than to drive it: without them, tightening the rule later
+// could start refusing valid input with nothing to catch it.
+func TestRejectEmptyBoolFlagValuesAcceptsEveryLegitimateForm(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{name: "bare bool flag", args: []string{"list", "flows", "--debug"}},
+		{name: "equals form true", args: []string{"list", "flows", "--debug=true"}},
+		{name: "equals form false", args: []string{"list", "flows", "--debug=false"}},
+		{name: "space form", args: []string{"list", "flows", "--debug", "false"}},
+		{name: "bare dry-run", args: []string{"list", "flows", "--dry-run"}},
+		{name: "dry-run with a value", args: []string{"list", "flows", "--dry-run=false"}},
+		{name: "empty value for a non-bool flag", args: []string{"list", "flows", "--org", ""}},
+		{name: "empty token after the terminator", args: []string{"fingerprint", "--", "--debug", ""}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root, err := newRootCmd(io.Discard, io.Discard, tc.args)
+			require.NoError(t, err)
+
+			err = rejectEmptyBoolFlagValues(root, normalizeBoolFlagArgs(root, tc.args))
+
+			require.NoError(t, err)
+		})
+	}
+}

--- a/cmd/kosli/normalizeBoolFlagArgs_test.go
+++ b/cmd/kosli/normalizeBoolFlagArgs_test.go
@@ -223,6 +223,58 @@ func TestRejectEmptyBoolFlagValueNamesTheFlag(t *testing.T) {
 	require.ErrorContains(t, err, "--compliant")
 }
 
+// TestRejectEmptyBoolFlagValueInEqualsForm pins that "--flag=" is refused the
+// same way as "--flag \"\"". pflag refuses it either way, but with a message
+// naming strconv.ParseBool, which describes the parser rather than what the
+// user got wrong. Both spellings of an empty boolean value are the same
+// mistake, so both get the same message.
+func TestRejectEmptyBoolFlagValueInEqualsForm(t *testing.T) {
+	args := []string{
+		"attest", "generic", "Dockerfile",
+		"--artifact-type", "file",
+		"--compliant=",
+		"--flow", "my-flow",
+	}
+	root, err := newRootCmd(io.Discard, io.Discard, args)
+	require.NoError(t, err)
+
+	err = rejectEmptyBoolFlagValues(root, args)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "--compliant")
+	require.ErrorContains(t, err, "empty value")
+}
+
+// TestRejectEmptyBoolFlagValueCoversShorthands pins that a shorthand is refused
+// the same way as its long form. boolFlagTokens emits both, so this holds
+// already; the cases are here so that a change narrowing the token set to long
+// forms cannot pass unnoticed. -C is the shorthand for --compliant, which
+// carries a compliance verdict.
+func TestRejectEmptyBoolFlagValueCoversShorthands(t *testing.T) {
+	for _, shorthand := range []string{"-C", "-C="} {
+		t.Run(shorthand, func(t *testing.T) {
+			args := []string{
+				"attest", "generic", "Dockerfile",
+				"--artifact-type", "file",
+				shorthand,
+			}
+			if shorthand == "-C" {
+				args = append(args, "")
+			}
+			args = append(args, "--flow", "my-flow")
+
+			root, err := newRootCmd(io.Discard, io.Discard, args)
+			require.NoError(t, err)
+
+			err = rejectEmptyBoolFlagValues(root, args)
+
+			require.Error(t, err)
+			require.ErrorContains(t, err, "-C")
+			require.ErrorContains(t, err, "empty value")
+		})
+	}
+}
+
 // TestRejectEmptyBoolFlagValuesAcceptsEveryLegitimateForm draws the boundary of
 // the rejection: only an empty token is refused, and every way of writing a
 // boolean flag that pflag or normalizeBoolFlagArgs accepts still passes. It

--- a/cmd/kosli/normalizeBoolFlagArgs_test.go
+++ b/cmd/kosli/normalizeBoolFlagArgs_test.go
@@ -195,72 +195,40 @@ func TestNormalizeBoolFlagArgsJoinsSpaceSeparatedBoolValue(t *testing.T) {
 	}, normalized)
 }
 
-// TestRejectEmptyBoolFlagValueNamesTheFlag pins that an empty token following a
-// boolean flag is an error naming that flag.
+// TestRejectEmptyBoolFlagValuesRefusesEveryEmptyForm is the counterpart to
+// TestRejectEmptyBoolFlagValuesAcceptsEveryLegitimateForm: every spelling of an
+// empty value for a boolean flag, and the flag each message must name.
 //
 // A boolean flag takes a value only in the "--flag=value" form; it never
 // consumes the following token. "--compliant false" works in this CLI solely
 // because normalizeBoolFlagArgs rewrites it to "--compliant=false" before pflag
 // sees it, and that rewrite requires a boolean literal. An empty token is not
-// one, so it is left alone: pflag then sets the flag to true from its presence
-// and treats the "" as a positional argument. Without this rejection
-// `--compliant "$UNSET"` would record a compliant attestation, and
-// `--new-compliance-status "$UNSET"` would override an artifact to compliant
-// even though that flag is declared false.
-func TestRejectEmptyBoolFlagValueNamesTheFlag(t *testing.T) {
-	args := []string{
-		"attest", "generic", "Dockerfile",
-		"--artifact-type", "file",
-		"--compliant", "",
-		"--flow", "my-flow",
+// one, so pflag sets the flag to true from its presence and treats the "" as a
+// positional argument. Refusing that is what keeps `--compliant "$UNSET"` from
+// recording a compliant attestation, and `--new-compliance-status "$UNSET"`
+// from overriding an artifact to compliant even though that flag is declared
+// false.
+//
+// The "=" spellings pflag refuses on its own, but with a message naming
+// strconv.ParseBool, which describes the parser rather than what the user got
+// wrong. The shorthands are refused because boolFlagTokens emits them alongside
+// long forms; they are here so that narrowing that set cannot pass unnoticed,
+// -C being the shorthand for --compliant.
+func TestRejectEmptyBoolFlagValuesRefusesEveryEmptyForm(t *testing.T) {
+	cases := []struct {
+		name     string
+		tokens   []string
+		wantFlag string
+	}{
+		{name: "space form", tokens: []string{"--compliant", ""}, wantFlag: "--compliant"},
+		{name: "equals form", tokens: []string{"--compliant="}, wantFlag: "--compliant"},
+		{name: "shorthand space form", tokens: []string{"-C", ""}, wantFlag: "-C"},
+		{name: "shorthand equals form", tokens: []string{"-C="}, wantFlag: "-C"},
 	}
-	root, err := newRootCmd(io.Discard, io.Discard, args)
-	require.NoError(t, err)
-
-	err = rejectEmptyBoolFlagValues(root, args)
-
-	require.Error(t, err)
-	require.ErrorContains(t, err, "--compliant")
-}
-
-// TestRejectEmptyBoolFlagValueInEqualsForm pins that "--flag=" is refused the
-// same way as "--flag \"\"". pflag refuses it either way, but with a message
-// naming strconv.ParseBool, which describes the parser rather than what the
-// user got wrong. Both spellings of an empty boolean value are the same
-// mistake, so both get the same message.
-func TestRejectEmptyBoolFlagValueInEqualsForm(t *testing.T) {
-	args := []string{
-		"attest", "generic", "Dockerfile",
-		"--artifact-type", "file",
-		"--compliant=",
-		"--flow", "my-flow",
-	}
-	root, err := newRootCmd(io.Discard, io.Discard, args)
-	require.NoError(t, err)
-
-	err = rejectEmptyBoolFlagValues(root, args)
-
-	require.Error(t, err)
-	require.ErrorContains(t, err, "--compliant")
-	require.ErrorContains(t, err, "empty value")
-}
-
-// TestRejectEmptyBoolFlagValueCoversShorthands pins that a shorthand is refused
-// the same way as its long form. boolFlagTokens emits both, so this holds
-// already; the cases are here so that a change narrowing the token set to long
-// forms cannot pass unnoticed. -C is the shorthand for --compliant, which
-// carries a compliance verdict.
-func TestRejectEmptyBoolFlagValueCoversShorthands(t *testing.T) {
-	for _, shorthand := range []string{"-C", "-C="} {
-		t.Run(shorthand, func(t *testing.T) {
-			args := []string{
-				"attest", "generic", "Dockerfile",
-				"--artifact-type", "file",
-				shorthand,
-			}
-			if shorthand == "-C" {
-				args = append(args, "")
-			}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := []string{"attest", "generic", "Dockerfile", "--artifact-type", "file"}
+			args = append(args, tc.tokens...)
 			args = append(args, "--flow", "my-flow")
 
 			root, err := newRootCmd(io.Discard, io.Discard, args)
@@ -269,7 +237,7 @@ func TestRejectEmptyBoolFlagValueCoversShorthands(t *testing.T) {
 			err = rejectEmptyBoolFlagValues(root, args)
 
 			require.Error(t, err)
-			require.ErrorContains(t, err, "-C")
+			require.ErrorContains(t, err, tc.wantFlag)
 			require.ErrorContains(t, err, "empty value")
 		})
 	}

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -170,6 +170,7 @@ func (suite *RootCommandTestSuite) TestInnerMainRejectsEmptyValueAfterBoolFlag()
 
 	suite.Require().Error(err)
 	suite.ErrorContains(err, "--new-compliance-status")
+}
 // TestConfigValueThatCannotBeAppliedIsReported pins that a config file value
 // the CLI cannot apply to its flag produces an error naming the flag, rather
 // than a bare exit 1 with no output at all (the previous behavior, where the

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -171,6 +171,7 @@ func (suite *RootCommandTestSuite) TestInnerMainRejectsEmptyValueAfterBoolFlag()
 	suite.Require().Error(err)
 	suite.ErrorContains(err, "--new-compliance-status")
 }
+
 // TestConfigValueThatCannotBeAppliedIsReported pins that a config file value
 // the CLI cannot apply to its flag produces an error naming the flag, rather
 // than a bare exit 1 with no output at all (the previous behavior, where the

--- a/cmd/kosli/root_test.go
+++ b/cmd/kosli/root_test.go
@@ -134,6 +134,44 @@ func (suite *RootCommandTestSuite) TestEmptyConfigFileEnvVarFallsBackToDefault()
 		"an empty KOSLI_CONFIG_FILE must leave the default config path in place")
 }
 
+// TestEmptyValueAfterBoolFlagIsRejected pins that the rejection reaches a real
+// command run, not only the token scanner that implements it. attest override
+// is used because --new-compliance-status is declared false, so an empty value
+// is the case where the recorded verdict is the opposite of the one asked for.
+func (suite *RootCommandTestSuite) TestEmptyValueAfterBoolFlagIsRejected() {
+	_, _, _, _, err := executeCommandC(
+		`attest override --new-compliance-status "" ` +
+			`--fingerprint 0000000000000000000000000000000000000000000000000000000000000001 ` +
+			`--name foo --reason audit --original-attestation-type generic ` +
+			`--flow f --trail t --org demo --api-token DRY_RUN --dry-run`)
+
+	suite.Require().Error(err)
+	suite.ErrorContains(err, "--new-compliance-status")
+}
+
+// TestInnerMainRejectsEmptyValueAfterBoolFlag drives the empty boolean value
+// through innerMain, which is the path a real CLI user takes and which the
+// golden test harness bypasses. Without the check there, the rejection would
+// hold only in tests.
+func (suite *RootCommandTestSuite) TestInnerMainRejectsEmptyValueAfterBoolFlag() {
+	args := []string{
+		"attest", "override",
+		"--new-compliance-status", "",
+		"--fingerprint", "0000000000000000000000000000000000000000000000000000000000000001",
+		"--name", "foo", "--reason", "audit",
+		"--original-attestation-type", "generic",
+		"--flow", "f", "--trail", "t",
+		"--org", "demo", "--api-token", "DRY_RUN",
+	}
+	cmd, err := newRootCmd(io.Discard, io.Discard, args)
+	suite.Require().NoError(err)
+
+	err = innerMain(cmd, append([]string{"kosli"}, args...))
+
+	suite.Require().Error(err)
+	suite.ErrorContains(err, "--new-compliance-status")
+}
+
 func (suite *RootCommandTestSuite) TestQuietFlagSuppressesWarnings() {
 	_, _, _, stderr, err := executeCommandC(
 		"version --config-file testdata/config/plain-text-token.yaml --quiet")

--- a/cmd/kosli/testHelpers.go
+++ b/cmd/kosli/testHelpers.go
@@ -78,7 +78,11 @@ func executeCommandStdinC(cmd string, stdin string) (*cobra.Command, string, str
 	root.SetOut(outWriter)
 	root.SetErr(errWriter)
 	root.SetIn(strings.NewReader(stdin))
-	root.SetArgs(normalizeBoolFlagArgs(root, args))
+	normalized := normalizeBoolFlagArgs(root, args)
+	if err := rejectEmptyBoolFlagValues(root, normalized); err != nil {
+		return nil, "", "", "", err
+	}
+	root.SetArgs(normalized)
 
 	c, err := root.ExecuteC()
 


### PR DESCRIPTION
  A boolean flag takes a value only in the "--flag=value" form. The space form
  survives only because normalizeBoolFlagArgs rewrites it, and that rewrite needs
  a boolean literal. An empty token is not one, so pflag set the flag to true from
  its presence alone and left the "" as a positional argument.

  The value the user wrote therefore vanished, and for the flags carrying a
  compliance verdict the recorded result was the opposite of the one asked for.
  `kosli attest override --new-compliance-status "$STATUS"` with STATUS unset
  overrode an artifact to compliant and exited 0, on the one command whose purpose
  is changing a compliance verdict. `--compliant`, `--dry-run` and `--no-assert`
  have the same shape, the last two silently disabling gates.

  An empty token after a boolean flag is now an error naming the flag. It is
  checked in innerMain and in the golden test harness, which already mirror each
  other for the rewrite itself. Every legitimate form is untouched: bare, "=true",
  "=false", the space form, and anything after a "--" terminator.

  This closes the quoted form only. `--compliant $UNSET` unquoted leaves no token
  at all, so nothing can distinguish it from a deliberate bare flag.

<!-- What does this PR change and why? Link any related issue. -->

### Checklist

- [ ] **Docs** are autogenerated from CLI help — make sure the help text reflects your changes
- [ ] **Helm chart** (`charts/k8s-reporter/`) updated, if needed. Note: these changes live in a **separate PR**
- [ ] **Terraform provider** and related changes ([terraform-provider-kosli](https://github.com/kosli-dev/terraform-provider-kosli), [terraform-aws-evidence-reporter](https://github.com/kosli-dev/terraform-aws-evidence-reporter), [terraform-aws-kosli-reporter](https://github.com/kosli-dev/terraform-aws-kosli-reporter)) updated, if needed
