### PR TITLE
test(validation): expect schema-pattern wording for illegal names

### DIFF
--- a/cmd/kosli/createControl_test.go
+++ b/cmd/kosli/createControl_test.go
@@ -56,10 +56,10 @@ func (suite *CreateControlTestSuite) TestCreateControlCmd() {
 			goldenRegex: "^Error: A control with identifier 'my-control' already exists in organization",
 		},
 		{
-			wantError:   true,
-			name:        "fails when the identifier contains invalid characters",
-			cmd:         "create control 'bad identifier' --name 'My Control'" + suite.defaultKosliArguments,
-			goldenRegex: "^Error: Input payload validation failed:.*Control identifier 'bad identifier' contains invalid characters",
+			wantError: true,
+			name:      "fails when the identifier contains invalid characters",
+			cmd:       "create control 'bad identifier' --name 'My Control'" + suite.defaultKosliArguments,
+			golden:    "Error: Input payload validation failed: map[identifier:String should match pattern '^[a-zA-Z0-9\\-._~]+$' [input: bad identifier]]\n",
 		},
 	}
 

--- a/cmd/kosli/renameEnvironment_test.go
+++ b/cmd/kosli/renameEnvironment_test.go
@@ -39,7 +39,7 @@ func (suite *RenameEnvironmentCommandTestSuite) TestRenameEnvironmentCmd() {
 			wantError: true,
 			name:      "renaming environment fails if the new name is illegal",
 			cmd:       fmt.Sprintf(`rename environment %s 'new illegal name' %s`, suite.envName, suite.defaultKosliArguments),
-			golden:    "Error: 'new illegal name' is an invalid name for environments. Valid names should start with an alphanumeric and only contain alphanumeric characters, '.', '-' and '_'.\n",
+			golden:    "Error: Input payload validation failed: map[new_name:String should match pattern '^[a-zA-Z0-9][a-zA-Z0-9\\.\\-_]*$' [input: new illegal name]]\n",
 		},
 		{
 			wantError: true,

--- a/cmd/kosli/renameFlow_test.go
+++ b/cmd/kosli/renameFlow_test.go
@@ -39,7 +39,7 @@ func (suite *RenameFlowCommandTestSuite) TestRenameFlowCmd() {
 			wantError: true,
 			name:      "renaming flow fails if the new name is illegal",
 			cmd:       fmt.Sprintf(`rename flow %s 'new illegal name' %s`, suite.flowName, suite.defaultKosliArguments),
-			golden:    "Error: 'new illegal name' is an invalid name for flows. Valid names should start with an alphanumeric and only contain alphanumeric characters, '.', '-', '_' and '~'.\n",
+			golden:    "Error: Input payload validation failed: map[new_name:String should match pattern '^[a-zA-Z0-9][a-zA-Z0-9\\.\\-_~]*$' [input: new illegal name]]\n",
 		},
 		{
 			wantError: true,


### PR DESCRIPTION
Identifier and rename validation moved onto the OpenAPI schema server-side, which reports the pattern that was violated rather than a sentence about it. Three test cases pinned the old sentence and fail against a server that has moved:

- `create control` with an invalid identifier
- `rename environment` with an illegal new name
- `rename flow` with an illegal new name

They now pin the new wording. Nothing else changes — no production code is touched.

**Merge order:** this needs the server change deployed to `staging-aws` first — that is the snapshot `hack/get-server-image.sh` pins the test image from. Until then these three cases fail against the older image.

Running locally: `make test_setup` only re-resolves the image when `/tmp/server-image.txt` is absent, so if you have a cached ref from before the server change, run `make clear_local_image_ref` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
