### PR TITLE
ci(release): generate the full changelog, including What's Changed list

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,7 +30,6 @@ tmp
 client_reference
 **/*~
 TODO.md
-release_notes.md
 .claude/settings.local.json
 .idea
 .vscode

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,6 @@
+# Release notes GitHub generates, requested by .goreleaser.yml's github-native
+# changelog.
+changelog:
+  exclude:
+    labels:
+      - dependencies # Dependabot labels every PR it opens; see dependabot.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,34 +164,34 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
-      # Use release notes from the tag body when present (set by interactive `make release` or `make release tag=vX.Y.Z` with dist/release_notes.md). Otherwise GoReleaser uses its default changelog.
-      # Write to repo root so GoReleaser's --clean (which removes dist/) does not delete the file before it is read.
-      - name: Get release notes from tag
+      # GoReleaser puts RELEASE_HEADER above the changelog it generates.
+      - name: Export release notes from tag
         id: get-tag-notes
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
-          # %(contents), not %(contents:body): the latter drops the tag message's
-          # first paragraph as a "subject", silently swallowing the first heading
-          # or bullet of the release notes. Unlike %(contents:body), %(contents)
-          # keeps the signature of a signed tag, so cut it off at its marker.
+          # %(contents:body) would drop the first paragraph as a "subject",
+          # swallowing the first heading; %(contents) keeps a signed tag's
+          # signature, so cut that off instead.
           BODY=$(git tag -l --format='%(contents)' "$TAG" \
             | sed '/^-----BEGIN [A-Z ]*SIGNATURE-----$/,$d')
-          # `make release tag=vX.Y.Z` with no dist/release_notes.md tags with the
-          # version as the whole message; that is not release notes.
+          # `make release tag=vX.Y.Z` with no notes tags with the version alone.
           if [ "$(printf '%s' "$BODY" | tr -d '[:space:]')" = "$TAG" ]; then
             BODY=""
           fi
-          if [ -n "$BODY" ]; then
-            printf '%s' "$BODY" > release_notes.md
-            echo "args=--release-notes=release_notes.md" >> $GITHUB_OUTPUT
-          fi
+          # Always define it — the header template errors on a missing key.
+          # $GITHUB_ENV, not a step output: multi-line values break `env:`.
+          {
+            echo "RELEASE_HEADER<<KOSLI_NOTES_EOF"
+            printf '%s\n' "$BODY"
+            echo "KOSLI_NOTES_EOF"
+          } >> "$GITHUB_ENV"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser-pro
           version: '~> v2' # latest
-          args: release --clean ${{ steps.get-tag-notes.outputs.args }}
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FURY_TOKEN: ${{ secrets.FURY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,6 @@ jobs:
 
       # GoReleaser puts RELEASE_HEADER above the changelog it generates.
       - name: Export release notes from tag
-        id: get-tag-notes
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           # %(contents:body) would drop the first paragraph as a "subject",
@@ -178,12 +177,14 @@ jobs:
           if [ "$(printf '%s' "$BODY" | tr -d '[:space:]')" = "$TAG" ]; then
             BODY=""
           fi
-          # Always define it — the header template errors on a missing key.
           # $GITHUB_ENV, not a step output: multi-line values break `env:`.
+          # Random delimiter — a fixed one appearing in the body would break the
+          # write, or let the body define env vars of its own.
+          DELIM="EOF_$(openssl rand -hex 16)"
           {
-            echo "RELEASE_HEADER<<KOSLI_NOTES_EOF"
+            echo "RELEASE_HEADER<<$DELIM"
             printf '%s\n' "$BODY"
-            echo "KOSLI_NOTES_EOF"
+            echo "$DELIM"
           } >> "$GITHUB_ENV"
 
       - name: Run GoReleaser

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ npm/*/kosli*.tgz
 *~
 /.idea
 tmp/
-release_notes.md
 junit.xml
 junit-test-results/.
 .claude/settings.local.json

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -121,9 +121,11 @@ release:
   prerelease: auto
   draft: false
   disable: false
-  # Release notes from the tag body, exported by the release workflow.
+  # Release notes from the tag body, exported by the release workflow. `index`,
+  # not `.Env.RELEASE_HEADER`: templates run with missingkey=error, so the dot
+  # form fails a local `make build_release`, where the var is unset.
   header: |
-    {{ .Env.RELEASE_HEADER }}
+    {{ index .Env "RELEASE_HEADER" }}
 
 changelog:
   # GitHub's "What's Changed" PR list. Ignores sort/filters/groups — ordering

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -123,7 +123,7 @@ release:
   disable: false
   # Release notes from the tag body, exported by the release workflow. `index`,
   # not `.Env.RELEASE_HEADER`: templates run with missingkey=error, so the dot
-  # form fails a local `make build_release`, where the var is unset.
+  # form errors on any run where the var is unset (e.g. a local goreleaser run).
   header: |
     {{ index .Env "RELEASE_HEADER" }}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -121,7 +121,11 @@ release:
   prerelease: auto
   draft: false
   disable: false
+  # Release notes from the tag body, exported by the release workflow.
+  header: |
+    {{ .Env.RELEASE_HEADER }}
 
 changelog:
-  use: git # github(-native)
-  sort: asc
+  # GitHub's "What's Changed" PR list. Ignores sort/filters/groups — ordering
+  # and exclusions live in .github/release.yml.
+  use: github-native

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ add_test_tag:
 
 build_release: check_dirty add_test_tag
 	rm -rf dist/
-	goreleaser release --skip-publish --debug
+	goreleaser release --skip=publish,changelog --verbose
 	@git tag -d v0.0.99 2> /dev/null || true
 
 clean: ## Clean build artefacts
@@ -215,7 +215,7 @@ docs: build ## Generate CLI reference docs (use CMD="attest snyk" for one comman
 	@echo "Docs written to client_reference/"
 
 # Suggest next semver and changelog using Claude.
-# Writes changelog to dist/release_notes.md for use with goreleaser --release-notes.
+# Writes changelog to dist/release_notes.md, used as the annotated tag's body.
 # Requires: jq, curl, op (1Password CLI). API key from 1Password via op.
 # Usage: make suggest-version-ai [BASE_REF=v1.2.3]
 suggest-version-ai: ## Suggest next version using AI

--- a/bin/suggest-version-ai.sh
+++ b/bin/suggest-version-ai.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Suggest next semver and changelog by sending the git diff to Claude.
-# Does not rely on commit messages. Changelog is suitable for GoReleaser --release-notes.
+# Does not rely on commit messages. Changelog will be attached as a header to release Changelog.
 #
 # Auth (first non-empty wins):
 #   - ANTHROPIC_API_KEY: call Claude directly.

--- a/release-guide.md
+++ b/release-guide.md
@@ -45,7 +45,16 @@ make release
 
 1. A script uses Claude to suggest the next semver and draft release notes from the **git diff** (no commit messages). It reads the API key from 1Password via `op` using a default secret reference (vault/item/field); you can override with `OP_ANTHROPIC_API_KEY_REF` if your item lives elsewhere.
 2. You see the suggested tag and release notes. You can press Enter to open your editor and edit `dist/release_notes.md`, or Enter to skip.
-3. You are prompted: **Create tag vX.Y.Z and push? [y/N]**. On **y**, an annotated tag is created with the release notes as the tag body and pushed. The `release.yml` workflow runs on GitHub; it reads the notes from the tag body and passes them to GoReleaser for the GitHub Release. On **n**, nothing is pushed.
+3. You are prompted: **Create tag vX.Y.Z and push? [y/N]**. On **y**, an annotated tag is created with the release notes as the tag body and pushed. The `release.yml` workflow runs on GitHub; it reads the notes from the tag body and passes them to GoReleaser, which puts them at the top of the GitHub Release. On **n**, nothing is pushed.
+
+### Release body layout
+
+The release body has two parts:
+
+1. The notes carried in the tag body — AI-drafted, edited by you, describing user-facing CLI changes.
+2. GitHub's **What's Changed** list of merged PRs and the **Full Changelog** compare link, from GoReleaser's `github-native` changelog. Dependency bumps are filtered out by `.github/release.yml`.
+
+A tag with no notes gets part 2 only.
 
 ### Fallback: release with an explicit tag
 
@@ -55,7 +64,7 @@ If you don’t want the AI flow (e.g. 1Password/`op` not available or the sugges
 make release tag=v2.x.y
 ```
 
-This checks the branch is up to date, creates an annotated tag (using `dist/release_notes.md` as the tag body if that file exists, otherwise the version string), and pushes it. No prompt. The release workflow runs as above; if the tag has no body, GoReleaser uses its default changelog on the GitHub Release.
+This checks the branch is up to date, creates an annotated tag (using `dist/release_notes.md` as the tag body if that file exists, otherwise the version string), and pushes it. No prompt. The release workflow runs as above; if the tag has no notes, the release body is the auto-generated **What's Changed** list alone.
 
 ### 1. Pre-build
 


### PR DESCRIPTION
Make sure to include the notes drafted by `make release` as well as GitHub "What's Changed" generated ones, which needed manual action now.

Changes:

- `.goreleaser.yml`: add `release.header`, fed from RELEASE_HEADER, and switch the changelog to github-native for the merged-PR list and compare link.
- `release.yml`: export the tag body as RELEASE_HEADER via $GITHUB_ENV, always defined so the header template does not error on a missing key, and drop `--release-notes`.
- `.github/release.yml`: exclude PRs labelled `dependencies`. github-native ignores GoReleaser's own filters, and half of v2.39.0's list was Dependabot (12 of 24 commits). Takes effect once this is on the default branch.

The signature-stripping and version-only-message guards are unchanged.

<!-- What does this PR change and why? Link any related issue. -->

### Checklist

- [x] **Docs** are autogenerated from CLI help — make sure the help text reflects your changes
- [x] **Helm chart** (`charts/k8s-reporter/`) updated, if needed. Note: these changes live in a **separate PR**
- [x] **Terraform provider** and related changes ([terraform-provider-kosli](https://github.com/kosli-dev/terraform-provider-kosli), [terraform-aws-evidence-reporter](https://github.com/kosli-dev/terraform-aws-evidence-reporter), [terraform-aws-kosli-reporter](https://github.com/kosli-dev/terraform-aws-kosli-reporter)) updated, if needed
