### PR TITLE
fix(jira): differentiate rejected token from a missing issue

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -7,7 +7,7 @@ documentation:
 go:
   - changed-files:
       - any-glob-to-any-file:
-          - '*.go'
+          - '**/*.go'
 
 github-actions:
   - changed-files:

--- a/cmd/kosli/attestJira.go
+++ b/cmd/kosli/attestJira.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/kosli-dev/cli/internal/gitview"
@@ -70,7 +71,9 @@ The found issue references will be checked against Jira to confirm their existen
 The attestation is reported in all cases, and its compliance status depends on referencing
 existing Jira issues.  
 If you have wrong Jira credentials or wrong Jira-base-url it will be reported as non existing Jira issue.
-This is because Jira returns same 404 error code in all cases.
+This is because Jira returns same 404 error code in all cases. When Jira's response shows that it did not
+accept the credentials, a warning naming them is printed and the issue is reported as not confirmed rather
+than silently as missing; run with ^--debug^ to see the status Jira returned for each issue.
 
 The ^--jira-issue-fields^ can be used to include fields from the jira issue. By default no fields
 are included. ^*all^ will give all fields. Using ^--jira-issue-fields "*all" --dry-run^ will give you
@@ -309,18 +312,30 @@ func (o *attestJiraOptions) run(args []string) error {
 
 	issueLog := ""
 	issueFoundCount := 0
+	unconfirmedIDs := []string{}
+	unconfirmedReasons := []string{}
 	for _, issueID := range issueIDs {
-		result, err := jc.GetJiraIssueInfo(issueID, o.issueFields)
+		result, err := jc.GetJiraIssueInfo(issueID, o.issueFields, logger)
 		if err != nil {
 			return err
 		}
 		o.payload.JiraResults = append(o.payload.JiraResults, result)
-		issueExistLog := "issue not found"
-		if result.IssueExists {
-			issueExistLog = "issue found"
+		switch result.LookupStatus {
+		case jira.IssueFound:
 			issueFoundCount++
+		case jira.LookupUnverified:
+			unconfirmedIDs = append(unconfirmedIDs, issueID)
+			// deduplicated: every issue in a run reports the same run-level cause
+			if !slices.Contains(unconfirmedReasons, result.LookupReason) {
+				unconfirmedReasons = append(unconfirmedReasons, result.LookupReason)
+			}
+		case jira.IssueMissing:
+			// counted as neither, and listed as not found below
 		}
-		issueLog += fmt.Sprintf("\n\t%s: %s", result.IssueID, issueExistLog)
+		issueLog += fmt.Sprintf("\n\t%s: %s", result.IssueID, jiraIssueLogLine(result))
+	}
+	if len(unconfirmedIDs) > 0 {
+		logger.Warn("%s", jiraUnconfirmedWarning(unconfirmedIDs, unconfirmedReasons))
 	}
 
 	form, cleanupNeeded, evidencePath, err := prepareAttestationForm(o.payload, o.attachments)
@@ -361,9 +376,51 @@ func (o *attestJiraOptions) run(args []string) error {
 		if err != nil {
 			errString = fmt.Sprintf("%s\nError: ", err.Error())
 		}
-		err = fmt.Errorf("%smissing Jira issues from references found in commit message or branch name%s", errString, issueLog)
+		// prefixed, so it does not read as another entry in the issue list it follows
+		reasonLog := ""
+		for _, reason := range unconfirmedReasons {
+			reasonLog += fmt.Sprintf("\n\treason: %s", reason)
+		}
+		err = fmt.Errorf("%s%s from references found in commit message or branch name%s%s", errString,
+			jiraAssertHeadline(len(issueIDs)-issueFoundCount-len(unconfirmedIDs), len(unconfirmedIDs)), issueLog, reasonLog)
 	}
 	return wrapAttestationError(err)
+}
+
+// jiraAssertHeadline names what went wrong in the first line of an --assert failure. A
+// lookup Jira never answered is not evidence of a missing issue; when every lookup was
+// answered the wording is unchanged.
+func jiraAssertHeadline(missing, unconfirmed int) string {
+	switch {
+	case unconfirmed == 0:
+		return "missing Jira issues"
+	case missing == 0:
+		return "unconfirmed Jira issues"
+	default:
+		return "missing or unconfirmed Jira issues"
+	}
+}
+
+// jiraUnconfirmedWarning builds the one warning covering every lookup Jira did not answer.
+// The cause is run-level - an expired token, an unreachable host - so warning per issue would
+// repeat one sentence per issue key.
+func jiraUnconfirmedWarning(issueIDs, reasons []string) string {
+	return fmt.Sprintf("could not confirm %s in Jira: %s. Unconfirmed issues are counted as not found in the attestation.",
+		strings.Join(issueIDs, ", "), strings.Join(reasons, "; "))
+}
+
+// jiraIssueLogLine describes one lookup for the per-issue list in the log and the --assert
+// error. An unanswered lookup reads as not confirmed but still counts as not found
+// everywhere else, so compliance and the --assert exit code are unchanged.
+func jiraIssueLogLine(result *jira.JiraIssueInfo) string {
+	switch result.LookupStatus {
+	case jira.IssueFound:
+		return "issue found"
+	case jira.LookupUnverified:
+		return "issue not confirmed"
+	default:
+		return "issue not found"
+	}
 }
 
 // jiraSearchText joins the texts that are searched for Jira issue keys: the commit

--- a/cmd/kosli/attestJira_test.go
+++ b/cmd/kosli/attestJira_test.go
@@ -2,12 +2,16 @@ package main
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	billy "github.com/go-git/go-billy/v5"
 	git "github.com/go-git/go-git/v5"
 	"github.com/kosli-dev/cli/internal/gitview"
+	"github.com/kosli-dev/cli/internal/jira"
 	"github.com/kosli-dev/cli/internal/testHelpers"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -385,6 +389,157 @@ func execJiraTestCase(test cmdTestCase, suite *AttestJiraCommandTestSuite) {
 	}
 
 	runTestCmd(suite.T(), []cmdTestCase{test})
+}
+
+func TestJiraAssertHeadline(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		missing     int
+		unconfirmed int
+		want        string
+	}{
+		{
+			// every lookup was answered, so the long-standing wording is the accurate one
+			name:    "all missing",
+			missing: 2,
+			want:    "missing Jira issues",
+		},
+		{
+			name:        "none answered",
+			unconfirmed: 2,
+			want:        "unconfirmed Jira issues",
+		},
+		{
+			name:        "some missing, some unanswered",
+			missing:     1,
+			unconfirmed: 1,
+			want:        "missing or unconfirmed Jira issues",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, jiraAssertHeadline(tc.missing, tc.unconfirmed))
+		})
+	}
+}
+
+func TestJiraUnconfirmedWarning(t *testing.T) {
+	// three keys sharing one cause, as an expired token produces: stated once, not per key
+	warning := jiraUnconfirmedWarning(
+		[]string{"EX-1", "EX-2", "EX-3"},
+		[]string{"Jira did not accept the username user@example.com and API token"})
+
+	require.Equal(t, "could not confirm EX-1, EX-2, EX-3 in Jira: Jira did not accept the username user@example.com and API token."+
+		" Unconfirmed issues are counted as not found in the attestation.", warning)
+	require.Equal(t, 1, strings.Count(warning, "did not accept"))
+}
+
+// TestAttestJiraWarnsOnUnconfirmedIssue covers the wiring from an unanswered lookup to the
+// warning the user sees. It runs against a fake Jira in dry-run mode, so it needs neither
+// Jira credentials nor a Kosli server.
+func TestAttestJiraWarnsOnUnconfirmedIssue(t *testing.T) {
+	// a 404 that says the request was handled as anonymous, which is what Jira answers
+	// once the API token has expired
+	jiraServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-AUSERNAME", "anonymous")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"errorMessages":["Issue does not exist or you do not have permission to see it."]}`))
+	}))
+	defer jiraServer.Close()
+
+	tmpDir, err := os.MkdirTemp("", "testDir")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.RemoveAll(tmpDir), "failed to remove temp dir %s", tmpDir)
+	}()
+
+	_, workTree, fs, err := testHelpers.InitializeGitRepo(tmpDir)
+	require.NoError(t, err)
+	commitSha, err := testHelpers.CommitToRepo(workTree, fs, "EX-1 fix the thing")
+	require.NoError(t, err)
+
+	_, _, _, errOut, err := executeCommandC(fmt.Sprintf(`attest jira --name foo --flow flow --trail trail
+		--org org --api-token DRY_RUN --repo-root %s --commit %s
+		--jira-base-url %s --jira-username user@example.com --jira-api-token secret`,
+		tmpDir, commitSha, jiraServer.URL))
+	require.NoError(t, err)
+	require.Contains(t, errOut, "could not confirm EX-1 in Jira")
+	require.Contains(t, errOut, "user@example.com")
+	require.NotContains(t, errOut, "secret", "the API token must not appear in the warning")
+}
+
+// TestAttestJiraAssertNamesUnconfirmedIssues covers the --assert failure as a whole - the
+// headline, the per-issue lines and the reasons are assembled in run(), and the assert block
+// is guarded by !global.DryRun, so the dry-run test above never reaches it.
+func TestAttestJiraAssertNamesUnconfirmedIssues(t *testing.T) {
+	// the 404 an expired token produces
+	jiraServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-AUSERNAME", "anonymous")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"errorMessages":["Issue does not exist or you do not have permission to see it."]}`))
+	}))
+	defer jiraServer.Close()
+
+	// accepts the attestation, so the run gets as far as the assert block
+	kosliServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer kosliServer.Close()
+
+	tmpDir, err := os.MkdirTemp("", "testDir")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, os.RemoveAll(tmpDir), "failed to remove temp dir %s", tmpDir)
+	}()
+
+	_, workTree, fs, err := testHelpers.InitializeGitRepo(tmpDir)
+	require.NoError(t, err)
+	commitSha, err := testHelpers.CommitToRepo(workTree, fs, "EX-1 fix the thing")
+	require.NoError(t, err)
+
+	_, _, _, errOut, err := executeCommandC(fmt.Sprintf(`attest jira --name foo --flow flow --trail trail
+		--org org --host %s --api-token %s --assert --repo-root %s --commit %s
+		--jira-base-url %s --jira-username user@example.com --jira-api-token secret`,
+		kosliServer.URL,
+		"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6ImNkNzg4OTg5In0.e8i_lA_QrEhFncb05Xw6E_tkCHU9QfcY4OLTVUCHffY",
+		tmpDir, commitSha, jiraServer.URL))
+
+	require.Error(t, err)
+	require.Contains(t, errOut, "Error: unconfirmed Jira issues from references found in commit message or branch name")
+	require.Contains(t, errOut, "\n\tEX-1: issue not confirmed")
+	require.Contains(t, errOut, "\n\treason: Jira did not accept the username user@example.com and API token")
+	// the count a swapped argument would put here instead
+	require.NotContains(t, errOut, "missing Jira issues")
+}
+
+func TestJiraIssueLogLine(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		result *jira.JiraIssueInfo
+		want   string
+	}{
+		{
+			name:   "a found issue",
+			result: &jira.JiraIssueInfo{LookupStatus: jira.IssueFound, IssueExists: true},
+			want:   "issue found",
+		},
+		{
+			name:   "a missing issue",
+			result: &jira.JiraIssueInfo{LookupStatus: jira.IssueMissing},
+			want:   "issue not found",
+		},
+		{
+			// the reason is reported once for the run, so it is not repeated per line
+			name:   "an unanswered lookup is not claimed to be missing",
+			result: &jira.JiraIssueInfo{LookupStatus: jira.LookupUnverified, LookupReason: "no response from Jira at https://example.atlassian.net: timeout"},
+			want:   "issue not confirmed",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, jiraIssueLogLine(tc.result))
+		})
+	}
 }
 
 func TestJiraSearchText(t *testing.T) {

--- a/internal/jira/jira.go
+++ b/internal/jira/jira.go
@@ -1,6 +1,7 @@
 package jira
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -9,6 +10,20 @@ import (
 	"strings"
 
 	jira "github.com/andygrunwald/go-jira"
+	"github.com/kosli-dev/cli/internal/logger"
+)
+
+// LookupStatus records what a lookup established, which IssueExists cannot: Jira answers
+// 404 both for an issue that does not exist and for one the caller may not view, and a
+// caller whose credentials Jira rejected may not view any issue. LookupUnverified is the
+// zero value, so a path that never reached Jira cannot report an issue as found.
+type LookupStatus int
+
+const (
+	LookupUnverified LookupStatus = iota
+	IssueFound
+	// IssueMissing means Jira answered 404 and nothing indicates the credentials were rejected.
+	IssueMissing
 )
 
 type JiraConfig struct {
@@ -23,6 +38,11 @@ type JiraIssueInfo struct {
 	IssueURL    string            `json:"issue_url"`
 	IssueExists bool              `json:"issue_exists"`
 	IssueFields *jira.IssueFields `json:"issue_fields,omitempty"`
+
+	// LookupReason always explains a LookupUnverified status, and is empty otherwise.
+	// Both fields carry json:"-": the attestation payload stays what the API accepts today.
+	LookupStatus LookupStatus `json:"-"`
+	LookupReason string       `json:"-"`
 }
 
 // NewJiraConfig returns a new JiraConfig
@@ -66,7 +86,11 @@ func (jc *JiraConfig) NewJiraClient() (*jira.Client, error) {
 
 // GetJiraIssueInfo retrieve Jira issue information
 // if issue is not found, we still return a JiraIssueInfo object with IssueExists set to false
-func (jc *JiraConfig) GetJiraIssueInfo(issueID string, issueFields string) (*JiraIssueInfo, error) {
+//
+// An error is returned in exactly the cases it was before LookupStatus existed - a status
+// other than 404, and a 2xx whose body Jira's client could not decode - because callers
+// stop on it. Everything else is reported through LookupStatus and LookupReason.
+func (jc *JiraConfig) GetJiraIssueInfo(issueID string, issueFields string, log *logger.Logger) (*JiraIssueInfo, error) {
 	issueUrl, err := url.Parse(jc.BaseURL)
 	if err != nil {
 		return nil, err
@@ -81,6 +105,7 @@ func (jc *JiraConfig) GetJiraIssueInfo(issueID string, issueFields string) (*Jir
 
 	jiraClient, err := jc.NewJiraClient()
 	if err != nil {
+		result.LookupReason = err.Error()
 		return result, err
 	}
 
@@ -94,17 +119,175 @@ func (jc *JiraConfig) GetJiraIssueInfo(issueID string, issueFields string) (*Jir
 	}
 
 	issue, response, err := jiraClient.Issue.Get(issueID, &queryOptions)
-	if err != nil && response != nil && response.StatusCode != http.StatusNotFound {
-		return result, err
-	}
+	logLookup(log, issueID, jc.BaseURL, response)
 
-	if issue != nil {
+	switch {
+	case err == nil:
+		result.LookupStatus = IssueFound
 		result.IssueExists = true
-		if issue.Fields != nil {
+		if issue != nil && issue.Fields != nil {
 			result.IssueFields = issue.Fields
 		}
+	case response == nil:
+		// go-jira returns no response both when it could not build the request - an unusable
+		// base URL - and when the request never completed. The wrapped error says which.
+		result.LookupReason = fmt.Sprintf("no response from Jira at %s: %s", jc.BaseURL, transportDetail(err))
+	case response.StatusCode == http.StatusNotFound:
+		if reason, rejected := credentialsRejected(response.Header); rejected {
+			result.LookupReason = jc.rejectedReason(reason, "it answered 404 for every issue")
+		} else {
+			result.LookupStatus = IssueMissing
+		}
+	case response.StatusCode >= 200 && response.StatusCode <= 299:
+		// a decode failure comes back alongside the 2xx it could not read, so Jira did answer,
+		// and a redirect to a login page is one way it answers with something else entirely
+		if reason, rejected := credentialsRejected(response.Header); rejected {
+			result.LookupReason = jc.rejectedReason(reason, "its answer is a page rather than the issue")
+		} else {
+			result.LookupReason = withDetail(fmt.Sprintf("could not read Jira's answer for issue %s at %s (status %s)",
+				issueID, jc.BaseURL, response.Status), errorDetail(err, response))
+		}
+		return result, &lookupError{message: result.LookupReason, cause: err}
+	default:
+		message := fmt.Sprintf("looking up Jira issue %s at %s using %s returned %s",
+			issueID, jc.BaseURL, jc.authDescription(), response.Status)
+		if response.StatusCode == http.StatusUnauthorized || response.StatusCode == http.StatusForbidden {
+			message += "; the credentials may have expired or been revoked"
+		}
+		result.LookupReason = withDetail(message, errorDetail(err, response))
+		return result, &lookupError{message: result.LookupReason, cause: err}
 	}
+
 	return result, nil
+}
+
+// logLookup records a lookup at debug level, with the headers that say what the status
+// code cannot: whether Jira accepted the credentials.
+func logLookup(log *logger.Logger, issueID, baseURL string, response *jira.Response) {
+	if log == nil {
+		return
+	}
+	if response == nil {
+		log.Debug("looking up Jira issue %s at %s got no response", issueID, baseURL)
+		return
+	}
+	log.Debug("looking up Jira issue %s at %s returned status %d (X-AUSERNAME: %q, X-Seraph-LoginReason: %q)",
+		issueID, baseURL, response.StatusCode, response.Header.Get("X-AUSERNAME"), response.Header.Get("X-Seraph-LoginReason"))
+}
+
+// credentialsRejected reports whether a response carries positive evidence that Jira did
+// not accept the credentials, and a reason to quote in a message.
+//
+// These headers are Seraph-era: Jira Server and Data Center set them, Jira Cloud has
+// historically set them but does not document them as API contract. Their presence is
+// trustworthy and their absence proves nothing, so a missing one changes no classification.
+func credentialsRejected(header http.Header) (string, bool) {
+	if reason := header.Get("X-Seraph-LoginReason"); reason != "" && !strings.EqualFold(reason, "OK") {
+		return "X-Seraph-LoginReason: " + reason, true
+	}
+	if strings.EqualFold(header.Get("X-AUSERNAME"), "anonymous") {
+		return "the request was handled as anonymous", true
+	}
+	return "", false
+}
+
+// rejectedReason names credentials Jira did not accept; answered says what it sent instead.
+func (jc *JiraConfig) rejectedReason(reason, answered string) string {
+	return fmt.Sprintf("Jira did not accept the %s for %s (%s), so %s; the credentials may have expired or been revoked",
+		jc.authDescription(), jc.BaseURL, reason, answered)
+}
+
+// authDescription names the credentials to renew. The username is included deliberately -
+// it is the account the reader has to go and fix - the token and the PAT never are.
+func (jc *JiraConfig) authDescription() string {
+	if jc.Username != "" && jc.APIToken != "" {
+		return fmt.Sprintf("username %s and API token", jc.Username)
+	}
+	return "personal access token"
+}
+
+// lookupError keeps the error Jira's client returned reachable through errors.Is and As
+// while presenting a message built for the reader. %w cannot do both: it appends the
+// wrapped text, undoing the flattening errorDetail and oneLine apply.
+type lookupError struct {
+	message string
+	cause   error
+}
+
+func (e *lookupError) Error() string { return e.message }
+
+func (e *lookupError) Unwrap() error { return e.cause }
+
+// transportDetail reports the cause inside the *url.Error the HTTP client returns, rather
+// than its text, which embeds the per-issue request URL. That URL would give every issue in
+// a run a different reason for one run-level cause, defeating a caller deduplicating them.
+func transportDetail(err error) string {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) && urlErr.Err != nil {
+		return oneLine(urlErr.Err.Error())
+	}
+	return oneLine(err.Error())
+}
+
+// errorDetail extracts what Jira itself said, or "" when it said nothing beyond the status
+// the caller already names.
+//
+// When it cannot quote Jira - an HTML login page, an empty body, JSON that carries nothing
+// or does not parse - go-jira reports a generic "request failed ... Status code: N"
+// sentence, and for a decode failure the closed-body error too. These land in the message
+// text rather than the error chain, out of reach of errors.As, so they are trimmed off it.
+// Each trim is a no-op when it misses, so an unrecognised shape costs only a noisier message.
+func errorDetail(err error, response *jira.Response) string {
+	var jiraErr *jira.Error
+	if errors.As(err, &jiraErr) {
+		if len(jiraErr.ErrorMessages) > 0 {
+			return oneLine(strings.Join(jiraErr.ErrorMessages, "; "))
+		}
+		if len(jiraErr.Errors) > 0 {
+			// sorted and joined: (*jira.Error).Error() returns from inside a range over the
+			// map, reporting one arbitrary field and dropping the rest
+			fields := make([]string, 0, len(jiraErr.Errors))
+			for field, message := range jiraErr.Errors {
+				fields = append(fields, field+" - "+message)
+			}
+			sort.Strings(fields)
+			return oneLine(strings.Join(fields, "; "))
+		}
+	}
+	// go-jira puts the sentence behind "<status>: <body>: ", in front of a JSON parse
+	// failure, or bare - so it comes off either end, and without the separator
+	generic := fmt.Sprintf("request failed. Please analyze the request body for more details. Status code: %d",
+		response.StatusCode)
+	detail := strings.TrimPrefix(strings.TrimSuffix(err.Error(), generic), generic)
+	// the bottom of the chain is the closed-body error for a 2xx go-jira could not decode,
+	// and the unmarshal reason for a JSON body it could not parse; both only restate that
+	// the body was unreadable, which "could not parse JSON" already says
+	cause := err
+	for next := errors.Unwrap(cause); next != nil; next = errors.Unwrap(cause) {
+		cause = next
+	}
+	detail = strings.TrimSuffix(detail, ": "+cause.Error())
+	detail = strings.TrimRight(detail, ": ")
+	return oneLine(strings.TrimLeft(strings.TrimPrefix(detail, response.Status), ": "))
+}
+
+func withDetail(message, detail string) string {
+	if detail == "" {
+		return message
+	}
+	return message + ": " + detail
+}
+
+// oneLine flattens and truncates text taken from a Jira error. go-jira embeds the whole
+// response body in the errors it builds, and Jira can answer with an HTML login page.
+func oneLine(text string) string {
+	flattened := strings.Join(strings.Fields(text), " ")
+	const maxRunes = 200
+	runes := []rune(flattened)
+	if len(runes) > maxRunes {
+		return string(runes[:maxRunes]) + "..."
+	}
+	return flattened
 }
 
 const defaultJiraIssueKeyPattern = `\b[A-Z][A-Z0-9]{1,9}-[0-9]+`

--- a/internal/jira/jira_test.go
+++ b/internal/jira/jira_test.go
@@ -1,10 +1,20 @@
 package jira
 
 import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"regexp"
+	"strings"
 	"testing"
 
+	jira "github.com/andygrunwald/go-jira"
+	"github.com/kosli-dev/cli/internal/logger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMakeJiraIssueKey(t *testing.T) {
@@ -281,6 +291,333 @@ func TestFindJiraIssueKeys(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestGetJiraIssueInfo covers how a lookup is classified. Whether an error is returned is
+// part of the contract - the caller stops on it, before reporting the attestation - so each
+// case asserts that too.
+func TestGetJiraIssueInfo(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		// handler serves the issue endpoint. When nil the server is closed before the
+		// lookup, so the request fails at the transport level.
+		handler    http.HandlerFunc
+		wantStatus LookupStatus
+		wantExists bool
+		// wantErrExact pins the whole message, and empty means no error is expected.
+		// {{url}} stands in for the test server's URL.
+		wantErrExact string
+		wantReason   []string // substrings of LookupReason
+		wantDebug    string
+	}{
+		{
+			name: "an existing issue is found",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"key":"EX-1"}`))
+			},
+			wantStatus: IssueFound,
+			wantExists: true,
+			wantDebug:  "status 200",
+		},
+		{
+			name: "a 404 whose headers show the credentials accepted is a missing issue",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("X-AUSERNAME", "user@example.com")
+				w.Header().Set("X-Seraph-LoginReason", "OK")
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"errorMessages":["Issue does not exist"]}`))
+			},
+			wantStatus: IssueMissing,
+			wantDebug:  "status 404",
+		},
+		{
+			// the shape Jira Cloud is likeliest to answer with, and the costly one to get
+			// wrong: absence is not evidence, or every missing issue turns unverified
+			name: "a 404 carrying neither header is a missing issue",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"errorMessages":["Issue does not exist or you do not have permission to see it."]}`))
+			},
+			wantStatus: IssueMissing,
+			// %q renders an absent header as "", so this pins that neither was sent
+			wantDebug: `status 404 (X-AUSERNAME: "", X-Seraph-LoginReason: "")`,
+		},
+		{
+			name: "a 404 handled as anonymous is unverified, not missing",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("X-AUSERNAME", "anonymous")
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"errorMessages":["Issue does not exist"]}`))
+			},
+			wantStatus: LookupUnverified,
+			wantReason: []string{"username user@example.com and API token", "anonymous", "may have expired"},
+			wantDebug:  "status 404",
+		},
+		{
+			name: "a 404 with a failed login reason is unverified, not missing",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("X-Seraph-LoginReason", "AUTHENTICATED_FAILED")
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"errorMessages":["Issue does not exist"]}`))
+			},
+			wantStatus: LookupUnverified,
+			wantReason: []string{"AUTHENTICATED_FAILED", "may have expired"},
+			wantDebug:  "status 404",
+		},
+		{
+			name: "a 401 aborts, naming the base URL and the credentials",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"errorMessages":["Client must be authenticated"]}`))
+			},
+			wantErrExact: "looking up Jira issue EX-1 at {{url}} using username user@example.com and API token" +
+				" returned 401 Unauthorized; the credentials may have expired or been revoked:" +
+				" Client must be authenticated",
+			wantDebug: "status 401",
+		},
+		{
+			name: "a 403 aborts, naming the base URL and the credentials",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+			},
+			// an empty body is a shape a rejected token answers with, and go-jira has nothing
+			// to report for it beyond the status
+			wantErrExact: "looking up Jira issue EX-1 at {{url}} using username user@example.com and API token" +
+				" returned 403 Forbidden; the credentials may have expired or been revoked",
+			wantDebug: "status 403",
+		},
+		{
+			// Jira Cloud answers with this, and a bare {} renders the same way: go-jira
+			// parses it into a jira.Error carrying nothing, then reports its generic
+			// sentence with no separator in front of it
+			name: "a 403 whose JSON body carries no messages says nothing beyond the status",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`{"errorMessages":[],"errors":{}}`))
+			},
+			wantErrExact: "looking up Jira issue EX-1 at {{url}} using username user@example.com and API token" +
+				" returned 403 Forbidden; the credentials may have expired or been revoked",
+			wantDebug: "status 403",
+		},
+		{
+			// two fields, because (*jira.Error).Error() returns from inside a range over the
+			// map: one arbitrary field, and a different one from run to run
+			name: "a 403 reporting field errors quotes them all in a stable order",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`{"errors":{"summary":"Field required","issuekey":"Issue does not exist"}}`))
+			},
+			wantErrExact: "looking up Jira issue EX-1 at {{url}} using username user@example.com and API token" +
+				" returned 403 Forbidden; the credentials may have expired or been revoked:" +
+				" issuekey - Issue does not exist; summary - Field required",
+			wantDebug: "status 403",
+		},
+		{
+			// go-jira puts its generic sentence in front of the parse failure in this shape,
+			// not behind it
+			name: "a 401 whose JSON body does not parse says so",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+			},
+			wantErrExact: "looking up Jira issue EX-1 at {{url}} using username user@example.com and API token" +
+				" returned 401 Unauthorized; the credentials may have expired or been revoked:" +
+				" could not parse JSON",
+			wantDebug: "status 401",
+		},
+		{
+			// a redirect to an SSO login page arrives as a 200 with HTML, which says as little
+			// about the issue as the 404 a rejected token produces
+			name: "a 200 login page reached with rejected credentials names them",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/html")
+				w.Header().Set("X-AUSERNAME", "anonymous")
+				_, _ = w.Write([]byte("<html>login</html>"))
+			},
+			wantErrExact: "Jira did not accept the username user@example.com and API token for {{url}}" +
+				" (the request was handled as anonymous), so its answer is a page rather than the" +
+				" issue; the credentials may have expired or been revoked",
+			wantDebug: "status 200",
+		},
+		{
+			name: "a 500 aborts without blaming the credentials",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			wantErrExact: "looking up Jira issue EX-1 at {{url}} using username user@example.com" +
+				" and API token returned 500 Internal Server Error",
+			wantDebug: "status 500",
+		},
+		{
+			name:       "a transport failure is unverified rather than silently missing",
+			handler:    nil,
+			wantStatus: LookupUnverified,
+			wantReason: []string{"no response from Jira at"},
+			wantDebug:  "no response",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				tt.handler(w, r)
+			}))
+			if tt.handler == nil {
+				server.Close()
+			} else {
+				defer server.Close()
+			}
+
+			debug := new(bytes.Buffer)
+			jc := NewJiraConfig(server.URL, "user@example.com", "token", "")
+			result, err := jc.GetJiraIssueInfo("EX-1", "", logger.NewLogger(io.Discard, debug, true))
+
+			require.NotNil(t, result)
+			assert.Equal(t, "EX-1", result.IssueID)
+			assert.Contains(t, debug.String(), tt.wantDebug)
+
+			// asserted for the abort cases too: a result read after an error must not
+			// look like a found issue
+			assert.Equal(t, tt.wantStatus, result.LookupStatus)
+			assert.Equal(t, tt.wantExists, result.IssueExists)
+
+			if tt.wantErrExact != "" {
+				require.Error(t, err)
+				assert.Equal(t, strings.ReplaceAll(tt.wantErrExact, "{{url}}", server.URL), err.Error())
+				assert.NotContains(t, err.Error(), "\n", "an error built from a Jira response body must stay on one line")
+				assert.Equal(t, err.Error(), result.LookupReason, "an unverified status must never carry an empty reason")
+				return
+			}
+
+			require.NoError(t, err)
+			for _, want := range tt.wantReason {
+				assert.Contains(t, result.LookupReason, want)
+			}
+			if len(tt.wantReason) == 0 {
+				assert.Empty(t, result.LookupReason)
+			}
+		})
+	}
+}
+
+// TestGetJiraIssueInfoTransportReasonIsIssueIndependent covers the property the caller
+// deduplicates on: a failure that produced no response is run-level, so every issue in that
+// run must report it identically. The HTTP client's *url.Error carries the per-issue URL.
+func TestGetJiraIssueInfoTransportReasonIsIssueIndependent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	server.Close() // nothing is listening on that port now, so no request completes
+
+	jc := NewJiraConfig(server.URL, "user@example.com", "token", "")
+	log := logger.NewLogger(io.Discard, io.Discard, false)
+
+	first, err := jc.GetJiraIssueInfo("EX-1", "", log)
+	require.NoError(t, err)
+	second, err := jc.GetJiraIssueInfo("EX-2", "", log)
+	require.NoError(t, err)
+
+	assert.Equal(t, LookupUnverified, first.LookupStatus)
+	assert.Equal(t, first.LookupReason, second.LookupReason)
+	assert.NotContains(t, first.LookupReason, "EX-1")
+	assert.NotContains(t, first.LookupReason, "rest/api/2/issue")
+	assert.Contains(t, first.LookupReason, "connect")
+}
+
+// TestGetJiraIssueInfoWithoutCredentials covers the path that fails before Jira is reached.
+// The command validates the credential flags first, so this is unreachable from the CLI
+// today, but the result must still say why it could not verify the issue.
+func TestGetJiraIssueInfoWithoutCredentials(t *testing.T) {
+	jc := NewJiraConfig("https://example.atlassian.net", "", "", "")
+	result, err := jc.GetJiraIssueInfo("EX-1", "", logger.NewLogger(io.Discard, io.Discard, false))
+
+	require.Error(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, LookupUnverified, result.LookupStatus)
+	assert.Equal(t, err.Error(), result.LookupReason)
+}
+
+// TestGetJiraIssueInfoErrorUnwraps covers a caller inspecting the returned error: the
+// message is the one built for the reader, with Jira's own error reachable underneath.
+func TestGetJiraIssueInfoErrorUnwraps(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"errorMessages":["Client must be authenticated to access this resource."]}`))
+	}))
+	defer server.Close()
+
+	jc := NewJiraConfig(server.URL, "user@example.com", "token", "")
+	_, err := jc.GetJiraIssueInfo("EX-1", "", logger.NewLogger(io.Discard, io.Discard, false))
+
+	require.Error(t, err)
+	var jiraErr *jira.Error
+	require.True(t, errors.As(err, &jiraErr), "the error from Jira's client must stay reachable")
+	assert.Contains(t, err.Error(), "the credentials may have expired or been revoked")
+	assert.NotContains(t, err.Error(), "Status code: 401", "go-jira's generic sentence only repeats the status")
+}
+
+// TestGetJiraIssueInfoUnreadableAnswer covers a 2xx whose body cannot be decoded: Jira did
+// answer, so the message must not read as if the status were the problem.
+func TestGetJiraIssueInfoUnreadableAnswer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("<html>not json</html>"))
+	}))
+	defer server.Close()
+
+	jc := NewJiraConfig(server.URL, "user@example.com", "token", "")
+	result, err := jc.GetJiraIssueInfo("EX-1", "", logger.NewLogger(io.Discard, io.Discard, false))
+
+	// still an abort, as it was before the status was classified at all
+	require.Error(t, err)
+	assert.Equal(t, fmt.Sprintf("could not read Jira's answer for issue EX-1 at %s (status 200 OK):"+
+		" invalid character '<' looking for beginning of value", server.URL), err.Error())
+	assert.Equal(t, LookupUnverified, result.LookupStatus)
+	assert.Equal(t, err.Error(), result.LookupReason)
+	assert.False(t, result.IssueExists)
+}
+
+// TestGetJiraIssueInfoWithoutLogger covers a caller that passes no logger: the parameter is
+// new on an exported function, so nil is the easy mistake to make.
+func TestGetJiraIssueInfoWithoutLogger(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"key":"EX-1"}`))
+	}))
+	defer server.Close()
+
+	jc := NewJiraConfig(server.URL, "user@example.com", "token", "")
+	result, err := jc.GetJiraIssueInfo("EX-1", "", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, IssueFound, result.LookupStatus)
+	assert.True(t, result.IssueExists)
+}
+
+// TestGetJiraIssueInfoFlattensResponseBody guards against a non-JSON body: go-jira embeds
+// the whole body in the error it builds, and a login page must not reach a log line.
+func TestGetJiraIssueInfoFlattensResponseBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("<html>\n<body>\n" + strings.Repeat("login page ", 200) + "\n</body>\n</html>"))
+	}))
+	defer server.Close()
+
+	jc := NewJiraConfig(server.URL, "user@example.com", "token", "")
+	_, err := jc.GetJiraIssueInfo("EX-1", "", logger.NewLogger(io.Discard, io.Discard, false))
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "\n")
+	assert.Less(t, len(err.Error()), 500)
+	// a non-JSON body reaches errorDetail's fallback, which trims the generic sentence
+	assert.NotContains(t, err.Error(), "request failed")
+	assert.Equal(t, 1, strings.Count(err.Error(), "401 Unauthorized"))
 }
 
 func BenchmarkFindJiraIssueKeys(b *testing.B) {


### PR DESCRIPTION
<!-- What does this PR change and why? Link any related issue. -->
Jira answers 404 both for an issue that does not exist and for one the
caller may not view, and a caller whose credentials Jira rejected may not
view any issue. GetJiraIssueInfo looked only at the status code, so an
expired Atlassian API token came back as IssueExists=false with no error
and was reported as a missing issue - sending users to look for a ticket
instead of renewing a token. A transport failure reached the same outcome
through the response==nil case, because the guard it fell through required
a response to be present.

Classify the outcome in LookupStatus, with LookupReason carrying a message
for the caller to report, and reclassify a 404 only when the response
carries positive evidence that the credentials were rejected. That
evidence is Seraph-era, so its absence proves nothing and leaves the
lookup classified exactly as it was.

Behaviour is unchanged throughout: an error is returned in exactly the
cases it was before, so every abort path and exit code stands, and the two
new fields carry json:"-" so the attestation payload is what the API
accepts today. An unconfirmed lookup still counts as not found, so
compliance and --assert are untouched - only what the user reads changes.

kosli attest jira warns once per run rather than once per issue, naming
every affected issue and each distinct cause, and the --assert failure
names unconfirmed issues in its headline instead of announcing missing
ones.

The messages themselves are built from what Jira actually said:

- go-jira's generic "request failed ... Status code: N" sentence is
  trimmed in all three of its renderings, along with the status it
  repeats, so a message that has nothing to add ends at the status it
  already named.
- every field in an errors body is quoted, in a stable order, rather than
  letting go-jira return one arbitrary entry from inside a range.
- a 2xx that cannot be decoded names the credentials when the response
  says they were not accepted, which is what an SSO login page reached
  through a redirect looks like.
- a failure that produced no response reports the cause inside the
  *url.Error rather than its text, which embeds the per-issue URL and
  would give one run-level cause a different reason per issue.

The status and the two headers are logged at debug level, which is what a
run against a genuinely expired token needs to show whether Jira Cloud
still sends them.

Follow-up from https://github.com/kosli-dev/cli/pull/1118 troubleshooting issues

Also adjusts GHA label filter.

### Checklist

- [x] **Docs** are autogenerated from CLI help — make sure the help text reflects your changes
- [x] **Helm chart** (`charts/k8s-reporter/`) updated, if needed. Note: these changes live in a **separate PR**
- [x] **Terraform provider** and related changes ([terraform-provider-kosli](https://github.com/kosli-dev/terraform-provider-kosli), [terraform-aws-evidence-reporter](https://github.com/kosli-dev/terraform-aws-evidence-reporter), [terraform-aws-kosli-reporter](https://github.com/kosli-dev/terraform-aws-kosli-reporter)) updated, if needed
