### PR TITLE
fix(docs): minor Mintify docs generation fixes

### DIFF
--- a/cmd/kosli/attestJira.go
+++ b/cmd/kosli/attestJira.go
@@ -69,11 +69,11 @@ If the ^--ignore-branch-match^ is set, the branch name is not parsed for a match
 
 The found issue references will be checked against Jira to confirm their existence.
 The attestation is reported in all cases, and its compliance status depends on referencing
-existing Jira issues.  
-If you have wrong Jira credentials or wrong Jira-base-url it will be reported as non existing Jira issue.
-This is because Jira returns same 404 error code in all cases. When Jira's response shows that it did not
-accept the credentials, a warning naming them is printed and the issue is reported as not confirmed rather
-than silently as missing; run with ^--debug^ to see the status Jira returned for each issue.
+existing Jira issues.
+
+A wrong base URL still surfaces as a non-existent issue because Jira returns 404 either way,
+but a credential rejection is detected and reported as not confirmed, with a warning identifying
+the credentials. Use ^--debug^ to see the status Jira returned per issue.
 
 The ^--jira-issue-fields^ can be used to include fields from the jira issue. By default no fields
 are included. ^*all^ will give all fields. Using ^--jira-issue-fields "*all" --dry-run^ will give you

--- a/cmd/kosli/attestJira.go
+++ b/cmd/kosli/attestJira.go
@@ -71,9 +71,10 @@ The found issue references will be checked against Jira to confirm their existen
 The attestation is reported in all cases, and its compliance status depends on referencing
 existing Jira issues.
 
-A wrong base URL still surfaces as a non-existent issue because Jira returns 404 either way,
-but a credential rejection is detected and reported as not confirmed, with a warning identifying
-the credentials. Use ^--debug^ to see the status Jira returned per issue.
+An unreachable or wrong base URL still surfaces as a non-existent issue, because Jira answers 404
+both for an issue that does not exist and for one you may not view. A credential rejection, however,
+is detected and reported as not confirmed, with a warning identifying the credentials.
+Use ^--debug^ to see the status Jira returned per issue.
 
 The ^--jira-issue-fields^ can be used to include fields from the jira issue. By default no fields
 are included. ^*all^ will give all fields. Using ^--jira-issue-fields "*all" --dry-run^ will give you

--- a/cmd/kosli/attestJira.go
+++ b/cmd/kosli/attestJira.go
@@ -71,10 +71,11 @@ The found issue references will be checked against Jira to confirm their existen
 The attestation is reported in all cases, and its compliance status depends on referencing
 existing Jira issues.
 
-An unreachable or wrong base URL still surfaces as a non-existent issue, because Jira answers 404
-both for an issue that does not exist and for one you may not view. A credential rejection, however,
-is detected and reported as not confirmed, with a warning identifying the credentials.
-Use ^--debug^ to see the status Jira returned per issue.
+A reachable but wrong base URL still surfaces as a non-existent issue, because Jira answers 404
+both for an issue that does not exist and for one you may not view. A base URL that cannot be
+reached is reported as not confirmed, with the transport error as the reason. A credential
+rejection is likewise detected and reported as not confirmed, with a warning identifying the
+credentials. Use ^--debug^ to see the status Jira returned per issue.
 
 The ^--jira-issue-fields^ can be used to include fields from the jira issue. By default no fields
 are included. ^*all^ will give all fields. Using ^--jira-issue-fields "*all" --dry-run^ will give you

--- a/cmd/kosli/attestSonar.go
+++ b/cmd/kosli/attestSonar.go
@@ -49,8 +49,8 @@ exponential backoff between retries. Once the results are available they are att
 2. Providing the Sonar project key and either the revision or the pull-request ID of the scan (plus the SonarQube server URL if relevant).
 For branch scans: if running the Kosli CLI in some CI/CD pipeline, the revision is defaulted to the commit SHA. If you are running the command locally,
 or have overriden the revision in SonarQube via parameters to the Sonar scanner, you can provide the correct revision using the ^--sonar-revision^ flag.
-If the scan ran on a branch other than the project's main branch in SonarQube, also provide the branch name using the ^--sonar-branch^ flag:
-SonarQube searches only the main branch unless it is told otherwise, so without it the scan cannot be found.
+If the scan ran on a branch other than the project's main branch in SonarQube, also provide the branch name using the ^--sonar-branch^ flag.
+By default SonarQube only searches the main branch, unless it is told otherwise.
 For pull request scans: provide the pull-request ID using the ^--pull-request^ flag instead of the revision.
 Kosli then finds the scan results for the specified project key and revision or pull-request ID.
 

--- a/cmd/kosli/attestSonar.go
+++ b/cmd/kosli/attestSonar.go
@@ -50,7 +50,7 @@ exponential backoff between retries. Once the results are available they are att
 For branch scans: if running the Kosli CLI in some CI/CD pipeline, the revision is defaulted to the commit SHA. If you are running the command locally,
 or have overriden the revision in SonarQube via parameters to the Sonar scanner, you can provide the correct revision using the ^--sonar-revision^ flag.
 If the scan ran on a branch other than the project's main branch in SonarQube, also provide the branch name using the ^--sonar-branch^ flag.
-By default SonarQube only searches the main branch, unless it is told otherwise.
+SonarQube only searches the project's main branch unless told otherwise, so without this flag the scan cannot be found.
 For pull request scans: provide the pull-request ID using the ^--pull-request^ flag instead of the revision.
 Kosli then finds the scan results for the specified project key and revision or pull-request ID.
 

--- a/cmd/kosli/snapshotAzureApps.go
+++ b/cmd/kosli/snapshotAzureApps.go
@@ -20,10 +20,10 @@ For Azure Function apps or Web apps which uses zip deployment the fingerprint is
 content of the zip file. This is the same as unzipping the file and then running ^kosli fingerprint -t dir yourDirName^.
 When doing zip deployment the WEBSITE_RUN_FROM_PACKAGE must NOT be set to 1. This will cause the azure
 API calls to not return the content of what is running on the server and fingerprint calculations
-will not match. See 
+will not match. See
 https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings#website_run_from_package
 
-For zip-deployed apps, the fingerprint honours a ^.kosli_ignore^ file at the root of the deployed package.
+For zip-deployed apps, the fingerprint respects ^.kosli_ignore^ file at the root of the deployed package.
 ` + kosliIgnoreDesc + azureAuthDesc
 
 const snapshotAzureAppsExample = `

--- a/cmd/kosli/snapshotAzureApps.go
+++ b/cmd/kosli/snapshotAzureApps.go
@@ -23,7 +23,7 @@ API calls to not return the content of what is running on the server and fingerp
 will not match. See
 https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings#website_run_from_package
 
-For zip-deployed apps, the fingerprint respects ^.kosli_ignore^ file at the root of the deployed package.
+For zip-deployed apps, the fingerprint respects a ^.kosli_ignore^ file at the root of the deployed package.
 ` + kosliIgnoreDesc + azureAuthDesc
 
 const snapshotAzureAppsExample = `

--- a/internal/docgen/mintlify.go
+++ b/internal/docgen/mintlify.go
@@ -117,6 +117,8 @@ func (MintlifyFormatter) ExampleUseCases(commandName, example string) string {
 			exampleLines := all[i]
 			title := strings.Trim(exampleLines[0], ":")
 			if len(title) > 0 {
+				// A raw caret reaches the rendered accordion title verbatim, use supported backticks.
+				title = strings.ReplaceAll(title, "^", "`")
 				// Double quotes would terminate the JSX title attribute and break the MDX build.
 				title = strings.ReplaceAll(title, "\"", "'")
 				fmt.Fprintf(&b, "<Accordion title=\"%s\">\n", strings.TrimSpace(title[1:]))

--- a/internal/docgen/mintlify_test.go
+++ b/internal/docgen/mintlify_test.go
@@ -175,6 +175,27 @@ func TestMintlifyExampleUseCasesEscapesQuotesInTitle(t *testing.T) {
 	}
 }
 
+func TestMintlifyExampleUseCasesReplacesCaretsInTitle(t *testing.T) {
+	f := MintlifyFormatter{}
+	example := "# create a type with schema and ^jq^ evaluation rules:\nkosli create attestation-type foo"
+	got := f.ExampleUseCases("kosli create attestation-type", example)
+	if !strings.Contains(got, "<Accordion title=\"create a type with schema and `jq` evaluation rules\">") {
+		t.Errorf("expected carets in title to be replaced with backticks, got:\n%s", got)
+	}
+	if strings.Contains(got, "^jq^") {
+		t.Errorf("expected no raw carets inside the title attribute, got:\n%s", got)
+	}
+}
+
+func TestMintlifyExampleUseCasesKeepsCaretsInExampleBody(t *testing.T) {
+	f := MintlifyFormatter{}
+	example := "# filter lines starting with foo:\nkosli list flows | grep '^foo'"
+	got := f.ExampleUseCases("kosli list flows", example)
+	if !strings.Contains(got, "grep '^foo'") {
+		t.Errorf("expected carets in the shell example body to be left alone, got:\n%s", got)
+	}
+}
+
 func TestMintlifyLinkHandler(t *testing.T) {
 	f := MintlifyFormatter{}
 	got := f.LinkHandler("kosli_attest_snyk.md")


### PR DESCRIPTION
<!-- What does this PR change and why? Link any related issue. -->
* Adjust help text for commands and improve readability and align with changes
* Properly parse carets in the accordion titles when constructing docs pages


### Checklist

- [x] **Docs** are autogenerated from CLI help — make sure the help text reflects your changes
- [x] **Helm chart** (`charts/k8s-reporter/`) updated, if needed. Note: these changes live in a **separate PR**
- [x] **Terraform provider** and related changes ([terraform-provider-kosli](https://github.com/kosli-dev/terraform-provider-kosli), [terraform-aws-evidence-reporter](https://github.com/kosli-dev/terraform-aws-evidence-reporter), [terraform-aws-kosli-reporter](https://github.com/kosli-dev/terraform-aws-kosli-reporter)) updated, if needed
