### PR TITLE
fix(jira): stop reporting Jira failures as missing issues

### DIFF
--- a/cmd/kosli/attestJira.go
+++ b/cmd/kosli/attestJira.go
@@ -67,14 +67,19 @@ If you want to restrict the Jira issue matching to a specific project, use the
 If the ^--ignore-branch-match^ is set, the branch name is not parsed for a match.
 
 The found issue references will be checked against Jira to confirm their existence.
-The attestation is reported in all cases, and its compliance status depends on referencing
-existing Jira issues.
+The attestation is reported whenever Jira answers, and its compliance status depends on
+referencing existing Jira issues.
 If your Jira credentials are wrong, or ^--jira-base-url^ does not point at your Jira, the
 issues are reported as non existing. This is because Jira returns the same 404 whether an
 issue does not exist or your credentials may not see it.
 When that happens a warning naming the likely cause is written to stderr, so a run whose
 issues all came back missing says whether the credentials were the reason. The warning does
 not change the exit code; ^--assert^ still fails on the issues that were not found.
+
+If Jira cannot be reached at all, or answers the issue lookup with an error rather than a
+404, the command fails instead of reporting those issues as non existing: a lookup that was
+never answered is not evidence that an issue is missing. This means ^attest jira^ can exit
+non-zero on a Jira outage even without ^--assert^.
 
 The ^--jira-issue-fields^ can be used to include fields from the jira issue. By default no fields
 are included. ^*all^ will give all fields. Using ^--jira-issue-fields "*all" --dry-run^ will give you

--- a/cmd/kosli/attestJira.go
+++ b/cmd/kosli/attestJira.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -66,11 +67,16 @@ If you want to restrict the Jira issue matching to a specific project, use the
 
 If the ^--ignore-branch-match^ is set, the branch name is not parsed for a match.
 
-The found issue references will be checked against Jira to confirm their existence.
-The attestation is reported in all cases, and its compliance status depends on referencing
-existing Jira issues.  
-If you have wrong Jira credentials or wrong Jira-base-url it will be reported as non existing Jira issue.
-This is because Jira returns same 404 error code in all cases.
+The found issue references will be checked against Jira to confirm their existence, and the
+attestation's compliance status depends on referencing existing Jira issues.
+
+Jira answers 404 both for an issue that does not exist and for one your credentials may not
+see, so when a reference is not found your credentials are verified before that answer is
+believed. If Jira rejects them, the command fails saying so instead of reporting a
+non-existing issue. A wrong ^--jira-base-url^ produces the same 404, so the error names both
+as candidates. If the verification cannot be completed at all (Jira unreachable, a server
+error), a warning is logged and the attestation is still reported with the issue marked as
+non-existing.
 
 The ^--jira-issue-fields^ can be used to include fields from the jira issue. By default no fields
 are included. ^*all^ will give all fields. Using ^--jira-issue-fields "*all" --dry-run^ will give you
@@ -329,9 +335,18 @@ func (o *attestJiraOptions) run(args []string) error {
 	// are before believing it, and report a stale credential as one. Only asked when
 	// something was not found: where every reference resolved, the credential has
 	// already proved itself, and the extra call would be pure overhead.
+	//
+	// Only a rejection stops the attestation. If the check itself does not complete -
+	// Jira unreachable, a 5xx, a proxy in the way - we have learned nothing about the
+	// credential, and failing on that would put back the bug this replaced: a network
+	// blip failing a pipeline. Warn and report the 404 we did observe.
 	if issueFoundCount != len(issueIDs) {
 		if err := jc.VerifyCredentials(); err != nil {
-			return err
+			var notVerified *jira.CredentialNotVerifiedError
+			if errors.As(err, &notVerified) {
+				return err
+			}
+			logger.Warn("could not verify the Jira credential, so the issues Jira did not return are reported as not found on the strength of its 404 alone: %s", err)
 		}
 	}
 

--- a/cmd/kosli/attestJira.go
+++ b/cmd/kosli/attestJira.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -67,18 +66,15 @@ If you want to restrict the Jira issue matching to a specific project, use the
 
 If the ^--ignore-branch-match^ is set, the branch name is not parsed for a match.
 
-The found issue references will be checked against Jira to confirm their existence, and the
-attestation's compliance status depends on referencing existing Jira issues.
-
-Jira answers 404 both for an issue that does not exist and for one your credentials may not
-see, so when a reference is not found your credentials are verified before that answer is
-believed. If Jira refuses them, the command fails saying so instead of reporting a
-non-existing issue.
-Any other outcome of that check leaves the question open rather than answered, so a warning
-is logged and the attestation is still reported with the issue marked as non-existing. That
-covers Jira being unreachable or erroring, and a ^--jira-base-url^ that does not point at a
-Jira - the warning names it as a candidate, since a wrong base URL 404s exactly like a
-credential that may not see the issue.
+The found issue references will be checked against Jira to confirm their existence.
+The attestation is reported in all cases, and its compliance status depends on referencing
+existing Jira issues.
+If your Jira credentials are wrong, or ^--jira-base-url^ does not point at your Jira, the
+issues are reported as non existing. This is because Jira returns the same 404 whether an
+issue does not exist or your credentials may not see it.
+When that happens a warning naming the likely cause is written to stderr, so a run whose
+issues all came back missing says whether the credentials were the reason. The warning does
+not change the exit code; ^--assert^ still fails on the issues that were not found.
 
 The ^--jira-issue-fields^ can be used to include fields from the jira issue. By default no fields
 are included. ^*all^ will give all fields. Using ^--jira-issue-fields "*all" --dry-run^ will give you
@@ -331,25 +327,20 @@ func (o *attestJiraOptions) run(args []string) error {
 		issueLog += fmt.Sprintf("\n\t%s: %s", result.IssueID, issueExistLog)
 	}
 
-	// Jira answers a credential it will not accept with 404 on the issue endpoint - it
-	// does not confirm that an issue exists to a caller who may not see it - so a
-	// not-found issue may be an expired token rather than a missing issue. Ask who we
-	// are before believing it, and report a stale credential as one. Only asked when
-	// something was not found: where every reference resolved, the credential has
-	// already proved itself, and the extra call would be pure overhead.
+	// Jira answers a credential it will not accept with 404 on the issue endpoint - it does
+	// not confirm that an issue exists to a caller who may not see it - so a not-found
+	// issue may be an expired token rather than a missing issue. Ask who we are, so that
+	// the output can say which. Only asked when something was not found: where every
+	// reference resolved, the credential has already proved itself and the extra call would
+	// be pure overhead.
 	//
-	// Only a rejection stops the attestation. If the check does not conclude - Jira
-	// unreachable, a 5xx, a 404 from something that may not even be a Jira - we have
-	// learned nothing about the credential, and failing on that would put back the bug
-	// this replaced: a blip on a third-party call failing a pipeline. Warn and report the
-	// 404 we did observe.
+	// This only ever adds a warning. The attestation is still reported and the exit code is
+	// unchanged, so a stale token cannot fail a pipeline that would have passed, and
+	// neither can a blip on this call. --assert still fails on the issues that were not
+	// found, as it did before - with the warning now explaining why they were not.
 	if issueFoundCount != len(issueIDs) {
 		if err := jc.VerifyCredentials(); err != nil {
-			var rejected *jira.CredentialRejectedError
-			if errors.As(err, &rejected) {
-				return err
-			}
-			logger.Warn("could not verify the Jira credential (%s); issues Jira did not return are reported as not found", err)
+			logger.Warn("%s. Issues Jira did not return are reported as not found", err)
 		}
 	}
 

--- a/cmd/kosli/attestJira.go
+++ b/cmd/kosli/attestJira.go
@@ -72,11 +72,13 @@ attestation's compliance status depends on referencing existing Jira issues.
 
 Jira answers 404 both for an issue that does not exist and for one your credentials may not
 see, so when a reference is not found your credentials are verified before that answer is
-believed. If Jira rejects them, the command fails saying so instead of reporting a
-non-existing issue. A wrong ^--jira-base-url^ produces the same 404, so the error names both
-as candidates. If the verification cannot be completed at all (Jira unreachable, a server
-error), a warning is logged and the attestation is still reported with the issue marked as
-non-existing.
+believed. If Jira refuses them, the command fails saying so instead of reporting a
+non-existing issue.
+Any other outcome of that check leaves the question open rather than answered, so a warning
+is logged and the attestation is still reported with the issue marked as non-existing. That
+covers Jira being unreachable or erroring, and a ^--jira-base-url^ that does not point at a
+Jira - the warning names it as a candidate, since a wrong base URL 404s exactly like a
+credential that may not see the issue.
 
 The ^--jira-issue-fields^ can be used to include fields from the jira issue. By default no fields
 are included. ^*all^ will give all fields. Using ^--jira-issue-fields "*all" --dry-run^ will give you
@@ -336,17 +338,18 @@ func (o *attestJiraOptions) run(args []string) error {
 	// something was not found: where every reference resolved, the credential has
 	// already proved itself, and the extra call would be pure overhead.
 	//
-	// Only a rejection stops the attestation. If the check itself does not complete -
-	// Jira unreachable, a 5xx, a proxy in the way - we have learned nothing about the
-	// credential, and failing on that would put back the bug this replaced: a network
-	// blip failing a pipeline. Warn and report the 404 we did observe.
+	// Only a rejection stops the attestation. If the check does not conclude - Jira
+	// unreachable, a 5xx, a 404 from something that may not even be a Jira - we have
+	// learned nothing about the credential, and failing on that would put back the bug
+	// this replaced: a blip on a third-party call failing a pipeline. Warn and report the
+	// 404 we did observe.
 	if issueFoundCount != len(issueIDs) {
 		if err := jc.VerifyCredentials(); err != nil {
-			var notVerified *jira.CredentialNotVerifiedError
-			if errors.As(err, &notVerified) {
+			var rejected *jira.CredentialRejectedError
+			if errors.As(err, &rejected) {
 				return err
 			}
-			logger.Warn("could not verify the Jira credential, so the issues Jira did not return are reported as not found on the strength of its 404 alone: %s", err)
+			logger.Warn("could not verify the Jira credential (%s); issues Jira did not return are reported as not found", err)
 		}
 	}
 

--- a/cmd/kosli/attestJira.go
+++ b/cmd/kosli/attestJira.go
@@ -323,6 +323,18 @@ func (o *attestJiraOptions) run(args []string) error {
 		issueLog += fmt.Sprintf("\n\t%s: %s", result.IssueID, issueExistLog)
 	}
 
+	// Jira answers a credential it will not accept with 404 on the issue endpoint - it
+	// does not confirm that an issue exists to a caller who may not see it - so a
+	// not-found issue may be an expired token rather than a missing issue. Ask who we
+	// are before believing it, and report a stale credential as one. Only asked when
+	// something was not found: where every reference resolved, the credential has
+	// already proved itself, and the extra call would be pure overhead.
+	if issueFoundCount != len(issueIDs) {
+		if err := jc.VerifyCredentials(); err != nil {
+			return err
+		}
+	}
+
 	form, cleanupNeeded, evidencePath, err := prepareAttestationForm(o.payload, o.attachments)
 	if err != nil {
 		return err

--- a/cmd/kosli/attestJira.go
+++ b/cmd/kosli/attestJira.go
@@ -67,8 +67,8 @@ If you want to restrict the Jira issue matching to a specific project, use the
 If the ^--ignore-branch-match^ is set, the branch name is not parsed for a match.
 
 The found issue references will be checked against Jira to confirm their existence.
-The attestation is reported whenever Jira answers, and its compliance status depends on
-referencing existing Jira issues.
+The attestation is reported in all cases, and its compliance status depends on referencing
+existing Jira issues.
 If your Jira credentials are wrong, or ^--jira-base-url^ does not point at your Jira, the
 issues are reported as non existing. This is because Jira returns the same 404 whether an
 issue does not exist or your credentials may not see it.
@@ -76,10 +76,10 @@ When that happens a warning naming the likely cause is written to stderr, so a r
 issues all came back missing says whether the credentials were the reason. The warning does
 not change the exit code; ^--assert^ still fails on the issues that were not found.
 
-If Jira cannot be reached at all, or answers the issue lookup with an error rather than a
-404, the command fails instead of reporting those issues as non existing: a lookup that was
-never answered is not evidence that an issue is missing. This means ^attest jira^ can exit
-non-zero on a Jira outage even without ^--assert^.
+If Jira cannot be reached at all, the issues it did not answer for are reported as non
+existing, as before, with a warning on stderr saying that the lookup never got an answer.
+If Jira answers the lookup with an error instead - a rejected credential, a server error -
+the command fails, as it has always done for those.
 
 The ^--jira-issue-fields^ can be used to include fields from the jira issue. By default no fields
 are included. ^*all^ will give all fields. Using ^--jira-issue-fields "*all" --dry-run^ will give you
@@ -318,32 +318,45 @@ func (o *attestJiraOptions) run(args []string) error {
 
 	issueLog := ""
 	issueFoundCount := 0
+	// Issues Jira answered for, and said it does not have. These are the ambiguous ones: a
+	// 404 is also what it returns for an issue the credential may not see.
+	answeredNotFound := 0
 	for _, issueID := range issueIDs {
 		result, err := jc.GetJiraIssueInfo(issueID, o.issueFields)
 		if err != nil {
 			return err
 		}
 		o.payload.JiraResults = append(o.payload.JiraResults, result)
+		// A lookup Jira never answered is still counted as not found, as it always has
+		// been, but it is no longer silent about it.
+		if result.LookupFailure != nil {
+			logger.Warn("%s. It is reported as not found", result.LookupFailure)
+		}
 		issueExistLog := "issue not found"
 		if result.IssueExists {
 			issueExistLog = "issue found"
 			issueFoundCount++
+		} else if result.LookupFailure == nil {
+			answeredNotFound++
 		}
 		issueLog += fmt.Sprintf("\n\t%s: %s", result.IssueID, issueExistLog)
 	}
 
 	// Jira answers a credential it will not accept with 404 on the issue endpoint - it does
-	// not confirm that an issue exists to a caller who may not see it - so a not-found
-	// issue may be an expired token rather than a missing issue. Ask who we are, so that
-	// the output can say which. Only asked when something was not found: where every
-	// reference resolved, the credential has already proved itself and the extra call would
-	// be pure overhead.
+	// not confirm that an issue exists to a caller who may not see it - so an issue it says
+	// it does not have may be an expired token rather than a missing issue. Ask who we are,
+	// so that the output can say which.
+	//
+	// Only asked when Jira actually answered "not found" for something: where every
+	// reference resolved the credential has already proved itself, and where the lookup got
+	// no answer at all there is no ambiguity to resolve - only a second way to say that Jira
+	// could not be reached.
 	//
 	// This only ever adds a warning. The attestation is still reported and the exit code is
-	// unchanged, so a stale token cannot fail a pipeline that would have passed, and
-	// neither can a blip on this call. --assert still fails on the issues that were not
-	// found, as it did before - with the warning now explaining why they were not.
-	if issueFoundCount != len(issueIDs) {
+	// unchanged, so a stale token cannot fail a pipeline that would have passed, and neither
+	// can a blip on this call. --assert still fails on the issues that were not found, as it
+	// did before - with the warning now explaining why they were not.
+	if answeredNotFound > 0 {
 		if err := jc.VerifyCredentials(); err != nil {
 			logger.Warn("%s. Issues Jira did not return are reported as not found", err)
 		}

--- a/cmd/kosli/attestJira_test.go
+++ b/cmd/kosli/attestJira_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"os"
+	"sync/atomic"
 	"testing"
 
 	billy "github.com/go-git/go-billy/v5"
@@ -85,18 +87,59 @@ func newStubJiraWithStaleCredential(issueKey string) *httpfake.HTTPFake {
 	return fake
 }
 
-// TestAttestJiraStaleCredential pins the CLI-level half of the fix: a credential Jira will
-// not accept is reported as one, rather than as a commit whose Jira references have all
-// disappeared.
+// stubJiraIssueMissing serves a Jira that accepts the credential and does not have the
+// issue: the ordinary "this reference is genuinely missing" case.
+func stubJiraIssueMissing(issueKey string) *httpfake.HTTPFake {
+	fake := httpfake.New()
+	fake.NewHandler().
+		Get("/rest/api/2/myself").
+		Reply(200).
+		BodyString(`{"accountId":"1234","emailAddress":"ci@example.com","displayName":"CI"}`)
+	fake.NewHandler().
+		Get("/rest/api/2/issue/" + issueKey).
+		Reply(404).
+		BodyString(`{"errorMessages":["Issue does not exist or you do not have permission to see it."],"errors":{}}`)
+	return fake
+}
+
+// newStubKosliAttestation stubs the jira attestation endpoint and counts the requests it
+// receives, so that "the attestation was reported" is a fact about what was sent rather
+// than an inference from the output text. Stubbing it also keeps these tests off the local
+// Kosli server: without it a regression that moved the POST ahead of the credential check
+// would quietly attest a bogus issue_exists=false into the real attest-jira flow, and only
+// then fail on a missing string.
+func newStubKosliAttestation(t *testing.T) (*httpfake.HTTPFake, *atomic.Int32) {
+	t.Helper()
+	fake := httpfake.New()
+	var reported atomic.Int32
+	fake.NewHandler().
+		Post("/api/v2/attestations/docs-cmd-test-user/attest-jira/trail/test-123/jira").
+		Handle(func(w http.ResponseWriter, _ *http.Request, _ *httpfake.Request) {
+			reported.Add(1)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{}`))
+		})
+	return fake, &reported
+}
+
+// TestAttestJiraStaleCredential pins the CLI-level half of the fix: when Jira will not
+// accept the credential, the run says so, instead of leaving the reader with a commit whose
+// Jira references have all apparently disappeared.
 //
-// It sits outside AttestJiraCommandTestSuite on purpose. That suite's SetupTest skips
-// unless the shared Jira secrets are present, which would leave this regression covered
-// only in the secret-bearing environment - and it needs neither: the stub is the whole
-// point (a credential that is refused cannot come from the real Jira), and the command
-// fails before any attestation is POSTed, so the local Kosli server is not involved either.
+// The warning is all that changes. The attestation is still reported and the exit code is
+// still whatever --assert made it, so a stale token cannot fail a pipeline that would
+// otherwise have passed.
+//
+// It sits outside AttestJiraCommandTestSuite on purpose: that suite's SetupTest skips unless
+// the shared Jira secrets are present, which would leave this covered only in the
+// secret-bearing environment, and a credential that is refused cannot come from the real
+// Jira anyway. Both sides are stubbed, so it needs neither the secrets nor localhost:8001.
 func TestAttestJiraStaleCredential(t *testing.T) {
 	staleCredentialJira := newStubJiraWithStaleCredential("EX-1")
 	defer staleCredentialJira.Close()
+
+	kosliStub, reported := newStubKosliAttestation(t)
+	defer kosliStub.Close()
 
 	tmpDir, err := os.MkdirTemp("", "testDir")
 	require.NoError(t, err)
@@ -112,33 +155,40 @@ func TestAttestJiraStaleCredential(t *testing.T) {
 	global = &GlobalOpts{
 		ApiToken: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6ImNkNzg4OTg5In0.e8i_lA_QrEhFncb05Xw6E_tkCHU9QfcY4OLTVUCHffY",
 		Org:      "docs-cmd-test-user",
-		Host:     "http://localhost:8001",
+		Host:     kosliStub.Server.URL,
 	}
-	kosliArguments := fmt.Sprintf(" --flow attest-jira --trail test-123 --host %s --org %s --api-token %s", global.Host, global.Org, global.ApiToken)
-
 	cmd := fmt.Sprintf(`attest jira --name bar
 			--jira-base-url %s%s
 			--repo-root %s
 			--commit %s
-			--assert %s`, staleCredentialJira.Server.URL, stubJiraCredentials, tmpDir, commitSha, kosliArguments)
+			--assert
+			--flow attest-jira --trail test-123 --host %s --org %s --api-token %s`,
+		staleCredentialJira.Server.URL, stubJiraCredentials, tmpDir, commitSha,
+		global.Host, global.Org, global.ApiToken)
 
 	// Asserted on the output rather than against a golden: the CLI prefixes a repo-info
 	// warning when it cannot detect the CI environment, so an exact match would pass in CI
 	// and fail on a developer's machine - the portability this test exists for.
-	_, combined, _, _, err := executeCommandC(cmd)
+	_, combined, _, stderr, err := executeCommandC(cmd)
+
+	// The warning names the credential, and goes to stderr so that it cannot corrupt output
+	// a caller is parsing.
+	require.Contains(t, stderr, fmt.Sprintf("the API token of user ci@example.com was not accepted by Jira at %s (HTTP 401)", staleCredentialJira.Server.URL))
+
+	// The exit code is --assert's alone: the issues were not found, exactly as before this
+	// check existed. The credential warning explains why, it does not decide the outcome.
 	require.Error(t, err)
-	require.Contains(t, combined, fmt.Sprintf("failed to authenticate with Jira at %s: check the API token of user ci@example.com (Jira answered HTTP 401)", staleCredentialJira.Server.URL))
-	// And no attestation is reported: issue_exists=false is not a fact we established, so
-	// it does not belong in the trail.
-	require.NotContains(t, combined, "is reported to trail")
+	require.Contains(t, combined, "missing Jira issues from references found in commit message or branch name")
+	require.Contains(t, combined, "is reported to trail")
+	require.Equal(t, int32(1), reported.Load(), "the attestation must still be reported")
 }
 
-// TestAttestJiraUnverifiableCredential pins the other half of the same decision: when the
-// credential check does not complete - Jira answered, but with a 503 that says nothing
-// about the credential - the run carries on and reports the attestation.
+// TestAttestJiraUnverifiableCredential covers the check not completing at all - Jira
+// answered, but with a 503 - where the warning must not claim the credential was refused,
+// since nothing about the credential was learned.
 //
-// Failing there would reinstate the bug this change removed, a blip on a third-party call
-// failing a pipeline, just relocated to a verification that is only ever a tie-breaker.
+// The exit code and the attestation are the same as in the stale-credential case: this call
+// only ever adds a line to stderr, so a blip on it cannot fail a run either.
 func TestAttestJiraUnverifiableCredential(t *testing.T) {
 	jiraStub := httpfake.New()
 	defer jiraStub.Close()
@@ -151,13 +201,8 @@ func TestAttestJiraUnverifiableCredential(t *testing.T) {
 		Reply(503).
 		BodyString(`{"errorMessages":["Service unavailable"],"errors":{}}`)
 
-	// The attestation is stubbed too, so the test does not need the local Kosli server.
-	kosliStub := httpfake.New()
+	kosliStub, reported := newStubKosliAttestation(t)
 	defer kosliStub.Close()
-	kosliStub.NewHandler().
-		Post("/api/v2/attestations/docs-cmd-test-user/attest-jira/trail/test-123/jira").
-		Reply(201).
-		BodyString(`{}`)
 
 	tmpDir, err := os.MkdirTemp("", "testDir")
 	require.NoError(t, err)
@@ -183,10 +228,11 @@ func TestAttestJiraUnverifiableCredential(t *testing.T) {
 		jiraStub.Server.URL, stubJiraCredentials, tmpDir, commitSha,
 		global.Host, global.Org, global.ApiToken)
 
-	_, combined, _, _, err := executeCommandC(cmd)
+	_, combined, _, stderr, err := executeCommandC(cmd)
 	require.NoError(t, err)
-	require.Contains(t, combined, "could not verify the Jira credential")
+	require.Contains(t, stderr, "could not check the Jira credential")
 	require.Contains(t, combined, "is reported to trail")
+	require.Equal(t, int32(1), reported.Load(), "the attestation must still be reported")
 }
 
 // TestAttestJiraVerifiedCredentialMissingIssue pins the path the credential check is most
@@ -197,23 +243,11 @@ func TestAttestJiraUnverifiableCredential(t *testing.T) {
 // The equivalent suite cases (07, 09, 25) skip without the shared Jira secrets, so this is
 // the only place that pins it everywhere.
 func TestAttestJiraVerifiedCredentialMissingIssue(t *testing.T) {
-	jiraStub := httpfake.New()
+	jiraStub := stubJiraIssueMissing("EX-1")
 	defer jiraStub.Close()
-	jiraStub.NewHandler().
-		Get("/rest/api/2/myself").
-		Reply(200).
-		BodyString(`{"accountId":"1234","emailAddress":"ci@example.com","displayName":"CI"}`)
-	jiraStub.NewHandler().
-		Get("/rest/api/2/issue/EX-1").
-		Reply(404).
-		BodyString(`{"errorMessages":["Issue does not exist or you do not have permission to see it."],"errors":{}}`)
 
-	kosliStub := httpfake.New()
+	kosliStub, reported := newStubKosliAttestation(t)
 	defer kosliStub.Close()
-	kosliStub.NewHandler().
-		Post("/api/v2/attestations/docs-cmd-test-user/attest-jira/trail/test-123/jira").
-		Reply(201).
-		BodyString(`{}`)
 
 	tmpDir, err := os.MkdirTemp("", "testDir")
 	require.NoError(t, err)
@@ -240,13 +274,15 @@ func TestAttestJiraVerifiedCredentialMissingIssue(t *testing.T) {
 		jiraStub.Server.URL, stubJiraCredentials, tmpDir, commitSha,
 		global.Host, global.Org, global.ApiToken)
 
-	_, combined, _, _, err := executeCommandC(cmd)
+	_, combined, _, stderr, err := executeCommandC(cmd)
 	require.Error(t, err)
 	require.Contains(t, combined, "is reported to trail")
 	require.Contains(t, combined, "missing Jira issues from references found in commit message or branch name")
 	require.Contains(t, combined, "EX-1: issue not found")
-	// A credential that verified says nothing to warn about.
-	require.NotContains(t, combined, "could not verify the Jira credential")
+	require.Equal(t, int32(1), reported.Load(), "the attestation must still be reported")
+	// A credential Jira accepted leaves nothing to warn about.
+	require.NotContains(t, stderr, "Jira credential")
+	require.NotContains(t, stderr, "not accepted by Jira")
 }
 
 func (suite *AttestJiraCommandTestSuite) TestAttestJiraCmd() {

--- a/cmd/kosli/attestJira_test.go
+++ b/cmd/kosli/attestJira_test.go
@@ -9,6 +9,7 @@ import (
 	git "github.com/go-git/go-git/v5"
 	"github.com/kosli-dev/cli/internal/gitview"
 	"github.com/kosli-dev/cli/internal/testHelpers"
+	"github.com/maxcnunes/httpfake"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -60,7 +61,33 @@ func (suite *AttestJiraCommandTestSuite) TearDownSuite() {
 	require.NoError(suite.T(), err, "failed to remove temp dir %s", suite.tmpDir)
 }
 
+// stubJiraCredentials are passed explicitly to the case that runs against a stub, so
+// that it exercises the CLI's own behaviour without depending on the shared Jira
+// account. The username appears in the authentication error the stub provokes.
+const stubJiraCredentials = " --jira-username ci@example.com --jira-api-token stub-token"
+
+// newStubJiraWithStaleCredential serves what Jira answers a credential it will not
+// accept: 404 from the issue endpoint, because it does not confirm that an issue exists
+// to a caller who may not see it, and 401 from the identity endpoint. Reading the first
+// without the second is what made an expired API token look like a commit whose Jira
+// references had all disappeared.
+func newStubJiraWithStaleCredential(issueKey string) *httpfake.HTTPFake {
+	fake := httpfake.New()
+	fake.NewHandler().
+		Get("/rest/api/2/myself").
+		Reply(401).
+		BodyString(`{"errorMessages":["Client must be authenticated to access this resource."],"errors":{}}`)
+	fake.NewHandler().
+		Get("/rest/api/2/issue/" + issueKey).
+		Reply(404).
+		BodyString(`{"errorMessages":["Issue does not exist or you do not have permission to see it."],"errors":{}}`)
+	return fake
+}
+
 func (suite *AttestJiraCommandTestSuite) TestAttestJiraCmd() {
+	staleCredentialJira := newStubJiraWithStaleCredential("EX-1")
+	defer staleCredentialJira.Close()
+
 	tests := []cmdTestCase{
 		{
 			wantError: true,
@@ -320,9 +347,26 @@ func (suite *AttestJiraCommandTestSuite) TestAttestJiraCmd() {
 			name: "23 assert works and exits with zero code if issue exists",
 			cmd: fmt.Sprintf(`attest jira --name bar
 					--jira-base-url https://kosli-test.atlassian.net
-					--repo-root %s 
+					--repo-root %s
 					--assert %s`, suite.tmpDir, suite.defaultKosliArguments),
 			golden: "jira attestation 'bar' is reported to trail: test-123\n",
+			additionalConfig: jiraTestsAdditionalConfig{
+				commitMessage: "EX-1 test commit",
+			},
+		},
+		{
+			// A stale credential must be named as one. Before, the 404 Jira returns for
+			// an issue the caller may not see was reported as a missing issue, so an
+			// expired API token failed the assert by pointing at the commit's Jira
+			// references instead. No attestation is reported: issue_exists=false is not a
+			// fact we established, so it does not belong in the trail.
+			wantError: true,
+			name:      "23a a stale Jira credential is reported as one, not as a missing issue",
+			cmd: fmt.Sprintf(`attest jira --name bar
+					--jira-base-url %s%s
+					--repo-root %s
+					--assert %s`, staleCredentialJira.Server.URL, stubJiraCredentials, suite.tmpDir, suite.defaultKosliArguments),
+			golden: fmt.Sprintf("Error: failed to authenticate with Jira at %s: check the API token of user ci@example.com (Jira answered HTTP 401)\n", staleCredentialJira.Server.URL),
 			additionalConfig: jiraTestsAdditionalConfig{
 				commitMessage: "EX-1 test commit",
 			},

--- a/cmd/kosli/attestJira_test.go
+++ b/cmd/kosli/attestJira_test.go
@@ -189,6 +189,66 @@ func TestAttestJiraUnverifiableCredential(t *testing.T) {
 	require.Contains(t, combined, "is reported to trail")
 }
 
+// TestAttestJiraVerifiedCredentialMissingIssue pins the path the credential check is most
+// likely to have broken: the credential verifies, the issue really is missing, and the run
+// must behave exactly as it did before the check existed - attestation reported with the
+// issue not found, and --assert failing on that.
+//
+// The equivalent suite cases (07, 09, 25) skip without the shared Jira secrets, so this is
+// the only place that pins it everywhere.
+func TestAttestJiraVerifiedCredentialMissingIssue(t *testing.T) {
+	jiraStub := httpfake.New()
+	defer jiraStub.Close()
+	jiraStub.NewHandler().
+		Get("/rest/api/2/myself").
+		Reply(200).
+		BodyString(`{"accountId":"1234","emailAddress":"ci@example.com","displayName":"CI"}`)
+	jiraStub.NewHandler().
+		Get("/rest/api/2/issue/EX-1").
+		Reply(404).
+		BodyString(`{"errorMessages":["Issue does not exist or you do not have permission to see it."],"errors":{}}`)
+
+	kosliStub := httpfake.New()
+	defer kosliStub.Close()
+	kosliStub.NewHandler().
+		Post("/api/v2/attestations/docs-cmd-test-user/attest-jira/trail/test-123/jira").
+		Reply(201).
+		BodyString(`{}`)
+
+	tmpDir, err := os.MkdirTemp("", "testDir")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.RemoveAll(tmpDir))
+	}()
+
+	_, workTree, fs, err := testHelpers.InitializeGitRepo(tmpDir)
+	require.NoError(t, err)
+	commitSha, err := testHelpers.CommitToRepo(workTree, fs, "EX-1 test commit")
+	require.NoError(t, err)
+
+	global = &GlobalOpts{
+		ApiToken: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6ImNkNzg4OTg5In0.e8i_lA_QrEhFncb05Xw6E_tkCHU9QfcY4OLTVUCHffY",
+		Org:      "docs-cmd-test-user",
+		Host:     kosliStub.Server.URL,
+	}
+	cmd := fmt.Sprintf(`attest jira --name bar
+			--jira-base-url %s%s
+			--repo-root %s
+			--commit %s
+			--assert
+			--flow attest-jira --trail test-123 --host %s --org %s --api-token %s`,
+		jiraStub.Server.URL, stubJiraCredentials, tmpDir, commitSha,
+		global.Host, global.Org, global.ApiToken)
+
+	_, combined, _, _, err := executeCommandC(cmd)
+	require.Error(t, err)
+	require.Contains(t, combined, "is reported to trail")
+	require.Contains(t, combined, "missing Jira issues from references found in commit message or branch name")
+	require.Contains(t, combined, "EX-1: issue not found")
+	// A credential that verified says nothing to warn about.
+	require.NotContains(t, combined, "could not verify the Jira credential")
+}
+
 func (suite *AttestJiraCommandTestSuite) TestAttestJiraCmd() {
 	tests := []cmdTestCase{
 		{
@@ -264,7 +324,11 @@ func (suite *AttestJiraCommandTestSuite) TestAttestJiraCmd() {
 			cmd: fmt.Sprintf(`attest jira testdata/file1 --artifact-type file --name foo
 								--jira-base-url https://kosli-test.atlassian.net
 								--repo-root %s %s`, suite.tmpDir, suite.defaultKosliArguments),
-			golden: "jira attestation 'foo' is reported to trail: test-123\n",
+			// Matched rather than compared exactly: a non-existent issue takes the
+			// credential-verification path, so if the live Jira ever rate-limits or errors
+			// on /myself the run prepends a warning. The behaviour under test is that the
+			// attestation is still reported, which is what this pins.
+			goldenRegex: "jira attestation 'foo' is reported to trail: test-123\n",
 			additionalConfig: jiraTestsAdditionalConfig{
 				commitMessage: "EX-999 test commit",
 			},

--- a/cmd/kosli/attestJira_test.go
+++ b/cmd/kosli/attestJira_test.go
@@ -183,9 +183,55 @@ func TestAttestJiraStaleCredential(t *testing.T) {
 	require.Equal(t, int32(1), reported.Load(), "the attestation must still be reported")
 }
 
-// TestAttestJiraUnverifiableCredential covers the check not completing at all - Jira
-// answered, but with a 503 - where the warning must not claim the credential was refused,
-// since nothing about the credential was learned.
+// TestAttestJiraUnreachable covers a Jira that answers nothing at all: neither the issue
+// lookup nor the credential check gets a response.
+//
+// This is the case where the exit code matters most. Before any of this existed, an
+// unreachable Jira meant the issues were quietly reported as not found and the run passed,
+// so it still has to pass - a Jira outage must not fail a pipeline that would otherwise have
+// succeeded. What is new is that it says so, twice, on stderr.
+func TestAttestJiraUnreachable(t *testing.T) {
+	kosliStub, reported := newStubKosliAttestation(t)
+	defer kosliStub.Close()
+
+	tmpDir, err := os.MkdirTemp("", "testDir")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.RemoveAll(tmpDir))
+	}()
+
+	_, workTree, fs, err := testHelpers.InitializeGitRepo(tmpDir)
+	require.NoError(t, err)
+	commitSha, err := testHelpers.CommitToRepo(workTree, fs, "EX-1 test commit")
+	require.NoError(t, err)
+
+	global = &GlobalOpts{
+		ApiToken: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6ImNkNzg4OTg5In0.e8i_lA_QrEhFncb05Xw6E_tkCHU9QfcY4OLTVUCHffY",
+		Org:      "docs-cmd-test-user",
+		Host:     kosliStub.Server.URL,
+	}
+	// Port 0 can have no listener behind it, so the connection fails immediately.
+	cmd := fmt.Sprintf(`attest jira --name bar
+			--jira-base-url http://127.0.0.1:0%s
+			--repo-root %s
+			--commit %s
+			--flow attest-jira --trail test-123 --host %s --org %s --api-token %s`,
+		stubJiraCredentials, tmpDir, commitSha,
+		global.Host, global.Org, global.ApiToken)
+
+	_, combined, _, stderr, err := executeCommandC(cmd)
+	require.NoError(t, err, "an unreachable Jira must not fail the run")
+	require.Contains(t, combined, "is reported to trail")
+	require.Equal(t, int32(1), reported.Load(), "the attestation must still be reported")
+	require.Contains(t, stderr, "failed to reach Jira at http://127.0.0.1:0 while looking up issue EX-1")
+	// And the credential check is skipped: Jira answered nothing, so there is no ambiguous
+	// 404 to explain, and asking again would only repeat that it could not be reached.
+	require.NotContains(t, stderr, "credential")
+}
+
+// TestAttestJiraUnverifiableCredential covers the credential check not completing while the
+// issue lookup did - Jira answered the lookup, but 503s /myself - where the warning must not
+// claim the credential was refused, since nothing about the credential was learned.
 //
 // The exit code and the attestation are the same as in the stale-credential case: this call
 // only ever adds a line to stderr, so a blip on it cannot fail a run either.

--- a/cmd/kosli/attestJira_test.go
+++ b/cmd/kosli/attestJira_test.go
@@ -61,9 +61,10 @@ func (suite *AttestJiraCommandTestSuite) TearDownSuite() {
 	require.NoError(suite.T(), err, "failed to remove temp dir %s", suite.tmpDir)
 }
 
-// stubJiraCredentials are passed explicitly to the case that runs against a stub, so
-// that it exercises the CLI's own behaviour without depending on the shared Jira
-// account. The username appears in the authentication error the stub provokes.
+// stubJiraCredentials are passed explicitly by the tests that run against a stub, so that
+// they exercise the CLI's own behaviour without depending on the shared Jira account - and
+// without the secrets being present. The username appears in the authentication error the
+// stub provokes.
 const stubJiraCredentials = " --jira-username ci@example.com --jira-api-token stub-token"
 
 // newStubJiraWithStaleCredential serves what Jira answers a credential it will not
@@ -84,10 +85,111 @@ func newStubJiraWithStaleCredential(issueKey string) *httpfake.HTTPFake {
 	return fake
 }
 
-func (suite *AttestJiraCommandTestSuite) TestAttestJiraCmd() {
+// TestAttestJiraStaleCredential pins the CLI-level half of the fix: a credential Jira will
+// not accept is reported as one, rather than as a commit whose Jira references have all
+// disappeared.
+//
+// It sits outside AttestJiraCommandTestSuite on purpose. That suite's SetupTest skips
+// unless the shared Jira secrets are present, which would leave this regression covered
+// only in the secret-bearing environment - and it needs neither: the stub is the whole
+// point (a credential that is refused cannot come from the real Jira), and the command
+// fails before any attestation is POSTed, so the local Kosli server is not involved either.
+func TestAttestJiraStaleCredential(t *testing.T) {
 	staleCredentialJira := newStubJiraWithStaleCredential("EX-1")
 	defer staleCredentialJira.Close()
 
+	tmpDir, err := os.MkdirTemp("", "testDir")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.RemoveAll(tmpDir))
+	}()
+
+	_, workTree, fs, err := testHelpers.InitializeGitRepo(tmpDir)
+	require.NoError(t, err)
+	commitSha, err := testHelpers.CommitToRepo(workTree, fs, "EX-1 test commit")
+	require.NoError(t, err)
+
+	global = &GlobalOpts{
+		ApiToken: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6ImNkNzg4OTg5In0.e8i_lA_QrEhFncb05Xw6E_tkCHU9QfcY4OLTVUCHffY",
+		Org:      "docs-cmd-test-user",
+		Host:     "http://localhost:8001",
+	}
+	kosliArguments := fmt.Sprintf(" --flow attest-jira --trail test-123 --host %s --org %s --api-token %s", global.Host, global.Org, global.ApiToken)
+
+	cmd := fmt.Sprintf(`attest jira --name bar
+			--jira-base-url %s%s
+			--repo-root %s
+			--commit %s
+			--assert %s`, staleCredentialJira.Server.URL, stubJiraCredentials, tmpDir, commitSha, kosliArguments)
+
+	// Asserted on the output rather than against a golden: the CLI prefixes a repo-info
+	// warning when it cannot detect the CI environment, so an exact match would pass in CI
+	// and fail on a developer's machine - the portability this test exists for.
+	_, combined, _, _, err := executeCommandC(cmd)
+	require.Error(t, err)
+	require.Contains(t, combined, fmt.Sprintf("failed to authenticate with Jira at %s: check the API token of user ci@example.com (Jira answered HTTP 401)", staleCredentialJira.Server.URL))
+	// And no attestation is reported: issue_exists=false is not a fact we established, so
+	// it does not belong in the trail.
+	require.NotContains(t, combined, "is reported to trail")
+}
+
+// TestAttestJiraUnverifiableCredential pins the other half of the same decision: when the
+// credential check does not complete - Jira answered, but with a 503 that says nothing
+// about the credential - the run carries on and reports the attestation.
+//
+// Failing there would reinstate the bug this change removed, a blip on a third-party call
+// failing a pipeline, just relocated to a verification that is only ever a tie-breaker.
+func TestAttestJiraUnverifiableCredential(t *testing.T) {
+	jiraStub := httpfake.New()
+	defer jiraStub.Close()
+	jiraStub.NewHandler().
+		Get("/rest/api/2/issue/EX-1").
+		Reply(404).
+		BodyString(`{"errorMessages":["Issue does not exist or you do not have permission to see it."],"errors":{}}`)
+	jiraStub.NewHandler().
+		Get("/rest/api/2/myself").
+		Reply(503).
+		BodyString(`{"errorMessages":["Service unavailable"],"errors":{}}`)
+
+	// The attestation is stubbed too, so the test does not need the local Kosli server.
+	kosliStub := httpfake.New()
+	defer kosliStub.Close()
+	kosliStub.NewHandler().
+		Post("/api/v2/attestations/docs-cmd-test-user/attest-jira/trail/test-123/jira").
+		Reply(201).
+		BodyString(`{}`)
+
+	tmpDir, err := os.MkdirTemp("", "testDir")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.RemoveAll(tmpDir))
+	}()
+
+	_, workTree, fs, err := testHelpers.InitializeGitRepo(tmpDir)
+	require.NoError(t, err)
+	commitSha, err := testHelpers.CommitToRepo(workTree, fs, "EX-1 test commit")
+	require.NoError(t, err)
+
+	global = &GlobalOpts{
+		ApiToken: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6ImNkNzg4OTg5In0.e8i_lA_QrEhFncb05Xw6E_tkCHU9QfcY4OLTVUCHffY",
+		Org:      "docs-cmd-test-user",
+		Host:     kosliStub.Server.URL,
+	}
+	cmd := fmt.Sprintf(`attest jira --name bar
+			--jira-base-url %s%s
+			--repo-root %s
+			--commit %s
+			--flow attest-jira --trail test-123 --host %s --org %s --api-token %s`,
+		jiraStub.Server.URL, stubJiraCredentials, tmpDir, commitSha,
+		global.Host, global.Org, global.ApiToken)
+
+	_, combined, _, _, err := executeCommandC(cmd)
+	require.NoError(t, err)
+	require.Contains(t, combined, "could not verify the Jira credential")
+	require.Contains(t, combined, "is reported to trail")
+}
+
+func (suite *AttestJiraCommandTestSuite) TestAttestJiraCmd() {
 	tests := []cmdTestCase{
 		{
 			wantError: true,
@@ -350,23 +452,6 @@ func (suite *AttestJiraCommandTestSuite) TestAttestJiraCmd() {
 					--repo-root %s
 					--assert %s`, suite.tmpDir, suite.defaultKosliArguments),
 			golden: "jira attestation 'bar' is reported to trail: test-123\n",
-			additionalConfig: jiraTestsAdditionalConfig{
-				commitMessage: "EX-1 test commit",
-			},
-		},
-		{
-			// A stale credential must be named as one. Before, the 404 Jira returns for
-			// an issue the caller may not see was reported as a missing issue, so an
-			// expired API token failed the assert by pointing at the commit's Jira
-			// references instead. No attestation is reported: issue_exists=false is not a
-			// fact we established, so it does not belong in the trail.
-			wantError: true,
-			name:      "23a a stale Jira credential is reported as one, not as a missing issue",
-			cmd: fmt.Sprintf(`attest jira --name bar
-					--jira-base-url %s%s
-					--repo-root %s
-					--assert %s`, staleCredentialJira.Server.URL, stubJiraCredentials, suite.tmpDir, suite.defaultKosliArguments),
-			golden: fmt.Sprintf("Error: failed to authenticate with Jira at %s: check the API token of user ci@example.com (Jira answered HTTP 401)\n", staleCredentialJira.Server.URL),
 			additionalConfig: jiraTestsAdditionalConfig{
 				commitMessage: "EX-1 test commit",
 			},

--- a/internal/jira/jira.go
+++ b/internal/jira/jira.go
@@ -73,33 +73,22 @@ func (jc *JiraConfig) credentialDescription() string {
 	return "personal access token"
 }
 
-// CredentialRejectedError reports that Jira looked at the configured credential and
-// refused it. It is the one outcome that says something about the credential itself.
-//
-// Callers match it with errors.As to tell it apart from a check that did not conclude -
-// an unreachable Jira, a 5xx, a 404 from something that may not even be a Jira - none of
-// which say anything either way. It is a type rather than a sentinel so that the status
-// travels with the error and the message is not forced to embed a sentinel's wording.
-type CredentialRejectedError struct {
-	StatusCode int
-	msg        string
-}
-
-func (e *CredentialRejectedError) Error() string { return e.msg }
-
 // VerifyCredentials checks that Jira accepts the configured credential, by asking it
-// who we are.
+// who we are. It returns nil if Jira accepted it, and otherwise an error saying what to
+// go and look at.
 //
 // It exists because a 404 from the issue endpoint is ambiguous: Jira will not confirm
 // that an issue exists to a caller who may not see it, so it answers "not found" both
 // for an issue that is absent and for a credential that has expired or lost access. A
-// caller that has just been told an issue is missing can use this to find out which of
-// the two it is looking at, and report a stale token as a stale token rather than as a
-// commit whose Jira references do not exist.
+// caller that has just been told an issue is missing can use this to explain which of the
+// two it is probably looking at.
 //
-// A refusal is a *CredentialRejectedError. Every other failure - an unreachable Jira, a
-// 5xx, a 404 - is a plain error: the check did not conclude, which is not the same as an
-// answer and must not be treated as one.
+// The result is diagnostic, not a verdict: every outcome here is something the caller
+// reports, never something it fails on, so the statuses differ only in wording. 401 and
+// 403 name the credential, because Jira saw it and said no. A 404 names the base URL as
+// well, because everything that realistically answers /myself that way is shaped like a
+// misconfiguration rather than a credential - a base URL that is not a Jira, one missing a
+// Data Center context path, a proxy that 404s paths it does not recognise.
 func (jc *JiraConfig) VerifyCredentials() error {
 	jiraClient, err := jc.NewJiraClient()
 	if err != nil {
@@ -111,25 +100,15 @@ func (jc *JiraConfig) VerifyCredentials() error {
 		return nil
 	}
 	if response == nil {
-		return fmt.Errorf("failed to reach Jira at %s: %s", jc.BaseURL, err)
+		return fmt.Errorf("failed to reach Jira at %s: %w", jc.BaseURL, err)
 	}
 	switch response.StatusCode {
 	case http.StatusUnauthorized, http.StatusForbidden:
-		// The only statuses that single out the credential: Jira saw it and said no.
-		return &CredentialRejectedError{
-			StatusCode: response.StatusCode,
-			msg:        fmt.Sprintf("failed to authenticate with Jira at %s: check the %s (Jira answered HTTP %d)", jc.BaseURL, jc.credentialDescription(), response.StatusCode),
-		}
+		return fmt.Errorf("the %s was not accepted by Jira at %s (HTTP %d)", jc.credentialDescription(), jc.BaseURL, response.StatusCode)
 	case http.StatusNotFound:
-		// Not a rejection, and not verification either. Everything that realistically
-		// answers /myself with 404 is shaped like a misconfiguration rather than a
-		// credential: a base URL that is not a Jira, one missing a Data Center context
-		// path, or a proxy that 404s paths it does not recognise. So it names the base URL
-		// alongside the credential, and stays a plain error - a proxy that starts 404ing
-		// must not fail a pipeline over an issue that really is missing.
-		return fmt.Errorf("failed to verify the Jira credential at %s: check the %s, and that --jira-base-url points at your Jira (Jira answered HTTP 404)", jc.BaseURL, jc.credentialDescription())
+		return fmt.Errorf("could not check the %s at %s: verify the credential, and that --jira-base-url points at your Jira (HTTP 404)", jc.credentialDescription(), jc.BaseURL)
 	}
-	return fmt.Errorf("failed to verify the Jira credential at %s: %s", jc.BaseURL, err)
+	return fmt.Errorf("could not check the Jira credential at %s: %w", jc.BaseURL, err)
 }
 
 // GetJiraIssueInfo retrieve Jira issue information
@@ -169,7 +148,7 @@ func (jc *JiraConfig) GetJiraIssueInfo(issueID string, issueFields string) (*Jir
 		if response == nil {
 			// no response at all: DNS, TLS, timeout, connection refused. Nothing was
 			// learned about the issue, so this must not read as "the issue is missing".
-			return result, fmt.Errorf("failed to reach Jira at %s: %s", jc.BaseURL, err)
+			return result, fmt.Errorf("failed to reach Jira at %s while looking up issue %s: %w", jc.BaseURL, issueID, err)
 		}
 		switch response.StatusCode {
 		case http.StatusNotFound:
@@ -183,7 +162,10 @@ func (jc *JiraConfig) GetJiraIssueInfo(issueID string, issueFields string) (*Jir
 		case http.StatusForbidden:
 			return result, fmt.Errorf("not permitted to view Jira issue %s at %s: check that the %s has the Browse Projects permission (Jira answered HTTP 403)", issueID, jc.BaseURL, jc.credentialDescription())
 		default:
-			return result, err
+			// go-jira's message carries the status and the response body but names neither
+			// the Jira nor the issue, so on a 5xx it reads as an unattributable "request
+			// failed" in CI output. Say which call it was.
+			return result, fmt.Errorf("failed to look up Jira issue %s at %s: %w", issueID, jc.BaseURL, err)
 		}
 	}
 

--- a/internal/jira/jira.go
+++ b/internal/jira/jira.go
@@ -23,6 +23,15 @@ type JiraIssueInfo struct {
 	IssueURL    string            `json:"issue_url"`
 	IssueExists bool              `json:"issue_exists"`
 	IssueFields *jira.IssueFields `json:"issue_fields,omitempty"`
+
+	// LookupFailure is set when Jira never answered the lookup at all, so IssueExists is
+	// false because nothing was learned rather than because the issue is absent. It is
+	// reported rather than returned as an error, so that an unreachable Jira cannot fail a
+	// run that would otherwise have passed - the exit code stays what it was before this
+	// distinction existed. Excluded from the payload: it describes this attempt, not the
+	// issue, and the cause stays wrapped so a caller can still tell a timeout from a
+	// refused connection.
+	LookupFailure error `json:"-"`
 }
 
 // NewJiraConfig returns a new JiraConfig
@@ -113,9 +122,12 @@ func (jc *JiraConfig) VerifyCredentials() error {
 
 // GetJiraIssueInfo retrieve Jira issue information
 // if issue is not found, we still return a JiraIssueInfo object with IssueExists set to false.
-// Every other failure - an unreachable Jira, a rejected credential, a server error - is
-// returned as an error rather than as a missing issue, so that a caller asserting on
-// Jira references fails on what actually went wrong.
+//
+// A Jira that answers with something other than 404 - a rejected credential, a server error
+// - is returned as an error rather than as a missing issue, so that a caller asserting on
+// Jira references fails on what actually went wrong. A Jira that does not answer at all is
+// reported through JiraIssueInfo.LookupFailure instead, which keeps the exit code of such a
+// run what it has always been.
 func (jc *JiraConfig) GetJiraIssueInfo(issueID string, issueFields string) (*JiraIssueInfo, error) {
 	issueUrl, err := url.Parse(jc.BaseURL)
 	if err != nil {
@@ -146,9 +158,12 @@ func (jc *JiraConfig) GetJiraIssueInfo(issueID string, issueFields string) (*Jir
 	issue, response, err := jiraClient.Issue.Get(issueID, &queryOptions)
 	if err != nil {
 		if response == nil {
-			// no response at all: DNS, TLS, timeout, connection refused. Nothing was
-			// learned about the issue, so this must not read as "the issue is missing".
-			return result, fmt.Errorf("failed to reach Jira at %s while looking up issue %s: %w", jc.BaseURL, issueID, err)
+			// No response at all: DNS, TLS, timeout, connection refused. Nothing was learned
+			// about the issue, so IssueExists stays false but the reason travels with the
+			// result rather than becoming an error - a Jira outage must not fail a run that
+			// would have passed before this distinction was drawn.
+			result.LookupFailure = fmt.Errorf("failed to reach Jira at %s while looking up issue %s: %w", jc.BaseURL, issueID, err)
+			return result, nil
 		}
 		switch response.StatusCode {
 		case http.StatusNotFound:

--- a/internal/jira/jira.go
+++ b/internal/jira/jira.go
@@ -64,8 +64,20 @@ func (jc *JiraConfig) NewJiraClient() (*jira.Client, error) {
 	return jiraClient, nil
 }
 
+// credentialDescription names the credential the client is using, so that an
+// authentication or permission failure says which one to go and check.
+func (jc *JiraConfig) credentialDescription() string {
+	if jc.Username != "" && jc.APIToken != "" {
+		return fmt.Sprintf("API token of user %s", jc.Username)
+	}
+	return "personal access token"
+}
+
 // GetJiraIssueInfo retrieve Jira issue information
-// if issue is not found, we still return a JiraIssueInfo object with IssueExists set to false
+// if issue is not found, we still return a JiraIssueInfo object with IssueExists set to false.
+// Every other failure - an unreachable Jira, a rejected credential, a server error - is
+// returned as an error rather than as a missing issue, so that a caller asserting on
+// Jira references fails on what actually went wrong.
 func (jc *JiraConfig) GetJiraIssueInfo(issueID string, issueFields string) (*JiraIssueInfo, error) {
 	issueUrl, err := url.Parse(jc.BaseURL)
 	if err != nil {
@@ -94,8 +106,26 @@ func (jc *JiraConfig) GetJiraIssueInfo(issueID string, issueFields string) (*Jir
 	}
 
 	issue, response, err := jiraClient.Issue.Get(issueID, &queryOptions)
-	if err != nil && response != nil && response.StatusCode != http.StatusNotFound {
-		return result, err
+	if err != nil {
+		if response == nil {
+			// no response at all: DNS, TLS, timeout, connection refused. Nothing was
+			// learned about the issue, so this must not read as "the issue is missing".
+			return result, fmt.Errorf("failed to reach Jira at %s: %s", jc.BaseURL, err)
+		}
+		switch response.StatusCode {
+		case http.StatusNotFound:
+			// The only status that answers the question. Jira returns 404 both for an
+			// issue that does not exist and for one the credential may not browse - it
+			// will not confirm the existence of an issue you cannot see - so a 404
+			// alone cannot tell the two apart.
+			return result, nil
+		case http.StatusUnauthorized:
+			return result, fmt.Errorf("failed to authenticate with Jira at %s: check the %s (Jira answered HTTP 401)", jc.BaseURL, jc.credentialDescription())
+		case http.StatusForbidden:
+			return result, fmt.Errorf("not permitted to view Jira issue %s at %s: check that the %s has the Browse Projects permission (Jira answered HTTP 403)", issueID, jc.BaseURL, jc.credentialDescription())
+		default:
+			return result, err
+		}
 	}
 
 	if issue != nil {

--- a/internal/jira/jira.go
+++ b/internal/jira/jira.go
@@ -73,19 +73,19 @@ func (jc *JiraConfig) credentialDescription() string {
 	return "personal access token"
 }
 
-// CredentialNotVerifiedError reports that the credential check came back negative: Jira
-// either refused the credential or answered in a way that cannot be read as verification.
+// CredentialRejectedError reports that Jira looked at the configured credential and
+// refused it. It is the one outcome that says something about the credential itself.
 //
-// Callers match it with errors.As to tell it apart from a check that did not complete at
-// all - an unreachable Jira, a 5xx, a proxy in the way - which says nothing either way. It
-// is a type rather than a sentinel so that each status can carry its own wording: a 401
-// names the credential, while a 404 has to name the base URL too.
-type CredentialNotVerifiedError struct {
+// Callers match it with errors.As to tell it apart from a check that did not conclude -
+// an unreachable Jira, a 5xx, a 404 from something that may not even be a Jira - none of
+// which say anything either way. It is a type rather than a sentinel so that the status
+// travels with the error and the message is not forced to embed a sentinel's wording.
+type CredentialRejectedError struct {
 	StatusCode int
 	msg        string
 }
 
-func (e *CredentialNotVerifiedError) Error() string { return e.msg }
+func (e *CredentialRejectedError) Error() string { return e.msg }
 
 // VerifyCredentials checks that Jira accepts the configured credential, by asking it
 // who we are.
@@ -97,9 +97,9 @@ func (e *CredentialNotVerifiedError) Error() string { return e.msg }
 // the two it is looking at, and report a stale token as a stale token rather than as a
 // commit whose Jira references do not exist.
 //
-// A negative answer is a *CredentialNotVerifiedError. Any other failure - an unreachable
-// Jira, a 5xx, a proxy error - is a plain error, because it says nothing about the
-// credential and should not be mistaken for an answer.
+// A refusal is a *CredentialRejectedError. Every other failure - an unreachable Jira, a
+// 5xx, a 404 - is a plain error: the check did not conclude, which is not the same as an
+// answer and must not be treated as one.
 func (jc *JiraConfig) VerifyCredentials() error {
 	jiraClient, err := jc.NewJiraClient()
 	if err != nil {
@@ -115,23 +115,19 @@ func (jc *JiraConfig) VerifyCredentials() error {
 	}
 	switch response.StatusCode {
 	case http.StatusUnauthorized, http.StatusForbidden:
-		// These single out the credential: Jira saw it and refused it.
-		return &CredentialNotVerifiedError{
+		// The only statuses that single out the credential: Jira saw it and said no.
+		return &CredentialRejectedError{
 			StatusCode: response.StatusCode,
 			msg:        fmt.Sprintf("failed to authenticate with Jira at %s: check the %s (Jira answered HTTP %d)", jc.BaseURL, jc.credentialDescription(), response.StatusCode),
 		}
 	case http.StatusNotFound:
-		// A 404 cannot be read as "verified", but it does not single out the credential
-		// either: a base URL that is not a Jira, carries the wrong context path, or sits
-		// behind a proxy that 404s unknown paths answers exactly the same way. Name both
-		// candidates rather than sending the reader off to rotate a token that was never
-		// the problem. Kept in this bucket defensively - we have not observed a Jira
-		// answering /myself with 404 for a credential it rejects - because treating it as
-		// verification would be the more expensive guess.
-		return &CredentialNotVerifiedError{
-			StatusCode: response.StatusCode,
-			msg:        fmt.Sprintf("failed to verify the Jira credential at %s: check the %s, and that --jira-base-url points at your Jira (Jira answered HTTP 404)", jc.BaseURL, jc.credentialDescription()),
-		}
+		// Not a rejection, and not verification either. Everything that realistically
+		// answers /myself with 404 is shaped like a misconfiguration rather than a
+		// credential: a base URL that is not a Jira, one missing a Data Center context
+		// path, or a proxy that 404s paths it does not recognise. So it names the base URL
+		// alongside the credential, and stays a plain error - a proxy that starts 404ing
+		// must not fail a pipeline over an issue that really is missing.
+		return fmt.Errorf("failed to verify the Jira credential at %s: check the %s, and that --jira-base-url points at your Jira (Jira answered HTTP 404)", jc.BaseURL, jc.credentialDescription())
 	}
 	return fmt.Errorf("failed to verify the Jira credential at %s: %s", jc.BaseURL, err)
 }

--- a/internal/jira/jira.go
+++ b/internal/jira/jira.go
@@ -73,6 +73,36 @@ func (jc *JiraConfig) credentialDescription() string {
 	return "personal access token"
 }
 
+// VerifyCredentials checks that Jira accepts the configured credential, by asking it
+// who we are.
+//
+// It exists because a 404 from the issue endpoint is ambiguous: Jira will not confirm
+// that an issue exists to a caller who may not see it, so it answers "not found" both
+// for an issue that is absent and for a credential that has expired or lost access. A
+// caller that has just been told an issue is missing can use this to find out which of
+// the two it is looking at, and report a stale token as a stale token rather than as a
+// commit whose Jira references do not exist.
+func (jc *JiraConfig) VerifyCredentials() error {
+	jiraClient, err := jc.NewJiraClient()
+	if err != nil {
+		return err
+	}
+
+	_, response, err := jiraClient.User.GetSelf()
+	if err == nil {
+		return nil
+	}
+	if response == nil {
+		return fmt.Errorf("failed to reach Jira at %s: %s", jc.BaseURL, err)
+	}
+	// Unlike the issue endpoint, a 404 here is not an answer about an issue, so it is
+	// not waved through: whatever Jira means by it, the credential did not verify.
+	if response.StatusCode == http.StatusUnauthorized || response.StatusCode == http.StatusForbidden || response.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("failed to authenticate with Jira at %s: check the %s (Jira answered HTTP %d)", jc.BaseURL, jc.credentialDescription(), response.StatusCode)
+	}
+	return fmt.Errorf("failed to verify the Jira credential at %s: %s", jc.BaseURL, err)
+}
+
 // GetJiraIssueInfo retrieve Jira issue information
 // if issue is not found, we still return a JiraIssueInfo object with IssueExists set to false.
 // Every other failure - an unreachable Jira, a rejected credential, a server error - is

--- a/internal/jira/jira.go
+++ b/internal/jira/jira.go
@@ -73,6 +73,20 @@ func (jc *JiraConfig) credentialDescription() string {
 	return "personal access token"
 }
 
+// CredentialNotVerifiedError reports that the credential check came back negative: Jira
+// either refused the credential or answered in a way that cannot be read as verification.
+//
+// Callers match it with errors.As to tell it apart from a check that did not complete at
+// all - an unreachable Jira, a 5xx, a proxy in the way - which says nothing either way. It
+// is a type rather than a sentinel so that each status can carry its own wording: a 401
+// names the credential, while a 404 has to name the base URL too.
+type CredentialNotVerifiedError struct {
+	StatusCode int
+	msg        string
+}
+
+func (e *CredentialNotVerifiedError) Error() string { return e.msg }
+
 // VerifyCredentials checks that Jira accepts the configured credential, by asking it
 // who we are.
 //
@@ -82,6 +96,10 @@ func (jc *JiraConfig) credentialDescription() string {
 // caller that has just been told an issue is missing can use this to find out which of
 // the two it is looking at, and report a stale token as a stale token rather than as a
 // commit whose Jira references do not exist.
+//
+// A negative answer is a *CredentialNotVerifiedError. Any other failure - an unreachable
+// Jira, a 5xx, a proxy error - is a plain error, because it says nothing about the
+// credential and should not be mistaken for an answer.
 func (jc *JiraConfig) VerifyCredentials() error {
 	jiraClient, err := jc.NewJiraClient()
 	if err != nil {
@@ -95,10 +113,25 @@ func (jc *JiraConfig) VerifyCredentials() error {
 	if response == nil {
 		return fmt.Errorf("failed to reach Jira at %s: %s", jc.BaseURL, err)
 	}
-	// Unlike the issue endpoint, a 404 here is not an answer about an issue, so it is
-	// not waved through: whatever Jira means by it, the credential did not verify.
-	if response.StatusCode == http.StatusUnauthorized || response.StatusCode == http.StatusForbidden || response.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("failed to authenticate with Jira at %s: check the %s (Jira answered HTTP %d)", jc.BaseURL, jc.credentialDescription(), response.StatusCode)
+	switch response.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		// These single out the credential: Jira saw it and refused it.
+		return &CredentialNotVerifiedError{
+			StatusCode: response.StatusCode,
+			msg:        fmt.Sprintf("failed to authenticate with Jira at %s: check the %s (Jira answered HTTP %d)", jc.BaseURL, jc.credentialDescription(), response.StatusCode),
+		}
+	case http.StatusNotFound:
+		// A 404 cannot be read as "verified", but it does not single out the credential
+		// either: a base URL that is not a Jira, carries the wrong context path, or sits
+		// behind a proxy that 404s unknown paths answers exactly the same way. Name both
+		// candidates rather than sending the reader off to rotate a token that was never
+		// the problem. Kept in this bucket defensively - we have not observed a Jira
+		// answering /myself with 404 for a credential it rejects - because treating it as
+		// verification would be the more expensive guess.
+		return &CredentialNotVerifiedError{
+			StatusCode: response.StatusCode,
+			msg:        fmt.Sprintf("failed to verify the Jira credential at %s: check the %s, and that --jira-base-url points at your Jira (Jira answered HTTP 404)", jc.BaseURL, jc.credentialDescription()),
+		}
 	}
 	return fmt.Errorf("failed to verify the Jira credential at %s: %s", jc.BaseURL, err)
 }

--- a/internal/jira/jira_test.go
+++ b/internal/jira/jira_test.go
@@ -388,19 +388,39 @@ func TestGetJiraIssueInfo(t *testing.T) {
 		assert.Contains(t, err.Error(), "500")
 	})
 
-	// The transport failure is the other half of the same bug: go-jira returns a nil
-	// response there, so the status switch never runs and the old guard fell through
-	// to IssueExists=false with no error.
-	t.Run("an unreachable Jira is an error, not a missing issue", func(t *testing.T) {
+	// A Jira that never answers is the case the old guard fell through silently: go-jira
+	// returns a nil response, so the status switch never ran and IssueExists=false came back
+	// with no error and no explanation. It still must not fail the caller - that would give a
+	// Jira outage the power to fail runs that used to pass - so the reason rides along on the
+	// result instead of becoming an error.
+	t.Run("an unreachable Jira reports why, without failing", func(t *testing.T) {
 		jc := NewJiraConfig(unreachableJira, "user@example.com", "token", "")
 		result, err := jc.GetJiraIssueInfo(issueID, "")
-		require.Error(t, err)
+		require.NoError(t, err, "an unanswered lookup must not fail the caller")
 		assert.False(t, result.IssueExists)
-		assert.Contains(t, err.Error(), unreachableJira)
-		assert.Contains(t, err.Error(), issueID)
+		require.Error(t, result.LookupFailure)
+		assert.Contains(t, result.LookupFailure.Error(), unreachableJira)
+		assert.Contains(t, result.LookupFailure.Error(), issueID)
 		// Wrapped, so a caller can still tell a timeout from a refused connection.
 		var opErr *net.OpError
-		assert.ErrorAs(t, err, &opErr, "the transport error must stay unwrappable")
+		assert.ErrorAs(t, result.LookupFailure, &opErr, "the transport error must stay unwrappable")
+	})
+
+	// Every other outcome leaves LookupFailure clear, so a caller can use it as "was this
+	// answered at all" without also having to check the error.
+	t.Run("an answered lookup records no lookup failure", func(t *testing.T) {
+		fake := httpfake.New()
+		defer fake.Close()
+		fake.NewHandler().
+			Get("/rest/api/2/issue/" + issueID).
+			Reply(404).
+			BodyString(`{"errorMessages":["Issue does not exist or you do not have permission to see it."],"errors":{}}`)
+
+		jc := NewJiraConfig(fake.Server.URL, "user@example.com", "token", "")
+		result, err := jc.GetJiraIssueInfo(issueID, "")
+		require.NoError(t, err)
+		assert.False(t, result.IssueExists)
+		assert.NoError(t, result.LookupFailure)
 	})
 }
 

--- a/internal/jira/jira_test.go
+++ b/internal/jira/jira_test.go
@@ -389,6 +389,65 @@ func TestGetJiraIssueInfo(t *testing.T) {
 	})
 }
 
+// TestVerifyCredentials pins the check that tells a stale credential apart from a
+// genuinely missing issue. Jira answers a request it cannot authenticate with 404 on
+// the issue endpoint - it will not confirm that an issue exists to someone who may not
+// see it - so the issue lookup alone cannot distinguish the two, and an expired API
+// token reads as "every referenced issue is missing". Asking who we are is the question
+// that does come back with a straight answer.
+func TestVerifyCredentials(t *testing.T) {
+	t.Run("a working credential verifies", func(t *testing.T) {
+		fake := httpfake.New()
+		defer fake.Close()
+		fake.NewHandler().
+			Get("/rest/api/2/myself").
+			Reply(200).
+			BodyString(`{"accountId":"1234","emailAddress":"user@example.com","displayName":"A User"}`)
+
+		jc := NewJiraConfig(fake.Server.URL, "user@example.com", "token", "")
+		require.NoError(t, jc.VerifyCredentials())
+	})
+
+	t.Run("a rejected credential is named in the error", func(t *testing.T) {
+		fake := httpfake.New()
+		defer fake.Close()
+		fake.NewHandler().
+			Get("/rest/api/2/myself").
+			Reply(401).
+			BodyString(`{"errorMessages":["Client must be authenticated to access this resource."],"errors":{}}`)
+
+		jc := NewJiraConfig(fake.Server.URL, "user@example.com", "token", "")
+		err := jc.VerifyCredentials()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "authenticate")
+		assert.Contains(t, err.Error(), "user@example.com")
+		assert.Contains(t, err.Error(), fake.Server.URL)
+	})
+
+	// Jira Cloud answers /myself with 404 rather than 401 for some rejected
+	// credentials, so a 404 here cannot be waved through as "no such user".
+	t.Run("a 404 on the identity endpoint is still a failure to verify", func(t *testing.T) {
+		fake := httpfake.New()
+		defer fake.Close()
+		fake.NewHandler().
+			Get("/rest/api/2/myself").
+			Reply(404).
+			BodyString(`{"errorMessages":["Not found"],"errors":{}}`)
+
+		jc := NewJiraConfig(fake.Server.URL, "user@example.com", "token", "")
+		require.Error(t, jc.VerifyCredentials())
+	})
+
+	t.Run("an unreachable Jira is a failure to verify", func(t *testing.T) {
+		fake := httpfake.New()
+		fake.Close() // nothing is listening on this address any more
+		jc := NewJiraConfig(fake.Server.URL, "user@example.com", "token", "")
+		err := jc.VerifyCredentials()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), fake.Server.URL)
+	})
+}
+
 func BenchmarkFindJiraIssueKeys(b *testing.B) {
 	text := "EX-1 fixes the regression reported in EX-2, see also branch bugfix/EX-3"
 	b.Run("default pattern", func(b *testing.B) {

--- a/internal/jira/jira_test.go
+++ b/internal/jira/jira_test.go
@@ -425,18 +425,19 @@ func TestVerifyCredentials(t *testing.T) {
 			jc := NewJiraConfig(fake.Server.URL, "user@example.com", "token", "")
 			err := jc.VerifyCredentials()
 			require.Error(t, err)
-			var notVerified *CredentialNotVerifiedError
-			require.ErrorAs(t, err, &notVerified)
-			assert.Equal(t, status, notVerified.StatusCode)
+			var rejected *CredentialRejectedError
+			require.ErrorAs(t, err, &rejected)
+			assert.Equal(t, status, rejected.StatusCode)
 			assert.Contains(t, err.Error(), "user@example.com")
 			assert.Contains(t, err.Error(), fake.Server.URL)
 		})
 	}
 
-	// A 404 cannot be read as "verified", but it does not single out the credential
-	// either: the same 404 comes back from a base URL that is not a Jira. The error has to
-	// name both, or it sends the reader off to rotate a token that was never the problem.
-	t.Run("a 404 on the identity endpoint names the base URL as well as the credential", func(t *testing.T) {
+	// A 404 is neither a rejection nor verification. Everything that realistically answers
+	// /myself with 404 is a misconfiguration rather than a credential, so it names the base
+	// URL alongside the credential and does NOT count as a rejection: a proxy that starts
+	// 404ing unknown paths must not fail a run over an issue that really is missing.
+	t.Run("a 404 on the identity endpoint names the base URL and is not a rejection", func(t *testing.T) {
 		fake := httpfake.New()
 		defer fake.Close()
 		fake.NewHandler().
@@ -447,21 +448,21 @@ func TestVerifyCredentials(t *testing.T) {
 		jc := NewJiraConfig(fake.Server.URL, "user@example.com", "token", "")
 		err := jc.VerifyCredentials()
 		require.Error(t, err)
-		var notVerified *CredentialNotVerifiedError
-		require.ErrorAs(t, err, &notVerified)
+		var rejected *CredentialRejectedError
+		assert.NotErrorAs(t, err, &rejected)
 		assert.Contains(t, err.Error(), "user@example.com")
 		assert.Contains(t, err.Error(), "--jira-base-url")
 	})
 
-	// The failures below say nothing about the credential, so they must NOT wrap the
-	// sentinel: a caller that hard-fails on rejection would otherwise abort a good run
+	// The failures below say nothing about the credential either, so they must not be
+	// rejections: a caller that hard-fails on rejection would otherwise abort a good run
 	// every time a verification call happens to blip.
 	t.Run("an unreachable Jira is a failure to verify, not a rejection", func(t *testing.T) {
 		jc := NewJiraConfig(unreachableJira, "user@example.com", "token", "")
 		err := jc.VerifyCredentials()
 		require.Error(t, err)
-		var notVerified *CredentialNotVerifiedError
-		assert.NotErrorAs(t, err, &notVerified)
+		var rejected *CredentialRejectedError
+		assert.NotErrorAs(t, err, &rejected)
 		assert.Contains(t, err.Error(), unreachableJira)
 	})
 
@@ -476,8 +477,8 @@ func TestVerifyCredentials(t *testing.T) {
 		jc := NewJiraConfig(fake.Server.URL, "user@example.com", "token", "")
 		err := jc.VerifyCredentials()
 		require.Error(t, err)
-		var notVerified *CredentialNotVerifiedError
-		assert.NotErrorAs(t, err, &notVerified)
+		var rejected *CredentialRejectedError
+		assert.NotErrorAs(t, err, &rejected)
 	})
 }
 

--- a/internal/jira/jira_test.go
+++ b/internal/jira/jira_test.go
@@ -4,7 +4,9 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/maxcnunes/httpfake"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMakeJiraIssueKey(t *testing.T) {
@@ -281,6 +283,110 @@ func TestFindJiraIssueKeys(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestGetJiraIssueInfo pins which Jira responses mean "the issue does not exist"
+// and which mean "we could not find out". Only a 404 is an answer about the issue:
+// every other failure has to reach the caller as an error, because reporting it as
+// a missing issue makes `attest jira --assert` fail a pipeline for a reason that
+// has nothing to do with the commit's Jira references.
+func TestGetJiraIssueInfo(t *testing.T) {
+	const issueID = "EX-1"
+
+	t.Run("an existing issue is reported as existing", func(t *testing.T) {
+		fake := httpfake.New()
+		defer fake.Close()
+		fake.NewHandler().
+			Get("/rest/api/2/issue/" + issueID).
+			Reply(200).
+			BodyString(`{"id":"10001","key":"EX-1","fields":{"summary":"a summary"}}`)
+
+		jc := NewJiraConfig(fake.Server.URL, "user@example.com", "token", "")
+		result, err := jc.GetJiraIssueInfo(issueID, "summary")
+		require.NoError(t, err)
+		assert.True(t, result.IssueExists)
+		assert.Equal(t, issueID, result.IssueID)
+	})
+
+	t.Run("a 404 is the one status that means the issue does not exist", func(t *testing.T) {
+		fake := httpfake.New()
+		defer fake.Close()
+		fake.NewHandler().
+			Get("/rest/api/2/issue/" + issueID).
+			Reply(404).
+			BodyString(`{"errorMessages":["Issue does not exist or you do not have permission to see it."],"errors":{}}`)
+
+		jc := NewJiraConfig(fake.Server.URL, "user@example.com", "token", "")
+		result, err := jc.GetJiraIssueInfo(issueID, "")
+		require.NoError(t, err)
+		assert.False(t, result.IssueExists)
+	})
+
+	// A stale API token is what this whole classification is for: Jira answers an
+	// expired credential with 401, and swallowing it reported every referenced issue
+	// as missing until someone recycled the token.
+	t.Run("an expired credential is an error, not a missing issue", func(t *testing.T) {
+		fake := httpfake.New()
+		defer fake.Close()
+		fake.NewHandler().
+			Get("/rest/api/2/issue/" + issueID).
+			Reply(401).
+			BodyString(`{"errorMessages":["Client must be authenticated to access this resource."],"errors":{}}`)
+
+		jc := NewJiraConfig(fake.Server.URL, "user@example.com", "token", "")
+		result, err := jc.GetJiraIssueInfo(issueID, "")
+		require.Error(t, err)
+		assert.False(t, result.IssueExists)
+		assert.Contains(t, err.Error(), "authenticate")
+		// the message has to name the credential to check and where it was used
+		assert.Contains(t, err.Error(), "user@example.com")
+		assert.Contains(t, err.Error(), fake.Server.URL)
+	})
+
+	t.Run("a credential without browse permission is an error, not a missing issue", func(t *testing.T) {
+		fake := httpfake.New()
+		defer fake.Close()
+		fake.NewHandler().
+			Get("/rest/api/2/issue/" + issueID).
+			Reply(403).
+			BodyString(`{"errorMessages":["You do not have the permission to see the specified issue."],"errors":{}}`)
+
+		jc := NewJiraConfig(fake.Server.URL, "user@example.com", "token", "")
+		result, err := jc.GetJiraIssueInfo(issueID, "")
+		require.Error(t, err)
+		assert.False(t, result.IssueExists)
+		assert.Contains(t, err.Error(), "permission")
+		assert.Contains(t, err.Error(), issueID)
+	})
+
+	t.Run("a server error is an error, not a missing issue", func(t *testing.T) {
+		fake := httpfake.New()
+		defer fake.Close()
+		fake.NewHandler().
+			Get("/rest/api/2/issue/" + issueID).
+			Reply(500).
+			BodyString(`{"errorMessages":["Internal server error"],"errors":{}}`)
+
+		jc := NewJiraConfig(fake.Server.URL, "user@example.com", "token", "")
+		result, err := jc.GetJiraIssueInfo(issueID, "")
+		require.Error(t, err)
+		assert.False(t, result.IssueExists)
+	})
+
+	// The transport failure is the other half of the same bug: go-jira returns a nil
+	// response there, so the status switch never runs and the old guard fell through
+	// to IssueExists=false with no error.
+	t.Run("an unreachable Jira is an error, not a missing issue", func(t *testing.T) {
+		fake := httpfake.New()
+		fake.Close() // nothing is listening on this address any more
+		unreachableURL := fake.Server.URL
+
+		jc := NewJiraConfig(unreachableURL, "user@example.com", "token", "")
+		result, err := jc.GetJiraIssueInfo(issueID, "")
+		require.Error(t, err)
+		assert.False(t, result.IssueExists)
+		assert.Contains(t, err.Error(), unreachableURL)
+	})
 }
 
 func BenchmarkFindJiraIssueKeys(b *testing.B) {

--- a/internal/jira/jira_test.go
+++ b/internal/jira/jira_test.go
@@ -2,6 +2,7 @@ package jira
 
 import (
 	"fmt"
+	"net"
 	"regexp"
 	"testing"
 
@@ -366,7 +367,10 @@ func TestGetJiraIssueInfo(t *testing.T) {
 		assert.Contains(t, err.Error(), issueID)
 	})
 
-	t.Run("a server error is an error, not a missing issue", func(t *testing.T) {
+	// go-jira's own message for a 5xx is "request failed. Please analyze the request body
+	// for more details. Status code: 500", which names neither the Jira nor the issue: in CI
+	// output there is no way to tell which of the two Jira calls produced it.
+	t.Run("a server error names the issue and the Jira it was looked up in", func(t *testing.T) {
 		fake := httpfake.New()
 		defer fake.Close()
 		fake.NewHandler().
@@ -378,6 +382,10 @@ func TestGetJiraIssueInfo(t *testing.T) {
 		result, err := jc.GetJiraIssueInfo(issueID, "")
 		require.Error(t, err)
 		assert.False(t, result.IssueExists)
+		assert.Contains(t, err.Error(), issueID)
+		assert.Contains(t, err.Error(), fake.Server.URL)
+		// and go-jira's own text is kept, not replaced
+		assert.Contains(t, err.Error(), "500")
 	})
 
 	// The transport failure is the other half of the same bug: go-jira returns a nil
@@ -389,15 +397,21 @@ func TestGetJiraIssueInfo(t *testing.T) {
 		require.Error(t, err)
 		assert.False(t, result.IssueExists)
 		assert.Contains(t, err.Error(), unreachableJira)
+		assert.Contains(t, err.Error(), issueID)
+		// Wrapped, so a caller can still tell a timeout from a refused connection.
+		var opErr *net.OpError
+		assert.ErrorAs(t, err, &opErr, "the transport error must stay unwrappable")
 	})
 }
 
-// TestVerifyCredentials pins the check that tells a stale credential apart from a
-// genuinely missing issue. Jira answers a request it cannot authenticate with 404 on
-// the issue endpoint - it will not confirm that an issue exists to someone who may not
-// see it - so the issue lookup alone cannot distinguish the two, and an expired API
-// token reads as "every referenced issue is missing". Asking who we are is the question
-// that does come back with a straight answer.
+// TestVerifyCredentials pins the check that explains a stale credential rather than leaving
+// it looking like a set of missing issues. Jira answers a request it cannot authenticate
+// with 404 on the issue endpoint - it will not confirm that an issue exists to someone who
+// may not see it - so the lookup alone cannot tell the two apart, and an expired API token
+// reads as "every referenced issue is missing".
+//
+// Its result is diagnostic only: the caller warns on every outcome and never fails, so what
+// each branch owes is an accurate message. Nothing here should be treated as a verdict.
 func TestVerifyCredentials(t *testing.T) {
 	t.Run("a working credential verifies", func(t *testing.T) {
 		fake := httpfake.New()
@@ -411,10 +425,11 @@ func TestVerifyCredentials(t *testing.T) {
 		require.NoError(t, jc.VerifyCredentials())
 	})
 
-	// 401 and 403 are the answers that single out the credential, so the error both wraps
-	// the sentinel and says which credential to go and check.
+	// Every failure here is reported rather than acted on, so what each one has to get
+	// right is the wording: 401 and 403 are the two where Jira saw the credential and said
+	// no, so those name the credential and nothing else.
 	for _, status := range []int{401, 403} {
-		t.Run(fmt.Sprintf("a credential rejected with %d is reported as rejected", status), func(t *testing.T) {
+		t.Run(fmt.Sprintf("a credential refused with %d names the credential", status), func(t *testing.T) {
 			fake := httpfake.New()
 			defer fake.Close()
 			fake.NewHandler().
@@ -425,19 +440,19 @@ func TestVerifyCredentials(t *testing.T) {
 			jc := NewJiraConfig(fake.Server.URL, "user@example.com", "token", "")
 			err := jc.VerifyCredentials()
 			require.Error(t, err)
-			var rejected *CredentialRejectedError
-			require.ErrorAs(t, err, &rejected)
-			assert.Equal(t, status, rejected.StatusCode)
+			assert.Contains(t, err.Error(), "was not accepted by Jira")
 			assert.Contains(t, err.Error(), "user@example.com")
 			assert.Contains(t, err.Error(), fake.Server.URL)
+			assert.Contains(t, err.Error(), fmt.Sprintf("HTTP %d", status))
 		})
 	}
 
-	// A 404 is neither a rejection nor verification. Everything that realistically answers
-	// /myself with 404 is a misconfiguration rather than a credential, so it names the base
-	// URL alongside the credential and does NOT count as a rejection: a proxy that starts
-	// 404ing unknown paths must not fail a run over an issue that really is missing.
-	t.Run("a 404 on the identity endpoint names the base URL and is not a rejection", func(t *testing.T) {
+	// A 404 is not Jira refusing the credential. Everything that realistically answers
+	// /myself that way is a misconfiguration - a base URL that is not a Jira, one missing a
+	// Data Center context path, a proxy that 404s what it does not recognise - so the
+	// message has to offer the base URL as a candidate too, or it sends the reader off to
+	// rotate a token that was never the problem.
+	t.Run("a 404 on the identity endpoint names the base URL as well as the credential", func(t *testing.T) {
 		fake := httpfake.New()
 		defer fake.Close()
 		fake.NewHandler().
@@ -448,25 +463,25 @@ func TestVerifyCredentials(t *testing.T) {
 		jc := NewJiraConfig(fake.Server.URL, "user@example.com", "token", "")
 		err := jc.VerifyCredentials()
 		require.Error(t, err)
-		var rejected *CredentialRejectedError
-		assert.NotErrorAs(t, err, &rejected)
 		assert.Contains(t, err.Error(), "user@example.com")
 		assert.Contains(t, err.Error(), "--jira-base-url")
+		// Not phrased as a refusal, because Jira may never have seen the credential.
+		assert.NotContains(t, err.Error(), "was not accepted by Jira")
 	})
 
-	// The failures below say nothing about the credential either, so they must not be
-	// rejections: a caller that hard-fails on rejection would otherwise abort a good run
-	// every time a verification call happens to blip.
-	t.Run("an unreachable Jira is a failure to verify, not a rejection", func(t *testing.T) {
+	// The two below say nothing about the credential at all, and wrap their cause so that a
+	// caller can still ask what kind of failure it was.
+	t.Run("an unreachable Jira names the Jira and wraps the cause", func(t *testing.T) {
 		jc := NewJiraConfig(unreachableJira, "user@example.com", "token", "")
 		err := jc.VerifyCredentials()
 		require.Error(t, err)
-		var rejected *CredentialRejectedError
-		assert.NotErrorAs(t, err, &rejected)
 		assert.Contains(t, err.Error(), unreachableJira)
+		assert.NotContains(t, err.Error(), "was not accepted by Jira")
+		var opErr *net.OpError
+		assert.ErrorAs(t, err, &opErr, "the transport error must stay unwrappable")
 	})
 
-	t.Run("a server error is a failure to verify, not a rejection", func(t *testing.T) {
+	t.Run("a server error names the Jira and is not phrased as a refusal", func(t *testing.T) {
 		fake := httpfake.New()
 		defer fake.Close()
 		fake.NewHandler().
@@ -477,8 +492,8 @@ func TestVerifyCredentials(t *testing.T) {
 		jc := NewJiraConfig(fake.Server.URL, "user@example.com", "token", "")
 		err := jc.VerifyCredentials()
 		require.Error(t, err)
-		var rejected *CredentialRejectedError
-		assert.NotErrorAs(t, err, &rejected)
+		assert.Contains(t, err.Error(), fake.Server.URL)
+		assert.NotContains(t, err.Error(), "was not accepted by Jira")
 	})
 }
 

--- a/internal/jira/jira_test.go
+++ b/internal/jira/jira_test.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -285,6 +286,12 @@ func TestFindJiraIssueKeys(t *testing.T) {
 	}
 }
 
+// unreachableJira is a base URL no listener can be behind: a connection to port 0 fails
+// immediately, whatever else is running on the box. Starting a server and closing it
+// would leave the port free for anything else to claim - including another package's
+// tests, which run concurrently under `make test_integration`.
+const unreachableJira = "http://127.0.0.1:0"
+
 // TestGetJiraIssueInfo pins which Jira responses mean "the issue does not exist"
 // and which mean "we could not find out". Only a 404 is an answer about the issue:
 // every other failure has to reach the caller as an error, because reporting it as
@@ -377,15 +384,11 @@ func TestGetJiraIssueInfo(t *testing.T) {
 	// response there, so the status switch never runs and the old guard fell through
 	// to IssueExists=false with no error.
 	t.Run("an unreachable Jira is an error, not a missing issue", func(t *testing.T) {
-		fake := httpfake.New()
-		fake.Close() // nothing is listening on this address any more
-		unreachableURL := fake.Server.URL
-
-		jc := NewJiraConfig(unreachableURL, "user@example.com", "token", "")
+		jc := NewJiraConfig(unreachableJira, "user@example.com", "token", "")
 		result, err := jc.GetJiraIssueInfo(issueID, "")
 		require.Error(t, err)
 		assert.False(t, result.IssueExists)
-		assert.Contains(t, err.Error(), unreachableURL)
+		assert.Contains(t, err.Error(), unreachableJira)
 	})
 }
 
@@ -408,25 +411,32 @@ func TestVerifyCredentials(t *testing.T) {
 		require.NoError(t, jc.VerifyCredentials())
 	})
 
-	t.Run("a rejected credential is named in the error", func(t *testing.T) {
-		fake := httpfake.New()
-		defer fake.Close()
-		fake.NewHandler().
-			Get("/rest/api/2/myself").
-			Reply(401).
-			BodyString(`{"errorMessages":["Client must be authenticated to access this resource."],"errors":{}}`)
+	// 401 and 403 are the answers that single out the credential, so the error both wraps
+	// the sentinel and says which credential to go and check.
+	for _, status := range []int{401, 403} {
+		t.Run(fmt.Sprintf("a credential rejected with %d is reported as rejected", status), func(t *testing.T) {
+			fake := httpfake.New()
+			defer fake.Close()
+			fake.NewHandler().
+				Get("/rest/api/2/myself").
+				Reply(status).
+				BodyString(`{"errorMessages":["Client must be authenticated to access this resource."],"errors":{}}`)
 
-		jc := NewJiraConfig(fake.Server.URL, "user@example.com", "token", "")
-		err := jc.VerifyCredentials()
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "authenticate")
-		assert.Contains(t, err.Error(), "user@example.com")
-		assert.Contains(t, err.Error(), fake.Server.URL)
-	})
+			jc := NewJiraConfig(fake.Server.URL, "user@example.com", "token", "")
+			err := jc.VerifyCredentials()
+			require.Error(t, err)
+			var notVerified *CredentialNotVerifiedError
+			require.ErrorAs(t, err, &notVerified)
+			assert.Equal(t, status, notVerified.StatusCode)
+			assert.Contains(t, err.Error(), "user@example.com")
+			assert.Contains(t, err.Error(), fake.Server.URL)
+		})
+	}
 
-	// Jira Cloud answers /myself with 404 rather than 401 for some rejected
-	// credentials, so a 404 here cannot be waved through as "no such user".
-	t.Run("a 404 on the identity endpoint is still a failure to verify", func(t *testing.T) {
+	// A 404 cannot be read as "verified", but it does not single out the credential
+	// either: the same 404 comes back from a base URL that is not a Jira. The error has to
+	// name both, or it sends the reader off to rotate a token that was never the problem.
+	t.Run("a 404 on the identity endpoint names the base URL as well as the credential", func(t *testing.T) {
 		fake := httpfake.New()
 		defer fake.Close()
 		fake.NewHandler().
@@ -435,16 +445,39 @@ func TestVerifyCredentials(t *testing.T) {
 			BodyString(`{"errorMessages":["Not found"],"errors":{}}`)
 
 		jc := NewJiraConfig(fake.Server.URL, "user@example.com", "token", "")
-		require.Error(t, jc.VerifyCredentials())
+		err := jc.VerifyCredentials()
+		require.Error(t, err)
+		var notVerified *CredentialNotVerifiedError
+		require.ErrorAs(t, err, &notVerified)
+		assert.Contains(t, err.Error(), "user@example.com")
+		assert.Contains(t, err.Error(), "--jira-base-url")
 	})
 
-	t.Run("an unreachable Jira is a failure to verify", func(t *testing.T) {
+	// The failures below say nothing about the credential, so they must NOT wrap the
+	// sentinel: a caller that hard-fails on rejection would otherwise abort a good run
+	// every time a verification call happens to blip.
+	t.Run("an unreachable Jira is a failure to verify, not a rejection", func(t *testing.T) {
+		jc := NewJiraConfig(unreachableJira, "user@example.com", "token", "")
+		err := jc.VerifyCredentials()
+		require.Error(t, err)
+		var notVerified *CredentialNotVerifiedError
+		assert.NotErrorAs(t, err, &notVerified)
+		assert.Contains(t, err.Error(), unreachableJira)
+	})
+
+	t.Run("a server error is a failure to verify, not a rejection", func(t *testing.T) {
 		fake := httpfake.New()
-		fake.Close() // nothing is listening on this address any more
+		defer fake.Close()
+		fake.NewHandler().
+			Get("/rest/api/2/myself").
+			Reply(503).
+			BodyString(`{"errorMessages":["Service unavailable"],"errors":{}}`)
+
 		jc := NewJiraConfig(fake.Server.URL, "user@example.com", "token", "")
 		err := jc.VerifyCredentials()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), fake.Server.URL)
+		var notVerified *CredentialNotVerifiedError
+		assert.NotErrorAs(t, err, &notVerified)
 	})
 }
 


### PR DESCRIPTION
<!-- What does this PR change and why? Link any related issue. -->
GetJiraIssueInfo treated anything short of a non-404 HTTP response as "the issue
does not exist".

When go-jira returns an error with no response at all - DNS failure, TLS error,
timeout, connection refused - that guard is false, issue is nil, and the function
returns IssueExists=false with a nil error. A network blip was therefore reported
to the user as a missing Jira issue, and under `attest jira --assert` it failed
their pipeline with a message pointing at their commit's Jira references rather
than at the network.

Classify the outcome instead. A 404 is the only status that answers the question,
and stays a missing issue. A nil response is a reachability error naming the base
URL; 401 and 403 name the credential in play, since "check the API token of user
x" is the actionable part and go-jira's own message carries neither; any other
status keeps the error go-jira returned.

Tests cover each branch against a stubbed Jira, including the transport failure
that returned no error at all before this change.

Follow-up from #1118 troubleshooting issues

### Checklist

- [x] **Docs** are autogenerated from CLI help — make sure the help text reflects your changes
- [x] **Helm chart** (`charts/k8s-reporter/`) updated, if needed. Note: these changes live in a **separate PR**
- [x] **Terraform provider** and related changes ([terraform-provider-kosli](https://github.com/kosli-dev/terraform-provider-kosli), [terraform-aws-evidence-reporter](https://github.com/kosli-dev/terraform-aws-evidence-reporter), [terraform-aws-kosli-reporter](https://github.com/kosli-dev/terraform-aws-kosli-reporter)) updated, if needed
