### PR TITLE
fix(docker): add writable /tmp to the scratch-based image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,12 @@ COPY . .
 
 RUN make build
 
+RUN mkdir -p /image-tmp
+
 ### Final Image ###
 FROM scratch
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/src/kosli/kosli /bin/kosli
+COPY --from=builder --chmod=1777 /image-tmp /tmp
 ENTRYPOINT ["/bin/kosli"]


### PR DESCRIPTION
Kosli's temp-dir usage (directory fingerprinting, evidence tarballing) relies on os.MkdirTemp, which fails when /tmp doesn't exist at all, as is the case in the scratch base image. Stage an empty dir in the builder stage and copy it into the final image as a world-writable /tmp.

fixes kosli-dev/server#6508

<!-- What does this PR change and why? Link any related issue. -->

### Checklist

- [ ] **Docs** are autogenerated from CLI help — make sure the help text reflects your changes
- [ ] **Helm chart** (`charts/k8s-reporter/`) updated, if needed. Note: these changes live in a **separate PR**
- [ ] **Terraform provider** and related changes ([terraform-provider-kosli](https://github.com/kosli-dev/terraform-provider-kosli), [terraform-aws-evidence-reporter](https://github.com/kosli-dev/terraform-aws-evidence-reporter), [terraform-aws-kosli-reporter](https://github.com/kosli-dev/terraform-aws-kosli-reporter)) updated, if needed
