### PR TITLE
chore: bump Go version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,7 @@ before:
 builds:
   - id: kosli
     binary: kosli
-    ldflags: 
+    ldflags:
       - -w -s
       - -X github.com/kosli-dev/cli/internal/version.version={{ .Tag }}
       - -X github.com/kosli-dev/cli/internal/version.gitCommit={{ .FullCommit }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kosli-dev/cli
 
-go 1.26.6
+go 1.26.7
 
 require (
 	cloud.google.com/go/run v1.22.0


### PR DESCRIPTION
<!-- What does this PR change and why? Link any related issue. -->
Use latest Go and avoid Snyk scan flagging vulns. Remove obsolete blank spaces.

### Checklist

- [x] **Docs** are autogenerated from CLI help — make sure the help text reflects your changes
- [x] **Helm chart** (`charts/k8s-reporter/`) updated, if needed. Note: these changes live in a **separate PR**
- [x] **Terraform provider** and related changes ([terraform-provider-kosli](https://github.com/kosli-dev/terraform-provider-kosli), [terraform-aws-evidence-reporter](https://github.com/kosli-dev/terraform-aws-evidence-reporter), [terraform-aws-kosli-reporter](https://github.com/kosli-dev/terraform-aws-kosli-reporter)) updated, if needed
