### PR TITLE
fix(docker): report the real version and tree state in published images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,8 @@
 
 # Local build outputs
 kosli
+reporter
+merkely
 dist
 licenses
 npm/cli*/bin
@@ -19,9 +21,13 @@ junit.xml
 junit-test-results
 smoke-test-results.json
 
-# Scratch, editor and tooling state
+# Local config (may hold an API token) and scratch, editor and tooling state
+kosli.yaml
+merkely.yaml
+pipe.json
 tmp
 client_reference
+**/*~
 TODO.md
 release_notes.md
 .claude/settings.local.json

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 # Deny-list: list only git-ignored artefacts. The build reads the version and
 # tree state from git, so a *tracked* path excluded here reads as a deletion and
-# makes images report GitTreeState:"dirty" (#1133). .git/ is required.
+# makes images report GitTreeState:"dirty" (#1133); an untracked file left in
+# the workspace does the same. .git/ is required.
 # Careful: bin/ and npm/wrapper/bin/kosli are tracked.
 
 # Local build outputs

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,31 @@
-*
-!cmd/
-!internal/
-!Makefile
-!go.*
-!.git/
+# Deny-list: list only git-ignored artefacts. The build reads the version and
+# tree state from git, so a *tracked* path excluded here reads as a deletion and
+# makes images report GitTreeState:"dirty" (#1133). .git/ is required.
+# Careful: bin/ and npm/wrapper/bin/kosli are tracked.
+
+# Local build outputs
+kosli
+dist
+licenses
+npm/cli*/bin
+npm/*/kosli*.tgz
+**/*.tar.gz
+
+# Test and coverage output
+coverage.out
+cover.out
+coverage.html
+junit.xml
+junit-test-results
+smoke-test-results.json
+
+# Scratch, editor and tooling state
+tmp
+client_reference
+TODO.md
+release_notes.md
+.claude/settings.local.json
+.idea
+.vscode
+**/__pycache__
+**/.DS_Store

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -130,6 +130,9 @@ jobs:
           # The Makefile derives the version from `git describe`, and
           # fetch-depth > 0 fetches no tags unless asked (#1133).
           fetch-tags: true
+          # .git/ ships in the build context, which mode=max exports to the
+          # public cache ref.
+          persist-credentials: false
           ref: ${{ inputs.checkout_ref || github.sha }}
 
       - name: Set up Docker Buildx
@@ -199,6 +202,8 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 3
+          # The smoke tests mount this workspace into a container.
+          persist-credentials: false
           ref: ${{ inputs.checkout_ref || github.sha }}
 
       - uses: actions/setup-go@v7

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -127,6 +127,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 3
+          # The Makefile derives the version from `git describe`, and
+          # fetch-depth > 0 fetches no tags unless asked (#1133).
+          fetch-tags: true
           ref: ${{ inputs.checkout_ref || github.sha }}
 
       - name: Set up Docker Buildx
@@ -340,7 +343,13 @@ jobs:
         env:
           IMAGE: ${{ env.IMAGE }}
           TAG: ${{ inputs.tag }}
-        run: ./scripts/docker-smoke-tests.sh
+        run: |
+          # Release builds must report their tag; others are tagged with a
+          # sha and report dev+<sha>.
+          if [[ "$TAG" =~ ^v[0-9] ]]; then
+            export EXPECTED_VERSION="$TAG"
+          fi
+          ./scripts/docker-smoke-tests.sh
 
       - name: Report Docker smoke test attestation to Kosli
         if: ${{ inputs.report_to_kosli != 'none' && (success() || failure()) }}

--- a/scripts/docker-smoke-tests.sh
+++ b/scripts/docker-smoke-tests.sh
@@ -59,15 +59,24 @@ run_case() {
 # entry to the CASES array further down — no CI workflow changes needed.
 
 # Asserts the image reports the release it was published as, built from a clean
-# tree — the two halves of #1133. EXPECTED_VERSION is the exact version required;
-# unset for non-release builds, which are tagged with a sha and report dev+<sha>.
+# tree at the built commit — the two halves of #1133. EXPECTED_VERSION is the
+# exact version required; unset for non-release builds, which are tagged with a
+# sha and report dev+<sha>.
 test_version() {
-  local full short
+  local full short commit
   full="$(docker run --rm -e KOSLI_NO_UPDATE_CHECK=1 "${IMAGE}:${TAG}" version)" || return 1
   echo "$full"
 
   if ! grep -q 'GitTreeState:"clean"' <<< "$full"; then
     echo "expected GitTreeState:\"clean\"" >&2
+    return 1
+  fi
+
+  # This job checks out the same ref the build job did, so HEAD is the commit
+  # the image was built from.
+  commit="$(git -C "$REPO_ROOT" rev-parse HEAD)" || return 1
+  if ! grep -q "GitCommit:\"${commit}\"" <<< "$full"; then
+    echo "expected GitCommit:\"${commit}\"" >&2
     return 1
   fi
 

--- a/scripts/docker-smoke-tests.sh
+++ b/scripts/docker-smoke-tests.sh
@@ -3,7 +3,8 @@
 # outcome to $RESULTS_FILE for the CI workflow to report as a Kosli
 # attestation.
 #
-# Usage: IMAGE=... TAG=... RESULTS_FILE=... ./scripts/docker-smoke-tests.sh
+# Usage: IMAGE=... TAG=... RESULTS_FILE=... [EXPECTED_VERSION=...] \
+#          ./scripts/docker-smoke-tests.sh
 set -uo pipefail
 
 IMAGE="${IMAGE:?IMAGE is required}"
@@ -57,6 +58,33 @@ run_case() {
 # Add a new smoke test by writing a test_* function below and adding one
 # entry to the CASES array further down — no CI workflow changes needed.
 
+# Asserts the image reports the release it was published as, built from a clean
+# tree — the two halves of #1133. EXPECTED_VERSION is the exact version required;
+# unset for non-release builds, which are tagged with a sha and report dev+<sha>.
+test_version() {
+  local full short
+  full="$(docker run --rm -e KOSLI_NO_UPDATE_CHECK=1 "${IMAGE}:${TAG}" version)" || return 1
+  echo "$full"
+
+  if ! grep -q 'GitTreeState:"clean"' <<< "$full"; then
+    echo "expected GitTreeState:\"clean\"" >&2
+    return 1
+  fi
+
+  short="$(docker run --rm -e KOSLI_NO_UPDATE_CHECK=1 "${IMAGE}:${TAG}" version --short)" || return 1
+  echo "version --short: ${short}"
+
+  if [ -n "${EXPECTED_VERSION:-}" ]; then
+    if [ "$short" != "$EXPECTED_VERSION" ]; then
+      echo "expected version ${EXPECTED_VERSION}, got ${short}" >&2
+      return 1
+    fi
+  elif ! grep -qE '^dev\+[0-9a-f]{7,}$' <<< "$short"; then
+    echo "expected dev+<sha> for a non-release build, got ${short}" >&2
+    return 1
+  fi
+}
+
 test_attest_artifact_dir() {
   local commit_sha
   commit_sha="$(git -C "$REPO_ROOT" rev-parse HEAD)" || return 1
@@ -93,8 +121,11 @@ test_attest_artifact_dir() {
 
 # --- Run all cases ------------------------------------------------------
 # Add a case by adding one entry here alongside its test_* function above.
+# Entries are "<case-name>:<test-function>" — the name labels the case in the
+# CI log and the results file; neither field may contain a colon.
 
 CASES=(
+  "version:test_version"
   "attest-artifact-dir:test_attest_artifact_dir"
 )
 


### PR DESCRIPTION
Published container images reported themselves as `dev+<sha>` with GitTreeState `dirty`, so `kosli version` inside a container could not name the release it was running. Two independent causes, both in the Docker build path rather than in the Go code:

- The build context was a deny-all allow-list keeping only cmd/, internal/, Makefile, go.* and .git/. With .git/ present but 153 tracked files absent, `git status --porcelain` reported every excluded file as deleted and the Makefile's GIT_DIRTY resolved to "dirty". Topping the allow-list up was not an option: the tracked tree has 43 distinct top-level entries, so a correct allow-list names all 43, and any new top-level file would silently make images "dirty" again. Reversed to a deny-list of git-ignored artefacts. Measured cost: 1.10 MiB of extra context (6.17 -> 7.27 MiB of tracked files), against the 2.20 MiB .git/ the allow-list already shipped.

- The build job checked out with fetch-depth: 3 and no fetch-tags, which per actions/checkout fetches no tags at all, so `git describe --exact-match` found nothing, BINARY_VERSION was empty and the version ldflag was skipped entirely, leaving the "dev" default in internal/version/version.go.

Both failures were silent: an empty `BINARY_VERSION` omits the ldflag rather than failing, so a release build looked identical to a dev build, and `GIT_DIRTY` cannot distinguish an edited file from a missing one. Nothing ever read the published image's version back. This was affecting releases since at least May 2024.

A `version` smoke case now asserts the image reports exactly the tag it is published under (`dev+<sha>` for non-release builds) from a clean tree, so neither cause can return unnoticed.

Fixes #1133

<!-- What does this PR change and why? Link any related issue. -->

### Checklist

- [x] **Docs** are autogenerated from CLI help — make sure the help text reflects your changes
- [x] **Helm chart** (`charts/k8s-reporter/`) updated, if needed. Note: these changes live in a **separate PR**
- [x] **Terraform provider** and related changes ([terraform-provider-kosli](https://github.com/kosli-dev/terraform-provider-kosli), [terraform-aws-evidence-reporter](https://github.com/kosli-dev/terraform-aws-evidence-reporter), [terraform-aws-kosli-reporter](https://github.com/kosli-dev/terraform-aws-kosli-reporter)) updated, if needed
