### PR TITLE
fix(deps): move to Go 1.26.6 for six stdlib advisories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kosli-dev/cli
 
-go 1.26.5
+go 1.26.6
 
 require (
 	cloud.google.com/go/run v1.22.0


### PR DESCRIPTION
  Snyk's dependency test fails on six high and medium stdlib advisories, all
  of them fixed on this line in 1.26.6: crypto/tls (CVE-2026-56862), net/http
  (CVE-2026-56853), net (CVE-2026-46600), encoding/asn1 (CVE-2026-33818),
  encoding/xml (CVE-2026-56859) and html/template (CVE-2026-56858). std/net is
  the one that decides the target: it has no fix on the 1.25 line.

  Only go.mod names a patch level. .go-version and the Dockerfile track the
  1.26 line, every workflow reads .go-version, and the Dockerfile already sets
  GOTOOLCHAIN=auto, so the directive is what pulls the newer toolchain in.

<!-- What does this PR change and why? Link any related issue. -->

### Checklist

- [ ] **Docs** are autogenerated from CLI help — make sure the help text reflects your changes
- [ ] **Helm chart** (`charts/k8s-reporter/`) updated, if needed. Note: these changes live in a **separate PR**
- [ ] **Terraform provider** and related changes ([terraform-provider-kosli](https://github.com/kosli-dev/terraform-provider-kosli), [terraform-aws-evidence-reporter](https://github.com/kosli-dev/terraform-aws-evidence-reporter), [terraform-aws-kosli-reporter](https://github.com/kosli-dev/terraform-aws-kosli-reporter)) updated, if needed
