### PR TITLE
fix: paginate PR commits and reviews

### DIFF
--- a/internal/azure/azure.go
+++ b/internal/azure/azure.go
@@ -169,9 +169,13 @@ func (c *AzureConfig) GetPullRequestCommits(pr git.GitPullRequest) ([]types.Comm
 		Project:       &c.Project,
 	}, defaultMaxPages)
 	if err != nil {
-		// fetchAzurePRCommits cannot name the PR without risking a nil
-		// dereference, so the identity is added here.
-		return commits, fmt.Errorf("draining commits for pull request %d: %w", *pr.PullRequestId, err)
+		// A nil id is the one input the SDK rejects outright, so it is also the
+		// only one that reaches here without an id to name.
+		prID := "with no id"
+		if pr.PullRequestId != nil {
+			prID = strconv.Itoa(*pr.PullRequestId)
+		}
+		return commits, fmt.Errorf("draining commits for pull request %s: %w", prID, err)
 	}
 
 	for _, commit := range prCommits {

--- a/internal/azure/azure.go
+++ b/internal/azure/azure.go
@@ -158,21 +158,21 @@ func (c *AzureConfig) GetPullRequestCommits(pr git.GitPullRequest) ([]types.Comm
 	commits := []types.Commit{}
 
 	ctx := context.Background()
-	client, err := NewAzureClientFromToken(ctx, c.Token, c.OrgURL)
+	client, err := newPRCommitsClient(ctx, c.Token, c.OrgURL)
 	if err != nil {
 		return commits, err
 	}
 
-	prCommitsResponse, err := client.GetPullRequestCommits(ctx, git.GetPullRequestCommitsArgs{
+	prCommits, err := fetchAzurePRCommits(ctx, client, git.GetPullRequestCommitsArgs{
 		RepositoryId:  &c.Repository,
 		PullRequestId: pr.PullRequestId,
 		Project:       &c.Project,
-	})
+	}, defaultMaxPages)
 	if err != nil {
 		return commits, err
 	}
 
-	for _, commit := range prCommitsResponse.Value {
+	for _, commit := range prCommits {
 		commits = append(commits, commitFromAzureCommit(commit, *pr.SourceRefName))
 	}
 

--- a/internal/azure/azure.go
+++ b/internal/azure/azure.go
@@ -169,7 +169,9 @@ func (c *AzureConfig) GetPullRequestCommits(pr git.GitPullRequest) ([]types.Comm
 		Project:       &c.Project,
 	}, defaultMaxPages)
 	if err != nil {
-		return commits, err
+		// fetchAzurePRCommits cannot name the PR without risking a nil
+		// dereference, so the identity is added here.
+		return commits, fmt.Errorf("draining commits for pull request %d: %w", *pr.PullRequestId, err)
 	}
 
 	for _, commit := range prCommits {

--- a/internal/azure/pr_commits.go
+++ b/internal/azure/pr_commits.go
@@ -1,0 +1,56 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops/git"
+)
+
+const (
+	// defaultMaxPages bounds every pagination loop. It guards against an API
+	// that keeps reporting more results; it is not a tunable limit.
+	defaultMaxPages = 100
+	// azurePageSize is the $top sent per request. Nothing was sent before, so
+	// only Azure's first page was ever read (#1082).
+	azurePageSize = 100
+)
+
+// prCommitsClient is the slice of git.Client that PR commit retrieval needs,
+// narrowed so tests can drive the continuation-token loop with a fake.
+type prCommitsClient interface {
+	GetPullRequestCommits(context.Context, git.GetPullRequestCommitsArgs) (*git.GetPullRequestCommitsResponseValue, error)
+}
+
+// newPRCommitsClient builds the client used by GetPullRequestCommits.
+// Replaced in tests, restored with t.Cleanup.
+var newPRCommitsClient = func(ctx context.Context, token, orgURL string) (prCommitsClient, error) {
+	return NewAzureClientFromToken(ctx, token, orgURL)
+}
+
+// fetchAzurePRCommits drains the PR commits endpoint. Azure returns at most
+// $top commits per call plus an x-ms-continuationtoken; ignoring that token
+// silently truncated the commit list (#1082). A cap or a repeated token errors
+// rather than returning early, since quietly stopping is the bug being fixed.
+func fetchAzurePRCommits(ctx context.Context, client prCommitsClient,
+	args git.GetPullRequestCommitsArgs, maxPages int) ([]git.GitCommitRef, error) {
+	all := []git.GitCommitRef{}
+	top := azurePageSize
+	args.Top = &top
+	for pages := 0; pages < maxPages; pages++ {
+		response, err := client.GetPullRequestCommits(ctx, args)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, response.Value...)
+		if response.ContinuationToken == "" {
+			return all, nil
+		}
+		if args.ContinuationToken != nil && *args.ContinuationToken == response.ContinuationToken {
+			return nil, fmt.Errorf("continuation token %q did not advance", response.ContinuationToken)
+		}
+		token := response.ContinuationToken
+		args.ContinuationToken = &token
+	}
+	return nil, fmt.Errorf("aborting after %d pages of pull request commits", maxPages)
+}

--- a/internal/azure/pr_commits_test.go
+++ b/internal/azure/pr_commits_test.go
@@ -1,0 +1,138 @@
+package azure
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/git"
+	"github.com/stretchr/testify/require"
+)
+
+// fakePRCommitsClient returns canned pages and records the args of every call,
+// so tests can assert Top and the continuation token were sent.
+type fakePRCommitsClient struct {
+	pages []*git.GetPullRequestCommitsResponseValue
+	err   error
+	calls []git.GetPullRequestCommitsArgs
+}
+
+func (f *fakePRCommitsClient) GetPullRequestCommits(_ context.Context,
+	args git.GetPullRequestCommitsArgs) (*git.GetPullRequestCommitsResponseValue, error) {
+	f.calls = append(f.calls, args)
+	if f.err != nil {
+		return nil, f.err
+	}
+	if len(f.calls) > len(f.pages) {
+		return f.pages[len(f.pages)-1], nil
+	}
+	return f.pages[len(f.calls)-1], nil
+}
+
+func commitRefs(shas ...string) []git.GitCommitRef {
+	refs := []git.GitCommitRef{}
+	for _, sha := range shas {
+		sha, comment, url := sha, "msg", "https://dev.azure.com/o/_git/r/commit/"+sha
+		name, email := "Ada", "ada@example.com"
+		date := azuredevops.Time{Time: t0}
+		refs = append(refs, git.GitCommitRef{
+			CommitId: &sha,
+			Comment:  &comment,
+			Url:      &url,
+			Author:   &git.GitUserDate{Name: &name, Email: &email, Date: &date},
+		})
+	}
+	return refs
+}
+
+var t0 = time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
+func page(token string, shas ...string) *git.GetPullRequestCommitsResponseValue {
+	return &git.GetPullRequestCommitsResponseValue{Value: commitRefs(shas...), ContinuationToken: token}
+}
+
+func shasOf(refs []git.GitCommitRef) []string {
+	shas := []string{}
+	for _, r := range refs {
+		shas = append(shas, *r.CommitId)
+	}
+	return shas
+}
+
+func TestFetchAzurePRCommits_FollowsContinuationToken(t *testing.T) {
+	client := &fakePRCommitsClient{pages: []*git.GetPullRequestCommitsResponseValue{
+		page("tok1", "sha1", "sha2"),
+		page("", "sha3"),
+	}}
+
+	refs, err := fetchAzurePRCommits(context.Background(), client, git.GetPullRequestCommitsArgs{}, defaultMaxPages)
+	require.NoError(t, err)
+	require.Equal(t, []string{"sha1", "sha2", "sha3"}, shasOf(refs))
+	require.Len(t, client.calls, 2)
+	require.Equal(t, azurePageSize, *client.calls[0].Top)
+	require.Nil(t, client.calls[0].ContinuationToken)
+	require.Equal(t, "tok1", *client.calls[1].ContinuationToken)
+}
+
+func TestFetchAzurePRCommits_SingleCallWhenTokenEmpty(t *testing.T) {
+	client := &fakePRCommitsClient{pages: []*git.GetPullRequestCommitsResponseValue{page("", "sha1")}}
+
+	refs, err := fetchAzurePRCommits(context.Background(), client, git.GetPullRequestCommitsArgs{}, defaultMaxPages)
+	require.NoError(t, err)
+	require.Len(t, refs, 1)
+	require.Len(t, client.calls, 1)
+}
+
+func TestFetchAzurePRCommits_ErrorsWhenTokenRepeats(t *testing.T) {
+	client := &fakePRCommitsClient{pages: []*git.GetPullRequestCommitsResponseValue{
+		page("stuck", "sha1"),
+		page("stuck", "sha2"),
+	}}
+
+	_, err := fetchAzurePRCommits(context.Background(), client, git.GetPullRequestCommitsArgs{}, defaultMaxPages)
+	require.ErrorContains(t, err, "did not advance")
+	require.Len(t, client.calls, 2)
+}
+
+func TestFetchAzurePRCommits_ErrorsPastMaxPages(t *testing.T) {
+	client := &fakePRCommitsClient{pages: []*git.GetPullRequestCommitsResponseValue{
+		page("a", "sha1"), page("b", "sha2"), page("c", "sha3"),
+	}}
+
+	_, err := fetchAzurePRCommits(context.Background(), client, git.GetPullRequestCommitsArgs{}, 2)
+	require.ErrorContains(t, err, "2 pages")
+	require.Len(t, client.calls, 2)
+}
+
+func TestFetchAzurePRCommits_PropagatesError(t *testing.T) {
+	wantErr := errors.New("boom")
+	client := &fakePRCommitsClient{err: wantErr}
+
+	_, err := fetchAzurePRCommits(context.Background(), client, git.GetPullRequestCommitsArgs{}, defaultMaxPages)
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestGetPullRequestCommits_MapsEveryPage(t *testing.T) {
+	client := &fakePRCommitsClient{pages: []*git.GetPullRequestCommitsResponseValue{
+		page("tok1", "sha1"),
+		page("", "sha2"),
+	}}
+	original := newPRCommitsClient
+	newPRCommitsClient = func(context.Context, string, string) (prCommitsClient, error) { return client, nil }
+	t.Cleanup(func() { newPRCommitsClient = original })
+
+	prID, sourceRef := 5, "refs/heads/feature"
+	config := &AzureConfig{Token: "t", OrgURL: "https://dev.azure.com/o", Project: "p", Repository: "r"}
+	commits, err := config.GetPullRequestCommits(git.GitPullRequest{
+		PullRequestId: &prID, SourceRefName: &sourceRef,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, commits, 2)
+	require.Equal(t, "sha1", commits[0].SHA)
+	require.Equal(t, "sha2", commits[1].SHA)
+	require.Equal(t, sourceRef, commits[0].Branch)
+	require.Equal(t, "Ada <ada@example.com>", commits[0].Author)
+}

--- a/internal/azure/pr_commits_test.go
+++ b/internal/azure/pr_commits_test.go
@@ -136,3 +136,21 @@ func TestGetPullRequestCommits_MapsEveryPage(t *testing.T) {
 	require.Equal(t, sourceRef, commits[0].Branch)
 	require.Equal(t, "Ada <ada@example.com>", commits[0].Author)
 }
+
+// A nil PullRequestId is the one input the SDK rejects outright
+// (git/client.go:3434), so it is also the only input that reaches the error
+// wrap without an id — which must therefore not dereference it.
+func TestGetPullRequestCommits_NilPullRequestIDReturnsErrorNotPanic(t *testing.T) {
+	client := &fakePRCommitsClient{err: errors.New("args.PullRequestId")}
+	original := newPRCommitsClient
+	newPRCommitsClient = func(context.Context, string, string) (prCommitsClient, error) { return client, nil }
+	t.Cleanup(func() { newPRCommitsClient = original })
+
+	sourceRef := "refs/heads/feature"
+	config := &AzureConfig{Token: "t", OrgURL: "https://dev.azure.com/o", Project: "p", Repository: "r"}
+
+	_, err := config.GetPullRequestCommits(git.GitPullRequest{SourceRefName: &sourceRef})
+
+	require.ErrorContains(t, err, "args.PullRequestId", "the SDK's reason must survive")
+	require.ErrorContains(t, err, "pull request", "the wrap must still say what failed")
+}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -581,9 +581,21 @@ func (c *GithubConfig) PullRequestsForCommit(commit string) ([]*gh.PullRequest, 
 		return []*gh.PullRequest{}, err
 	}
 
-	pullrequests, _, err := client.PullRequests.ListPullRequestsWithCommit(ctx, c.Org, c.Repository,
-		commit, &gh.PullRequestListOptions{})
-	return pullrequests, err
+	opts := &gh.PullRequestListOptions{ListOptions: gh.ListOptions{PerPage: restPageSize}}
+	all := []*gh.PullRequest{}
+	for pages := 0; pages < c.maxPages(); pages++ {
+		pullrequests, resp, err := client.PullRequests.ListPullRequestsWithCommit(ctx, c.Org, c.Repository,
+			commit, opts)
+		if err != nil {
+			return all, err
+		}
+		all = append(all, pullrequests...)
+		if resp.NextPage == 0 {
+			return all, nil
+		}
+		opts.Page = resp.NextPage
+	}
+	return all, fmt.Errorf("aborting after %d pages of pull requests for commit %s", c.maxPages(), commit)
 }
 
 // GetPullRequestApprovers returns a list of approvers for a given pull request
@@ -594,16 +606,26 @@ func (c *GithubConfig) GetPullRequestApprovers(number int) ([]string, error) {
 	if err != nil {
 		return approvers, err
 	}
-	reviews, _, err := client.PullRequests.ListReviews(ctx, c.Org, c.Repository, number, &gh.ListOptions{})
-	if err != nil {
-		return approvers, err
-	}
-	for _, r := range reviews {
-		if r.GetState() == "APPROVED" {
-			approvers = append(approvers, r.GetUser().GetLogin())
+	// ListReviews returns every review event, not just approvals, so the
+	// APPROVED filter below must run over all pages: an approval past page one
+	// was previously dropped outright (#1082).
+	opts := &gh.ListOptions{PerPage: restPageSize}
+	for pages := 0; pages < c.maxPages(); pages++ {
+		reviews, resp, err := client.PullRequests.ListReviews(ctx, c.Org, c.Repository, number, opts)
+		if err != nil {
+			return approvers, err
 		}
+		for _, r := range reviews {
+			if r.GetState() == "APPROVED" {
+				approvers = append(approvers, r.GetUser().GetLogin())
+			}
+		}
+		if resp.NextPage == 0 {
+			return approvers, nil
+		}
+		opts.Page = resp.NextPage
 	}
-	return approvers, nil
+	return approvers, fmt.Errorf("aborting after %d pages of reviews for pull request %d", c.maxPages(), number)
 }
 
 func (c *GithubConfig) newPRGithubEvidence(pr *gh.PullRequest) (*types.PREvidence, error) {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -26,9 +26,9 @@ type GithubConfig struct {
 	Repository string
 	Debug      bool
 	// Sleep replaces the wait between GraphQL retries — every retry, including
-	// the follow-up page queries of both PR-evidence entry points. Nil means a
-	// real time.Sleep that honours context cancellation; setting it bypasses
-	// that, so leave it nil to exercise the cancellation path.
+	// the follow-up page queries of both PR-evidence entry points. Nil means an
+	// interruptible wait that returns as soon as the context is cancelled;
+	// setting it bypasses that, so leave it nil to exercise cancellation.
 	Sleep func(time.Duration)
 }
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -28,9 +28,6 @@ type GithubConfig struct {
 	// Sleep is called between retries in PREvidenceByPRNumber. Defaults to
 	// time.Sleep when nil. Override in tests to avoid real delays.
 	Sleep func(time.Duration)
-	// MaxPages bounds pagination loops; zero means defaultMaxPages. Set it in
-	// tests to keep the stuck-cursor cases cheap.
-	MaxPages int
 }
 
 type GithubFlagsTempValueHolder struct {
@@ -583,7 +580,7 @@ func (c *GithubConfig) PullRequestsForCommit(commit string) ([]*gh.PullRequest, 
 
 	opts := &gh.PullRequestListOptions{ListOptions: gh.ListOptions{PerPage: restPageSize}}
 	all := []*gh.PullRequest{}
-	for pages := 0; pages < c.maxPages(); pages++ {
+	for pages := 0; pages < defaultMaxPages; pages++ {
 		pullrequests, resp, err := client.PullRequests.ListPullRequestsWithCommit(ctx, c.Org, c.Repository,
 			commit, opts)
 		if err != nil {
@@ -595,7 +592,7 @@ func (c *GithubConfig) PullRequestsForCommit(commit string) ([]*gh.PullRequest, 
 		}
 		opts.Page = resp.NextPage
 	}
-	return all, fmt.Errorf("aborting after %d pages of pull requests for commit %s", c.maxPages(), commit)
+	return all, fmt.Errorf("aborting after %d pages of pull requests for commit %s", defaultMaxPages, commit)
 }
 
 // GetPullRequestApprovers returns a list of approvers for a given pull request
@@ -610,7 +607,7 @@ func (c *GithubConfig) GetPullRequestApprovers(number int) ([]string, error) {
 	// APPROVED filter below must run over all pages: an approval past page one
 	// was previously dropped outright (#1082).
 	opts := &gh.ListOptions{PerPage: restPageSize}
-	for pages := 0; pages < c.maxPages(); pages++ {
+	for pages := 0; pages < defaultMaxPages; pages++ {
 		reviews, resp, err := client.PullRequests.ListReviews(ctx, c.Org, c.Repository, number, opts)
 		if err != nil {
 			return approvers, err
@@ -625,7 +622,7 @@ func (c *GithubConfig) GetPullRequestApprovers(number int) ([]string, error) {
 		}
 		opts.Page = resp.NextPage
 	}
-	return approvers, fmt.Errorf("aborting after %d pages of reviews for pull request %d", c.maxPages(), number)
+	return approvers, fmt.Errorf("aborting after %d pages of reviews for pull request %d", defaultMaxPages, number)
 }
 
 func (c *GithubConfig) newPRGithubEvidence(pr *gh.PullRequest) (*types.PREvidence, error) {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -28,6 +28,9 @@ type GithubConfig struct {
 	// Sleep is called between retries in PREvidenceByPRNumber. Defaults to
 	// time.Sleep when nil. Override in tests to avoid real delays.
 	Sleep func(time.Duration)
+	// MaxPages bounds pagination loops; zero means defaultMaxPages. Set it in
+	// tests to keep the stuck-cursor cases cheap.
+	MaxPages int
 }
 
 type GithubFlagsTempValueHolder struct {
@@ -407,17 +410,11 @@ func (c *GithubConfig) PREvidenceByPRNumber(prNumber int) (*types.PREvidence, er
 				}
 				Commits struct {
 					Nodes    []graphqlCommitNode
-					PageInfo struct {
-						HasNextPage graphql.Boolean
-						EndCursor   graphql.String
-					}
+					PageInfo pageInfo
 				} `graphql:"commits(first: 100, after: $commitCursor)"`
 				Reviews struct {
 					Nodes    []graphqlReviewNode
-					PageInfo struct {
-						HasNextPage graphql.Boolean
-						EndCursor   graphql.String
-					}
+					PageInfo pageInfo
 				} `graphql:"reviews(first: 100, states: APPROVED, after: $reviewCursor)"`
 			} `graphql:"pullRequest(number: $prNumber)"`
 		} `graphql:"repository(owner: $owner, name: $repo)"`
@@ -431,21 +428,8 @@ func (c *GithubConfig) PREvidenceByPRNumber(prNumber int) (*types.PREvidence, er
 		"reviewCursor": (*graphql.String)(nil),
 	}
 
-	sleep := c.Sleep
-	if sleep == nil {
-		sleep = time.Sleep
-	}
-	delays := []time.Duration{0, 10 * time.Second, 20 * time.Second, 30 * time.Second}
-	for _, delay := range delays {
-		if delay > 0 {
-			sleep(delay)
-		}
-		err = client.Query(ctx, &query, variables)
-		if err == nil {
-			break
-		}
-	}
-	if err != nil {
+	run := c.queryWithRetry(client)
+	if err := run(ctx, &query, variables); err != nil {
 		return nil, err
 	}
 
@@ -459,10 +443,19 @@ func (c *GithubConfig) PREvidenceByPRNumber(prNumber int) (*types.PREvidence, er
 		mergeCommit = string(pr.MergeCommit.Oid)
 	}
 
+	commits, err := c.allPRCommits(ctx, run, prNumber, pr.Commits.Nodes, pr.Commits.PageInfo)
+	if err != nil {
+		return nil, err
+	}
+	reviews, err := c.allPRReviews(ctx, run, prNumber, pr.Reviews.Nodes, pr.Reviews.PageInfo)
+	if err != nil {
+		return nil, err
+	}
+
 	return buildPREvidence(
 		string(pr.URL), mergeCommit, string(pr.State), string(pr.Author.Login),
 		string(pr.CreatedAt), string(pr.MergedAt), string(pr.Title), string(pr.HeadRefName), string(pr.BaseRefName),
-		pr.Commits.Nodes, pr.Reviews.Nodes,
+		commits, reviews,
 	)
 }
 
@@ -499,24 +492,15 @@ func (c *GithubConfig) PREvidenceForCommitV2(commit string) ([]*types.PREvidence
 
 							Commits struct {
 								Nodes    []graphqlCommitNode
-								PageInfo struct {
-									HasNextPage graphql.Boolean
-									EndCursor   graphql.String
-								}
+								PageInfo pageInfo
 							} `graphql:"commits(first: 100, after: $commitCursor)"`
 
 							Reviews struct {
 								Nodes    []graphqlReviewNode
-								PageInfo struct {
-									HasNextPage graphql.Boolean
-									EndCursor   graphql.String
-								}
+								PageInfo pageInfo
 							} `graphql:"reviews(first: 100, states: APPROVED, after: $reviewCursor)"`
 						}
-						PageInfo struct {
-							HasNextPage graphql.Boolean
-							EndCursor   graphql.String
-						}
+						PageInfo pageInfo
 					} `graphql:"associatedPullRequests(first: 100, after: $prCursor)"`
 				} `graphql:"... on Commit"`
 			} `graphql:"object(oid: $commitSHA)"`
@@ -532,18 +516,29 @@ func (c *GithubConfig) PREvidenceForCommitV2(commit string) ([]*types.PREvidence
 		"reviewCursor": (*graphql.String)(nil),
 	}
 
-	err = client.Query(context.Background(), &query, variables)
-	if err != nil {
+	if err := client.Query(ctx, &query, variables); err != nil {
 		return pullRequestsEvidence, err
 	}
 
+	// Only the follow-up pages retry; the initial query keeps its fail-fast
+	// behaviour, which callers already depend on.
+	run := c.queryWithRetry(client)
 	for _, pr := range query.Repository.Object.Commit.AssociatedPullRequests.Nodes {
+		prNumber := int(pr.Number)
+		commits, err := c.allPRCommits(ctx, run, prNumber, pr.Commits.Nodes, pr.Commits.PageInfo)
+		if err != nil {
+			return pullRequestsEvidence, err
+		}
+		reviews, err := c.allPRReviews(ctx, run, prNumber, pr.Reviews.Nodes, pr.Reviews.PageInfo)
+		if err != nil {
+			return pullRequestsEvidence, err
+		}
 		// MergeCommit is set to the queried commit SHA — V2 queries by commit SHA
 		// so the commit is by definition the merge commit.
 		evidence, err := buildPREvidence(
 			string(pr.URL), commit, string(pr.State), string(pr.Author.Login),
 			string(pr.CreatedAt), string(pr.MergedAt), string(pr.Title), string(pr.HeadRefName), string(pr.BaseRefName),
-			pr.Commits.Nodes, pr.Reviews.Nodes,
+			commits, reviews,
 		)
 		if err != nil {
 			return pullRequestsEvidence, err

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -25,8 +25,10 @@ type GithubConfig struct {
 	Org        string
 	Repository string
 	Debug      bool
-	// Sleep is called between retries in PREvidenceByPRNumber. Defaults to
-	// time.Sleep when nil. Override in tests to avoid real delays.
+	// Sleep replaces the wait between GraphQL retries — every retry, including
+	// the follow-up page queries of both PR-evidence entry points. Nil means a
+	// real time.Sleep that honours context cancellation; setting it bypasses
+	// that, so leave it nil to exercise the cancellation path.
 	Sleep func(time.Duration)
 }
 
@@ -440,11 +442,12 @@ func (c *GithubConfig) PREvidenceByPRNumber(prNumber int) (*types.PREvidence, er
 		mergeCommit = string(pr.MergeCommit.Oid)
 	}
 
-	commits, err := c.allPRCommits(ctx, run, prNumber, pr.Commits.Nodes, pr.Commits.PageInfo)
+	ref := prRef{Owner: c.Org, Repo: c.Repository, Number: prNumber}
+	commits, err := c.allPRCommits(ctx, run, ref, pr.Commits.Nodes, pr.Commits.PageInfo)
 	if err != nil {
 		return nil, err
 	}
-	reviews, err := c.allPRReviews(ctx, run, prNumber, pr.Reviews.Nodes, pr.Reviews.PageInfo)
+	reviews, err := c.allPRReviews(ctx, run, ref, pr.Reviews.Nodes, pr.Reviews.PageInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -474,7 +477,15 @@ func (c *GithubConfig) PREvidenceForCommitV2(commit string) ([]*types.PREvidence
 				Commit struct {
 					AssociatedPullRequests struct {
 						Nodes []struct {
-							Number      graphql.Int
+							Number graphql.Int
+							// Follow-up page queries resolve the PR by number, so they
+							// need the repo it actually lives in, not the configured one.
+							Repository struct {
+								Name  graphql.String
+								Owner struct {
+									Login graphql.String
+								}
+							}
 							Title       graphql.String
 							State       graphql.String
 							HeadRefName graphql.String
@@ -497,6 +508,9 @@ func (c *GithubConfig) PREvidenceForCommitV2(commit string) ([]*types.PREvidence
 								PageInfo pageInfo
 							} `graphql:"reviews(first: 100, states: APPROVED, after: $reviewCursor)"`
 						}
+						// Intentionally not paginated: a commit with more than 100
+						// associated PRs is not a realistic case, and draining it
+						// would mean nesting a page walk per PR page (#1082).
 						PageInfo pageInfo
 					} `graphql:"associatedPullRequests(first: 100, after: $prCursor)"`
 				} `graphql:"... on Commit"`
@@ -519,14 +533,26 @@ func (c *GithubConfig) PREvidenceForCommitV2(commit string) ([]*types.PREvidence
 
 	// Only the follow-up pages retry; the initial query keeps its fail-fast
 	// behaviour, which callers already depend on.
-	run := c.queryWithRetry(client)
+	retrying := c.queryWithRetry(client)
 	for _, pr := range query.Repository.Object.Commit.AssociatedPullRequests.Nodes {
-		prNumber := int(pr.Number)
-		commits, err := c.allPRCommits(ctx, run, prNumber, pr.Commits.Nodes, pr.Commits.PageInfo)
+		ref := prRef{
+			Owner:  string(pr.Repository.Owner.Login),
+			Repo:   string(pr.Repository.Name),
+			Number: int(pr.Number),
+		}
+		// A node can live in a repo this token cannot read. That failure is
+		// permanent, and it is the likely one here, so cross-repo pages trade
+		// the retry ladder away rather than spend 60s reaching it — at the
+		// cost of not retrying a genuine blip on those pages either.
+		run := retrying
+		if !c.owns(ref) {
+			run = client.Query
+		}
+		commits, err := c.allPRCommits(ctx, run, ref, pr.Commits.Nodes, pr.Commits.PageInfo)
 		if err != nil {
 			return pullRequestsEvidence, err
 		}
-		reviews, err := c.allPRReviews(ctx, run, prNumber, pr.Reviews.Nodes, pr.Reviews.PageInfo)
+		reviews, err := c.allPRReviews(ctx, run, ref, pr.Reviews.Nodes, pr.Reviews.PageInfo)
 		if err != nil {
 			return pullRequestsEvidence, err
 		}
@@ -578,21 +604,34 @@ func (c *GithubConfig) PullRequestsForCommit(commit string) ([]*gh.PullRequest, 
 		return []*gh.PullRequest{}, err
 	}
 
-	opts := &gh.PullRequestListOptions{ListOptions: gh.ListOptions{PerPage: restPageSize}}
+	return c.listPullRequestsForCommit(ctx, client, commit, defaultMaxPages)
+}
+
+// listPullRequestsForCommit drains the PRs-for-commit endpoint. maxPages is a
+// parameter so the cap is testable without 100 round trips.
+func (c *GithubConfig) listPullRequestsForCommit(ctx context.Context, client *gh.Client,
+	commit string, maxPages int) ([]*gh.PullRequest, error) {
+	// Page starts at 1, not the zero value: at 0 the non-advancing guard below
+	// cannot fire on the first response. page=1 is the server default anyway.
+	opts := &gh.PullRequestListOptions{ListOptions: gh.ListOptions{PerPage: restPageSize, Page: 1}}
 	all := []*gh.PullRequest{}
-	for pages := 0; pages < defaultMaxPages; pages++ {
+	for pages := 0; pages < maxPages; pages++ {
 		pullrequests, resp, err := client.PullRequests.ListPullRequestsWithCommit(ctx, c.Org, c.Repository,
 			commit, opts)
 		if err != nil {
-			return all, err
+			return nil, err
 		}
 		all = append(all, pullrequests...)
 		if resp.NextPage == 0 {
 			return all, nil
 		}
+		if resp.NextPage <= opts.Page {
+			return nil, fmt.Errorf("next page %d did not advance past page %d for commit %s",
+				resp.NextPage, opts.Page, commit)
+		}
 		opts.Page = resp.NextPage
 	}
-	return all, fmt.Errorf("aborting after %d pages of pull requests for commit %s", defaultMaxPages, commit)
+	return nil, fmt.Errorf("aborting after %d pages of pull requests for commit %s", maxPages, commit)
 }
 
 // GetPullRequestApprovers returns a list of approvers for a given pull request
@@ -603,26 +642,46 @@ func (c *GithubConfig) GetPullRequestApprovers(number int) ([]string, error) {
 	if err != nil {
 		return approvers, err
 	}
-	// ListReviews returns every review event, not just approvals, so the
-	// APPROVED filter below must run over all pages: an approval past page one
-	// was previously dropped outright (#1082).
-	opts := &gh.ListOptions{PerPage: restPageSize}
-	for pages := 0; pages < defaultMaxPages; pages++ {
+	return c.listApprovers(ctx, client, number, defaultMaxPages)
+}
+
+// listApprovers drains the reviews endpoint, keeping the logins that approved.
+// maxPages is a parameter so the cap is testable without 100 round trips.
+//
+// ListReviews returns every review event, not just approvals, so the APPROVED
+// filter has to run over all pages: an approval past page one was previously
+// dropped outright (#1082).
+func (c *GithubConfig) listApprovers(ctx context.Context, client *gh.Client,
+	number, maxPages int) ([]string, error) {
+	approvers := []string{}
+	// Page starts at 1 for the same reason as above: the guard needs a floor it
+	// can compare against on the first response.
+	opts := &gh.ListOptions{PerPage: restPageSize, Page: 1}
+	// A reviewer can approve more than once. These entries carry no timestamp,
+	// so a repeated login adds nothing and is dropped.
+	seen := map[string]bool{}
+	for pages := 0; pages < maxPages; pages++ {
 		reviews, resp, err := client.PullRequests.ListReviews(ctx, c.Org, c.Repository, number, opts)
 		if err != nil {
-			return approvers, err
+			return nil, err
 		}
 		for _, r := range reviews {
-			if r.GetState() == "APPROVED" {
-				approvers = append(approvers, r.GetUser().GetLogin())
+			login := r.GetUser().GetLogin()
+			if r.GetState() == "APPROVED" && !seen[login] {
+				seen[login] = true
+				approvers = append(approvers, login)
 			}
 		}
 		if resp.NextPage == 0 {
 			return approvers, nil
 		}
+		if resp.NextPage <= opts.Page {
+			return nil, fmt.Errorf("next page %d did not advance past page %d for pull request %d",
+				resp.NextPage, opts.Page, number)
+		}
 		opts.Page = resp.NextPage
 	}
-	return approvers, fmt.Errorf("aborting after %d pages of reviews for pull request %d", defaultMaxPages, number)
+	return nil, fmt.Errorf("aborting after %d pages of reviews for pull request %d", maxPages, number)
 }
 
 func (c *GithubConfig) newPRGithubEvidence(pr *gh.PullRequest) (*types.PREvidence, error) {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -508,11 +508,11 @@ func (c *GithubConfig) PREvidenceForCommitV2(commit string) ([]*types.PREvidence
 								PageInfo pageInfo
 							} `graphql:"reviews(first: 100, states: APPROVED, after: $reviewCursor)"`
 						}
-						// Intentionally not paginated: a commit with more than 100
-						// associated PRs is not a realistic case, and draining it
-						// would mean nesting a page walk per PR page (#1082).
-						PageInfo pageInfo
-					} `graphql:"associatedPullRequests(first: 100, after: $prCursor)"`
+						// Intentionally not paginated, so no cursor is selected: a
+						// commit with more than 100 associated PRs is not a realistic
+						// case, and draining it would mean nesting a page walk per
+						// PR page (#1082).
+					} `graphql:"associatedPullRequests(first: 100)"`
 				} `graphql:"... on Commit"`
 			} `graphql:"object(oid: $commitSHA)"`
 		} `graphql:"repository(owner: $owner, name: $repo)"`
@@ -522,7 +522,6 @@ func (c *GithubConfig) PREvidenceForCommitV2(commit string) ([]*types.PREvidence
 		"owner":        graphql.String(c.Org),
 		"repo":         graphql.String(c.Repository),
 		"commitSHA":    GitObjectID(commit),
-		"prCursor":     (*graphql.String)(nil),
 		"commitCursor": (*graphql.String)(nil),
 		"reviewCursor": (*graphql.String)(nil),
 	}

--- a/internal/github/pagination.go
+++ b/internal/github/pagination.go
@@ -8,8 +8,15 @@ import (
 	"github.com/shurcooL/graphql"
 )
 
-// defaultMaxPages bounds pagination when a caller does not set MaxPages.
-const defaultMaxPages = 100
+const (
+	// defaultMaxPages bounds every pagination loop. It is a guard against an
+	// API that keeps reporting more results, not a tunable limit: at 100 pages
+	// of 100 items it sits far beyond any real pull request.
+	defaultMaxPages = 100
+	// restPageSize is GitHub's REST maximum. The zero-valued list options used
+	// before sent no per_page at all, so the API's default of 30 applied (#1082).
+	restPageSize = 100
+)
 
 // pageInfo is the cursor block shared by every paginated GraphQL connection.
 type pageInfo struct {
@@ -17,22 +24,18 @@ type pageInfo struct {
 	EndCursor   graphql.String
 }
 
-// maxPages resolves the configured page cap, falling back to the default.
-func (c *GithubConfig) maxPages() int {
-	if c.MaxPages > 0 {
-		return c.MaxPages
-	}
-	return defaultMaxPages
-}
-
 // paginate follows cursors from first onwards, appending each page to seed.
 // It errors rather than returning early when the cap is hit or a cursor
 // repeats: silently stopping is the truncation bug this fixes (#1082).
+//
+// The counter starts at 1 because seed is already the first page, so maxPages
+// means the same "at most N pages of results" here as in the REST, GitLab and
+// Azure loops, which count their first request inside the budget.
 func paginate[T any](seed []T, first pageInfo, maxPages int,
 	fetch func(after graphql.String) ([]T, pageInfo, error)) ([]T, error) {
 	all := seed
 	page := first
-	for pages := 0; page.HasNextPage; pages++ {
+	for pages := 1; page.HasNextPage; pages++ {
 		if pages >= maxPages {
 			return nil, fmt.Errorf("aborting after %d pages: the API keeps reporting more results", maxPages)
 		}
@@ -92,7 +95,7 @@ func (c *GithubConfig) pageVariables(prNumber int, after graphql.String) map[str
 // so draining one connection never re-fetches the other.
 func (c *GithubConfig) allPRCommits(ctx context.Context, run graphqlQueryFunc, prNumber int,
 	seed []graphqlCommitNode, first pageInfo) ([]graphqlCommitNode, error) {
-	return paginate(seed, first, c.maxPages(), func(after graphql.String) ([]graphqlCommitNode, pageInfo, error) {
+	return paginate(seed, first, defaultMaxPages, func(after graphql.String) ([]graphqlCommitNode, pageInfo, error) {
 		var q struct {
 			Repository struct {
 				PullRequest struct {
@@ -114,7 +117,7 @@ func (c *GithubConfig) allPRCommits(ctx context.Context, run graphqlQueryFunc, p
 // allPRReviews returns every approved review on prNumber, seeded as above.
 func (c *GithubConfig) allPRReviews(ctx context.Context, run graphqlQueryFunc, prNumber int,
 	seed []graphqlReviewNode, first pageInfo) ([]graphqlReviewNode, error) {
-	return paginate(seed, first, c.maxPages(), func(after graphql.String) ([]graphqlReviewNode, pageInfo, error) {
+	return paginate(seed, first, defaultMaxPages, func(after graphql.String) ([]graphqlReviewNode, pageInfo, error) {
 		var q struct {
 			Repository struct {
 				PullRequest struct {
@@ -132,7 +135,3 @@ func (c *GithubConfig) allPRReviews(ctx context.Context, run graphqlQueryFunc, p
 		return reviews.Nodes, reviews.PageInfo, nil
 	})
 }
-
-// restPageSize is GitHub's REST maximum. The zero-valued list options used
-// before sent no per_page at all, so the API's default of 30 applied (#1082).
-const restPageSize = 100

--- a/internal/github/pagination.go
+++ b/internal/github/pagination.go
@@ -1,0 +1,134 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/shurcooL/graphql"
+)
+
+// defaultMaxPages bounds pagination when a caller does not set MaxPages.
+const defaultMaxPages = 100
+
+// pageInfo is the cursor block shared by every paginated GraphQL connection.
+type pageInfo struct {
+	HasNextPage graphql.Boolean
+	EndCursor   graphql.String
+}
+
+// maxPages resolves the configured page cap, falling back to the default.
+func (c *GithubConfig) maxPages() int {
+	if c.MaxPages > 0 {
+		return c.MaxPages
+	}
+	return defaultMaxPages
+}
+
+// paginate follows cursors from first onwards, appending each page to seed.
+// It errors rather than returning early when the cap is hit or a cursor
+// repeats: silently stopping is the truncation bug this fixes (#1082).
+func paginate[T any](seed []T, first pageInfo, maxPages int,
+	fetch func(after graphql.String) ([]T, pageInfo, error)) ([]T, error) {
+	all := seed
+	page := first
+	for pages := 0; page.HasNextPage; pages++ {
+		if pages >= maxPages {
+			return nil, fmt.Errorf("aborting after %d pages: the API keeps reporting more results", maxPages)
+		}
+		cursor := page.EndCursor
+		nodes, next, err := fetch(cursor)
+		if err != nil {
+			return nil, err
+		}
+		if next.HasNextPage && next.EndCursor == cursor {
+			return nil, fmt.Errorf("pagination cursor %q did not advance", string(cursor))
+		}
+		all = append(all, nodes...)
+		page = next
+	}
+	return all, nil
+}
+
+// graphqlQueryFunc runs one GraphQL round trip.
+type graphqlQueryFunc func(ctx context.Context, q any, variables map[string]any) error
+
+// queryWithRetry runs a GraphQL query, retrying transient failures. Follow-up
+// pages use it too: one blip mid-drain would otherwise discard a PR's whole
+// commit list (#1082).
+func (c *GithubConfig) queryWithRetry(client *graphql.Client) graphqlQueryFunc {
+	return func(ctx context.Context, q any, variables map[string]any) error {
+		sleep := c.Sleep
+		if sleep == nil {
+			sleep = time.Sleep
+		}
+		var err error
+		for _, delay := range []time.Duration{0, 10 * time.Second, 20 * time.Second, 30 * time.Second} {
+			if delay > 0 {
+				sleep(delay)
+			}
+			if err = client.Query(ctx, q, variables); err == nil {
+				return nil
+			}
+		}
+		return err
+	}
+}
+
+// pageVariables are the query variables shared by both follow-up page queries.
+// The cursor is a plain graphql.String — the initial queries pass a nil
+// *graphql.String, so they declare `String` where these declare `String!`.
+func (c *GithubConfig) pageVariables(prNumber int, after graphql.String) map[string]any {
+	return map[string]any{
+		"owner":    graphql.String(c.Org),
+		"repo":     graphql.String(c.Repository),
+		"prNumber": graphql.Int(prNumber),
+		"cursor":   after,
+	}
+}
+
+// allPRCommits returns every commit on prNumber, seeded with the nodes the
+// caller's first query already returned. Follow-up pages select only commits,
+// so draining one connection never re-fetches the other.
+func (c *GithubConfig) allPRCommits(ctx context.Context, run graphqlQueryFunc, prNumber int,
+	seed []graphqlCommitNode, first pageInfo) ([]graphqlCommitNode, error) {
+	return paginate(seed, first, c.maxPages(), func(after graphql.String) ([]graphqlCommitNode, pageInfo, error) {
+		var q struct {
+			Repository struct {
+				PullRequest struct {
+					Commits struct {
+						Nodes    []graphqlCommitNode
+						PageInfo pageInfo
+					} `graphql:"commits(first: 100, after: $cursor)"`
+				} `graphql:"pullRequest(number: $prNumber)"`
+			} `graphql:"repository(owner: $owner, name: $repo)"`
+		}
+		if err := run(ctx, &q, c.pageVariables(prNumber, after)); err != nil {
+			return nil, pageInfo{}, err
+		}
+		commits := q.Repository.PullRequest.Commits
+		return commits.Nodes, commits.PageInfo, nil
+	})
+}
+
+// allPRReviews returns every approved review on prNumber, seeded as above.
+func (c *GithubConfig) allPRReviews(ctx context.Context, run graphqlQueryFunc, prNumber int,
+	seed []graphqlReviewNode, first pageInfo) ([]graphqlReviewNode, error) {
+	return paginate(seed, first, c.maxPages(), func(after graphql.String) ([]graphqlReviewNode, pageInfo, error) {
+		var q struct {
+			Repository struct {
+				PullRequest struct {
+					Reviews struct {
+						Nodes    []graphqlReviewNode
+						PageInfo pageInfo
+					} `graphql:"reviews(first: 100, states: APPROVED, after: $cursor)"`
+				} `graphql:"pullRequest(number: $prNumber)"`
+			} `graphql:"repository(owner: $owner, name: $repo)"`
+		}
+		if err := run(ctx, &q, c.pageVariables(prNumber, after)); err != nil {
+			return nil, pageInfo{}, err
+		}
+		reviews := q.Repository.PullRequest.Reviews
+		return reviews.Nodes, reviews.PageInfo, nil
+	})
+}

--- a/internal/github/pagination.go
+++ b/internal/github/pagination.go
@@ -109,6 +109,12 @@ type prRef struct {
 	Number int
 }
 
+// String renders ref the way GitHub writes a pull request reference, so the
+// errors wrapping a drain can name it.
+func (r prRef) String() string {
+	return fmt.Sprintf("%s/%s#%d", r.Owner, r.Repo, r.Number)
+}
+
 // owns reports whether ref names the configured repository. GitHub owner and
 // repo names are case-insensitive, so a differently-cased config value still
 // names the same repo.
@@ -133,7 +139,7 @@ func pageVariables(ref prRef, after graphql.String) map[string]any {
 // so draining one connection never re-fetches the other.
 func (c *GithubConfig) allPRCommits(ctx context.Context, run graphqlQueryFunc, ref prRef,
 	seed []graphqlCommitNode, first pageInfo) ([]graphqlCommitNode, error) {
-	return paginate(seed, first, defaultMaxPages, func(after graphql.String) ([]graphqlCommitNode, pageInfo, error) {
+	commits, err := paginate(seed, first, defaultMaxPages, func(after graphql.String) ([]graphqlCommitNode, pageInfo, error) {
 		var q struct {
 			Repository struct {
 				PullRequest struct {
@@ -147,15 +153,19 @@ func (c *GithubConfig) allPRCommits(ctx context.Context, run graphqlQueryFunc, r
 		if err := run(ctx, &q, pageVariables(ref, after)); err != nil {
 			return nil, pageInfo{}, err
 		}
-		commits := q.Repository.PullRequest.Commits
-		return commits.Nodes, commits.PageInfo, nil
+		page := q.Repository.PullRequest.Commits
+		return page.Nodes, page.PageInfo, nil
 	})
+	if err != nil {
+		return nil, fmt.Errorf("draining commits for %s: %w", ref, err)
+	}
+	return commits, nil
 }
 
 // allPRReviews returns every approved review on prNumber, seeded as above.
 func (c *GithubConfig) allPRReviews(ctx context.Context, run graphqlQueryFunc, ref prRef,
 	seed []graphqlReviewNode, first pageInfo) ([]graphqlReviewNode, error) {
-	return paginate(seed, first, defaultMaxPages, func(after graphql.String) ([]graphqlReviewNode, pageInfo, error) {
+	reviews, err := paginate(seed, first, defaultMaxPages, func(after graphql.String) ([]graphqlReviewNode, pageInfo, error) {
 		var q struct {
 			Repository struct {
 				PullRequest struct {
@@ -169,7 +179,11 @@ func (c *GithubConfig) allPRReviews(ctx context.Context, run graphqlQueryFunc, r
 		if err := run(ctx, &q, pageVariables(ref, after)); err != nil {
 			return nil, pageInfo{}, err
 		}
-		reviews := q.Repository.PullRequest.Reviews
-		return reviews.Nodes, reviews.PageInfo, nil
+		page := q.Repository.PullRequest.Reviews
+		return page.Nodes, page.PageInfo, nil
 	})
+	if err != nil {
+		return nil, fmt.Errorf("draining approvals for %s: %w", ref, err)
+	}
+	return reviews, nil
 }

--- a/internal/github/pagination.go
+++ b/internal/github/pagination.go
@@ -2,7 +2,9 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/shurcooL/graphql"
@@ -61,14 +63,15 @@ type graphqlQueryFunc func(ctx context.Context, q any, variables map[string]any)
 // commit list (#1082).
 func (c *GithubConfig) queryWithRetry(client *graphql.Client) graphqlQueryFunc {
 	return func(ctx context.Context, q any, variables map[string]any) error {
-		sleep := c.Sleep
-		if sleep == nil {
-			sleep = time.Sleep
-		}
 		var err error
 		for _, delay := range []time.Duration{0, 10 * time.Second, 20 * time.Second, 30 * time.Second} {
 			if delay > 0 {
-				sleep(delay)
+				// A wait only happens after a failed attempt, so err holds the
+				// reason every attempt failed. Join keeps it alongside the
+				// cancellation, so neither side loses its errors.Is.
+				if waitErr := c.wait(ctx, delay); waitErr != nil {
+					return errors.Join(err, waitErr)
+				}
 			}
 			if err = client.Query(ctx, q, variables); err == nil {
 				return nil
@@ -78,14 +81,47 @@ func (c *GithubConfig) queryWithRetry(client *graphql.Client) graphqlQueryFunc {
 	}
 }
 
+// wait pauses between retries. It honours ctx cancellation so a caller with a
+// deadline is not held for the full ladder; c.Sleep bypasses that, and exists
+// only so tests need not sleep for real.
+func (c *GithubConfig) wait(ctx context.Context, d time.Duration) error {
+	if c.Sleep != nil {
+		c.Sleep(d)
+		return nil
+	}
+	select {
+	case <-time.After(d):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// prRef identifies the pull request a follow-up page query must resolve. The
+// repo is carried explicitly because a follow-up is a separate query: resolving
+// pullRequest(number:) against the configured repo would silently return the
+// wrong PR, or none, for any node that is not in it.
+type prRef struct {
+	Owner  string
+	Repo   string
+	Number int
+}
+
+// owns reports whether ref names the configured repository. GitHub owner and
+// repo names are case-insensitive, so a differently-cased config value still
+// names the same repo.
+func (c *GithubConfig) owns(ref prRef) bool {
+	return strings.EqualFold(ref.Owner, c.Org) && strings.EqualFold(ref.Repo, c.Repository)
+}
+
 // pageVariables are the query variables shared by both follow-up page queries.
 // The cursor is a plain graphql.String — the initial queries pass a nil
 // *graphql.String, so they declare `String` where these declare `String!`.
-func (c *GithubConfig) pageVariables(prNumber int, after graphql.String) map[string]any {
+func pageVariables(ref prRef, after graphql.String) map[string]any {
 	return map[string]any{
-		"owner":    graphql.String(c.Org),
-		"repo":     graphql.String(c.Repository),
-		"prNumber": graphql.Int(prNumber),
+		"owner":    graphql.String(ref.Owner),
+		"repo":     graphql.String(ref.Repo),
+		"prNumber": graphql.Int(ref.Number),
 		"cursor":   after,
 	}
 }
@@ -93,7 +129,7 @@ func (c *GithubConfig) pageVariables(prNumber int, after graphql.String) map[str
 // allPRCommits returns every commit on prNumber, seeded with the nodes the
 // caller's first query already returned. Follow-up pages select only commits,
 // so draining one connection never re-fetches the other.
-func (c *GithubConfig) allPRCommits(ctx context.Context, run graphqlQueryFunc, prNumber int,
+func (c *GithubConfig) allPRCommits(ctx context.Context, run graphqlQueryFunc, ref prRef,
 	seed []graphqlCommitNode, first pageInfo) ([]graphqlCommitNode, error) {
 	return paginate(seed, first, defaultMaxPages, func(after graphql.String) ([]graphqlCommitNode, pageInfo, error) {
 		var q struct {
@@ -106,7 +142,7 @@ func (c *GithubConfig) allPRCommits(ctx context.Context, run graphqlQueryFunc, p
 				} `graphql:"pullRequest(number: $prNumber)"`
 			} `graphql:"repository(owner: $owner, name: $repo)"`
 		}
-		if err := run(ctx, &q, c.pageVariables(prNumber, after)); err != nil {
+		if err := run(ctx, &q, pageVariables(ref, after)); err != nil {
 			return nil, pageInfo{}, err
 		}
 		commits := q.Repository.PullRequest.Commits
@@ -115,7 +151,7 @@ func (c *GithubConfig) allPRCommits(ctx context.Context, run graphqlQueryFunc, p
 }
 
 // allPRReviews returns every approved review on prNumber, seeded as above.
-func (c *GithubConfig) allPRReviews(ctx context.Context, run graphqlQueryFunc, prNumber int,
+func (c *GithubConfig) allPRReviews(ctx context.Context, run graphqlQueryFunc, ref prRef,
 	seed []graphqlReviewNode, first pageInfo) ([]graphqlReviewNode, error) {
 	return paginate(seed, first, defaultMaxPages, func(after graphql.String) ([]graphqlReviewNode, pageInfo, error) {
 		var q struct {
@@ -128,7 +164,7 @@ func (c *GithubConfig) allPRReviews(ctx context.Context, run graphqlQueryFunc, p
 				} `graphql:"pullRequest(number: $prNumber)"`
 			} `graphql:"repository(owner: $owner, name: $repo)"`
 		}
-		if err := run(ctx, &q, c.pageVariables(prNumber, after)); err != nil {
+		if err := run(ctx, &q, pageVariables(ref, after)); err != nil {
 			return nil, pageInfo{}, err
 		}
 		reviews := q.Repository.PullRequest.Reviews

--- a/internal/github/pagination.go
+++ b/internal/github/pagination.go
@@ -35,7 +35,9 @@ type pageInfo struct {
 // Azure loops, which count their first request inside the budget.
 func paginate[T any](seed []T, first pageInfo, maxPages int,
 	fetch func(after graphql.String) ([]T, pageInfo, error)) ([]T, error) {
-	all := seed
+	// Cap the seed at its length so the first append allocates instead of
+	// writing into spare capacity the caller still owns.
+	all := seed[:len(seed):len(seed)]
 	page := first
 	for pages := 1; page.HasNextPage; pages++ {
 		if pages >= maxPages {

--- a/internal/github/pagination.go
+++ b/internal/github/pagination.go
@@ -132,3 +132,7 @@ func (c *GithubConfig) allPRReviews(ctx context.Context, run graphqlQueryFunc, p
 		return reviews.Nodes, reviews.PageInfo, nil
 	})
 }
+
+// restPageSize is GitHub's REST maximum. The zero-valued list options used
+// before sent no per_page at all, so the API's default of 30 applied (#1082).
+const restPageSize = 100

--- a/internal/github/pagination_test.go
+++ b/internal/github/pagination_test.go
@@ -72,7 +72,7 @@ func TestPaginate_ErrorsPastMaxPages(t *testing.T) {
 		})
 
 	require.ErrorContains(t, err, "2 pages")
-	require.Equal(t, 2, calls, "should stop at the cap")
+	require.Equal(t, 1, calls, "seed is page 1, so a cap of 2 allows one fetch")
 }
 
 func TestPaginate_PropagatesFetchError(t *testing.T) {
@@ -83,9 +83,4 @@ func TestPaginate_PropagatesFetchError(t *testing.T) {
 		})
 
 	require.ErrorIs(t, err, wantErr)
-}
-
-func TestMaxPages_DefaultsWhenUnset(t *testing.T) {
-	require.Equal(t, defaultMaxPages, (&GithubConfig{}).maxPages())
-	require.Equal(t, 3, (&GithubConfig{MaxPages: 3}).maxPages())
 }

--- a/internal/github/pagination_test.go
+++ b/internal/github/pagination_test.go
@@ -1,0 +1,91 @@
+package github
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/shurcooL/graphql"
+	"github.com/stretchr/testify/require"
+)
+
+// page builds a pageInfo for a connection that has more results after cursor.
+func page(cursor string) pageInfo {
+	return pageInfo{HasNextPage: true, EndCursor: graphql.String(cursor)}
+}
+
+// lastPage is the pageInfo of a connection with nothing after it.
+var lastPage = pageInfo{HasNextPage: false}
+
+func TestPaginate_ReturnsSeedWhenNoNextPage(t *testing.T) {
+	calls := 0
+	got, err := paginate([]string{"a"}, lastPage, defaultMaxPages,
+		func(after graphql.String) ([]string, pageInfo, error) {
+			calls++
+			return nil, lastPage, nil
+		})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"a"}, got)
+	require.Zero(t, calls, "should not fetch when the first page is the last")
+}
+
+func TestPaginate_ConcatenatesPagesInOrder(t *testing.T) {
+	pages := map[graphql.String]struct {
+		nodes []string
+		next  pageInfo
+	}{
+		"c1": {[]string{"b", "c"}, page("c2")},
+		"c2": {[]string{"d"}, lastPage},
+	}
+	var asked []graphql.String
+
+	got, err := paginate([]string{"a"}, page("c1"), defaultMaxPages,
+		func(after graphql.String) ([]string, pageInfo, error) {
+			asked = append(asked, after)
+			p := pages[after]
+			return p.nodes, p.next, nil
+		})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b", "c", "d"}, got)
+	require.Equal(t, []graphql.String{"c1", "c2"}, asked)
+}
+
+func TestPaginate_ErrorsWhenCursorDoesNotAdvance(t *testing.T) {
+	calls := 0
+	_, err := paginate([]string{"a"}, page("stuck"), defaultMaxPages,
+		func(after graphql.String) ([]string, pageInfo, error) {
+			calls++
+			return []string{"b"}, page("stuck"), nil
+		})
+
+	require.ErrorContains(t, err, "did not advance")
+	require.Equal(t, 1, calls, "should give up as soon as the cursor repeats")
+}
+
+func TestPaginate_ErrorsPastMaxPages(t *testing.T) {
+	calls := 0
+	_, err := paginate([]string{"a"}, page("c0"), 2,
+		func(after graphql.String) ([]string, pageInfo, error) {
+			calls++
+			return []string{"b"}, page(string(after) + "x"), nil
+		})
+
+	require.ErrorContains(t, err, "2 pages")
+	require.Equal(t, 2, calls, "should stop at the cap")
+}
+
+func TestPaginate_PropagatesFetchError(t *testing.T) {
+	wantErr := errors.New("boom")
+	_, err := paginate([]string{"a"}, page("c1"), defaultMaxPages,
+		func(after graphql.String) ([]string, pageInfo, error) {
+			return nil, pageInfo{}, wantErr
+		})
+
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestMaxPages_DefaultsWhenUnset(t *testing.T) {
+	require.Equal(t, defaultMaxPages, (&GithubConfig{}).maxPages())
+	require.Equal(t, 3, (&GithubConfig{MaxPages: 3}).maxPages())
+}

--- a/internal/github/pagination_test.go
+++ b/internal/github/pagination_test.go
@@ -156,3 +156,21 @@ func TestQueryWithRetry_CancellationKeepsUnderlyingError(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled, "cancellation must stay detectable")
 	require.ErrorContains(t, err, "500", "the server error must survive too")
 }
+
+// A seed with spare capacity must not be written through by paginate: the
+// caller still owns that array, and a second consumer of it would see the
+// appended nodes appear in its own tail.
+func TestPaginate_DoesNotWriteIntoSeedSpareCapacity(t *testing.T) {
+	backing := make([]string, 1, 4)
+	backing[0] = "a"
+	other := backing[:4] // a second view over the same array
+
+	got, err := paginate(backing, page("c1"), defaultMaxPages,
+		func(after graphql.String) ([]string, pageInfo, error) {
+			return []string{"b"}, lastPage, nil
+		})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b"}, got)
+	require.Empty(t, other[1], "paginate must not write into the caller's array")
+}

--- a/internal/github/pagination_test.go
+++ b/internal/github/pagination_test.go
@@ -1,8 +1,13 @@
 package github
 
 import (
+	"context"
 	"errors"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/shurcooL/graphql"
 	"github.com/stretchr/testify/require"
@@ -83,4 +88,71 @@ func TestPaginate_PropagatesFetchError(t *testing.T) {
 		})
 
 	require.ErrorIs(t, err, wantErr)
+}
+
+// GitHub owner and repo names are case-insensitive, so a config carrying a
+// differently-cased name still names the same repo — and must keep its retries.
+func TestOwns_IsCaseInsensitive(t *testing.T) {
+	config := &GithubConfig{Org: "kosli-dev", Repository: "cli"}
+
+	require.True(t, config.owns(prRef{Owner: "Kosli-Dev", Repo: "CLI", Number: 1}))
+	require.True(t, config.owns(prRef{Owner: "kosli-dev", Repo: "cli", Number: 1}))
+	require.False(t, config.owns(prRef{Owner: "upstream-org", Repo: "cli", Number: 1}))
+	require.False(t, config.owns(prRef{Owner: "kosli-dev", Repo: "other", Number: 1}))
+}
+
+// The retry ladder must not sit out a cancelled context. Sleep is left unset so
+// the production wait path is exercised.
+func TestQueryWithRetry_StopsOnContextCancellation(t *testing.T) {
+	ts := newGraphQLTestServer(t, "500", "500", "500", "500")
+	config := &GithubConfig{Token: "t", BaseURL: ts.URL, Org: "o", Repository: "r"}
+	client := graphql.NewClient(graphqlEndpoint(ts.URL), nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	err := config.queryWithRetry(client)(ctx, &struct{}{}, map[string]any{})
+	require.Error(t, err)
+	require.Less(t, time.Since(start), 5*time.Second, "must not wait out the ladder")
+}
+
+// failThenCancelTransport answers with a 500 and cancels the context before
+// returning, so the ladder's first wait always sees an already-cancelled
+// context while the server error is already in hand. Cancelling any later —
+// from the handler, or on a timer — races the client's body read, and losing
+// that race aborts the request itself so the 500 never reaches the caller.
+type failThenCancelTransport struct {
+	cancel context.CancelFunc
+	calls  int
+}
+
+func (t *failThenCancelTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	t.calls++
+	t.cancel()
+	return &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Status:     "500 Internal Server Error",
+		Body:       io.NopCloser(strings.NewReader("boom")),
+		Header:     make(http.Header),
+	}, nil
+}
+
+// Cancellation stops the ladder, but the error that caused every attempt to
+// fail is the useful one — it must not be replaced by "context canceled".
+func TestQueryWithRetry_CancellationKeepsUnderlyingError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	transport := &failThenCancelTransport{cancel: cancel}
+
+	config := &GithubConfig{Token: "t", Org: "o", Repository: "r"}
+	client := graphql.NewClient("http://example.invalid/api/graphql",
+		&http.Client{Transport: transport})
+
+	err := config.queryWithRetry(client)(ctx, &struct{}{}, map[string]any{})
+
+	require.Error(t, err)
+	require.Equal(t, 1, transport.calls, "the ladder must stop at the first wait")
+	require.ErrorIs(t, err, context.Canceled, "cancellation must stay detectable")
+	require.ErrorContains(t, err, "500", "the server error must survive too")
 }

--- a/internal/github/pr_pagination_test.go
+++ b/internal/github/pr_pagination_test.go
@@ -1,0 +1,259 @@
+package github
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kosli-dev/cli/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+// graphQLTestServer serves canned GraphQL responses in order and records every
+// request body, so tests can assert which connection each round trip queried.
+type graphQLTestServer struct {
+	*httptest.Server
+	bodies []string
+}
+
+// newGraphQLTestServer replies with responses in order. An entry of "500"
+// makes that request fail, to exercise the retry path.
+func newGraphQLTestServer(t *testing.T, responses ...string) *graphQLTestServer {
+	t.Helper()
+	s := &graphQLTestServer{}
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/graphql" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		s.bodies = append(s.bodies, string(body))
+		if len(s.bodies) > len(responses) {
+			t.Errorf("unexpected request %d: %s", len(s.bodies), body)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		reply := responses[len(s.bodies)-1]
+		if reply == "500" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, reply)
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+// newPaginationConfig points a config at ts with retries that do not sleep.
+func newPaginationConfig(ts *graphQLTestServer) *GithubConfig {
+	return &GithubConfig{
+		Token:      "fake-token",
+		BaseURL:    ts.URL,
+		Org:        "test-org",
+		Repository: "test-repo",
+		Sleep:      func(time.Duration) {},
+	}
+}
+
+// commitNodeJSON is one node of a GraphQL commits connection.
+func commitNodeJSON(sha string) string {
+	return fmt.Sprintf(`{"commit":{"oid":%q,"messageHeadline":"msg %s",`+
+		`"committedDate":"2026-03-01T12:00:00Z","authoredDate":"2026-03-01T12:00:00Z",`+
+		`"url":"https://github.com/o/r/commit/%s",`+
+		`"author":{"name":"Ada","email":"ada@example.com","user":{"login":"ada"}},`+
+		`"signature":null}}`, sha, sha, sha)
+}
+
+// reviewNodeJSON is one node of a GraphQL reviews connection.
+func reviewNodeJSON(login string) string {
+	return fmt.Sprintf(`{"author":{"login":%q},"state":"APPROVED","submittedAt":"2026-03-01T13:00:00Z"}`, login)
+}
+
+// connectionJSON wraps nodes with a pageInfo block. An empty cursor means the
+// connection has no further pages.
+func connectionJSON(nodes []string, nextCursor string) string {
+	hasNext := nextCursor != ""
+	return fmt.Sprintf(`{"nodes":[%s],"pageInfo":{"hasNextPage":%t,"endCursor":%q}}`,
+		strings.Join(nodes, ","), hasNext, nextCursor)
+}
+
+// prJSON is a full pullRequest object with the given commit and review connections.
+func prJSON(commits, reviews string) string {
+	return fmt.Sprintf(`{"title":"A PR","state":"MERGED","headRefName":"feature","baseRefName":"main",`+
+		`"url":"https://github.com/o/r/pull/1","createdAt":"2026-03-01T11:00:00Z",`+
+		`"mergedAt":"2026-03-01T14:00:00Z","mergeCommit":{"oid":"merge-sha"},`+
+		`"author":{"login":"ada"},"commits":%s,"reviews":%s}`, commits, reviews)
+}
+
+func byPRNumberResponse(commits, reviews string) string {
+	return fmt.Sprintf(`{"data":{"repository":{"pullRequest":%s}}}`, prJSON(commits, reviews))
+}
+
+// commitsPageResponse is a follow-up page reply selecting only commits.
+func commitsPageResponse(nodes []string, nextCursor string) string {
+	return fmt.Sprintf(`{"data":{"repository":{"pullRequest":{"commits":%s}}}}`,
+		connectionJSON(nodes, nextCursor))
+}
+
+// reviewsPageResponse is a follow-up page reply selecting only reviews.
+func reviewsPageResponse(nodes []string, nextCursor string) string {
+	return fmt.Sprintf(`{"data":{"repository":{"pullRequest":{"reviews":%s}}}}`,
+		connectionJSON(nodes, nextCursor))
+}
+
+func shasOf(t *testing.T, config *GithubConfig, prNumber int) []string {
+	t.Helper()
+	evidence, err := config.PREvidenceByPRNumber(prNumber)
+	require.NoError(t, err)
+	require.NotNil(t, evidence)
+	shas := []string{}
+	for _, c := range evidence.Commits {
+		shas = append(shas, c.SHA)
+	}
+	return shas
+}
+
+func TestPREvidenceByPRNumber_FollowsCommitPages(t *testing.T) {
+	ts := newGraphQLTestServer(t,
+		byPRNumberResponse(
+			connectionJSON([]string{commitNodeJSON("sha1"), commitNodeJSON("sha2")}, "c1"),
+			connectionJSON([]string{reviewNodeJSON("ada")}, ""),
+		),
+		commitsPageResponse([]string{commitNodeJSON("sha3")}, ""),
+	)
+
+	require.Equal(t, []string{"sha1", "sha2", "sha3"}, shasOf(t, newPaginationConfig(ts), 1))
+	require.Len(t, ts.bodies, 2)
+	require.Contains(t, ts.bodies[1], "c1", "follow-up must carry the cursor")
+	require.NotContains(t, ts.bodies[1], "reviews(", "follow-up must not re-fetch reviews")
+}
+
+func TestPREvidenceByPRNumber_FollowsReviewPages(t *testing.T) {
+	ts := newGraphQLTestServer(t,
+		byPRNumberResponse(
+			connectionJSON([]string{commitNodeJSON("sha1")}, ""),
+			connectionJSON([]string{reviewNodeJSON("ada")}, "r1"),
+		),
+		reviewsPageResponse([]string{reviewNodeJSON("grace")}, ""),
+	)
+
+	evidence, err := newPaginationConfig(ts).PREvidenceByPRNumber(1)
+	require.NoError(t, err)
+	require.Len(t, evidence.Approvers, 2)
+	require.Len(t, ts.bodies, 2)
+	require.Contains(t, ts.bodies[1], "r1")
+	require.NotContains(t, ts.bodies[1], "commits(", "follow-up must not re-fetch commits")
+}
+
+func TestPREvidenceByPRNumber_SingleRequestWhenNoMorePages(t *testing.T) {
+	ts := newGraphQLTestServer(t, byPRNumberResponse(
+		connectionJSON([]string{commitNodeJSON("sha1")}, ""),
+		connectionJSON([]string{reviewNodeJSON("ada")}, ""),
+	))
+
+	require.Equal(t, []string{"sha1"}, shasOf(t, newPaginationConfig(ts), 1))
+	require.Len(t, ts.bodies, 1)
+}
+
+func TestPREvidenceByPRNumber_RetriesFollowUpPage(t *testing.T) {
+	ts := newGraphQLTestServer(t,
+		byPRNumberResponse(
+			connectionJSON([]string{commitNodeJSON("sha1")}, "c1"),
+			connectionJSON(nil, ""),
+		),
+		"500",
+		commitsPageResponse([]string{commitNodeJSON("sha2")}, ""),
+	)
+
+	require.Equal(t, []string{"sha1", "sha2"}, shasOf(t, newPaginationConfig(ts), 1))
+	require.Len(t, ts.bodies, 3, "the failed follow-up page should have been retried")
+}
+
+func TestPREvidenceByPRNumber_ErrorsWhenCursorDoesNotAdvance(t *testing.T) {
+	config := newPaginationConfig(newGraphQLTestServer(t,
+		byPRNumberResponse(
+			connectionJSON([]string{commitNodeJSON("sha1")}, "stuck"),
+			connectionJSON(nil, ""),
+		),
+		commitsPageResponse([]string{commitNodeJSON("sha2")}, "stuck"),
+	))
+
+	_, err := config.PREvidenceByPRNumber(1)
+	require.ErrorContains(t, err, "did not advance")
+}
+
+// v2PRNodeJSON is one associatedPullRequests node. Unlike the by-number query
+// it carries the PR number and has no mergeCommit.
+func v2PRNodeJSON(number int, commits, reviews string) string {
+	return fmt.Sprintf(`{"number":%d,"title":"A PR","state":"MERGED","headRefName":"feature",`+
+		`"baseRefName":"main","url":"https://github.com/o/r/pull/%d",`+
+		`"createdAt":"2026-03-01T11:00:00Z","mergedAt":"2026-03-01T14:00:00Z",`+
+		`"author":{"login":"ada"},"commits":%s,"reviews":%s}`, number, number, commits, reviews)
+}
+
+func forCommitResponse(prNodes ...string) string {
+	return fmt.Sprintf(`{"data":{"repository":{"object":{"associatedPullRequests":%s}}}}`,
+		connectionJSON(prNodes, ""))
+}
+
+func TestPREvidenceForCommitV2_FollowsCommitPagesPerPR(t *testing.T) {
+	ts := newGraphQLTestServer(t,
+		forCommitResponse(
+			v2PRNodeJSON(7,
+				connectionJSON([]string{commitNodeJSON("sha1")}, "c1"),
+				connectionJSON(nil, "")),
+			v2PRNodeJSON(9,
+				connectionJSON([]string{commitNodeJSON("sha3")}, "c9"),
+				connectionJSON(nil, "")),
+		),
+		commitsPageResponse([]string{commitNodeJSON("sha2")}, ""),
+		commitsPageResponse([]string{commitNodeJSON("sha4")}, ""),
+	)
+
+	prs, err := newPaginationConfig(ts).PREvidenceForCommitV2("merge-sha")
+	require.NoError(t, err)
+	require.Len(t, prs, 2)
+	require.Equal(t, []string{"sha1", "sha2"}, shasIn(prs[0]))
+	require.Equal(t, []string{"sha3", "sha4"}, shasIn(prs[1]))
+	require.Len(t, ts.bodies, 3)
+	require.Contains(t, ts.bodies[1], `"prNumber":7`)
+	require.Contains(t, ts.bodies[2], `"prNumber":9`)
+}
+
+func TestPREvidenceForCommitV2_RetriesFollowUpPage(t *testing.T) {
+	ts := newGraphQLTestServer(t,
+		forCommitResponse(v2PRNodeJSON(7,
+			connectionJSON([]string{commitNodeJSON("sha1")}, "c1"),
+			connectionJSON(nil, ""))),
+		"500",
+		commitsPageResponse([]string{commitNodeJSON("sha2")}, ""),
+	)
+
+	prs, err := newPaginationConfig(ts).PREvidenceForCommitV2("merge-sha")
+	require.NoError(t, err)
+	require.Equal(t, []string{"sha1", "sha2"}, shasIn(prs[0]))
+	require.Len(t, ts.bodies, 3)
+}
+
+// The initial V2 query keeps its existing fail-fast behaviour; only the
+// follow-up pages this change introduces are retried.
+func TestPREvidenceForCommitV2_DoesNotRetryInitialQuery(t *testing.T) {
+	ts := newGraphQLTestServer(t, "500")
+
+	_, err := newPaginationConfig(ts).PREvidenceForCommitV2("merge-sha")
+	require.Error(t, err)
+	require.Len(t, ts.bodies, 1)
+}
+
+func shasIn(evidence *types.PREvidence) []string {
+	shas := []string{}
+	for _, c := range evidence.Commits {
+		shas = append(shas, c.SHA)
+	}
+	return shas
+}

--- a/internal/github/pr_pagination_test.go
+++ b/internal/github/pr_pagination_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -331,7 +332,9 @@ func TestPREvidenceForCommitV2_DrainErrorNamesThePullRequest(t *testing.T) {
 	_, err := newPaginationConfig(ts).PREvidenceForCommitV2("merge-sha")
 	require.ErrorContains(t, err, "upstream-org/upstream-repo#42")
 	require.ErrorContains(t, err, "commits")
-	require.ErrorContains(t, err, "did not advance", "the cause must survive the wrap")
+	// Unwrap, not ErrorContains: the message survives %v too, so only the chain
+	// distinguishes a wrapped cause from an interpolated one.
+	require.ErrorContains(t, errors.Unwrap(err), "did not advance", "the cause must stay unwrappable")
 }
 
 func TestPREvidenceByPRNumber_ApprovalDrainErrorNamesThePullRequest(t *testing.T) {

--- a/internal/github/pr_pagination_test.go
+++ b/internal/github/pr_pagination_test.go
@@ -204,9 +204,11 @@ func v2PRNodeInRepoJSON(owner, repo string, number int, commits, reviews string)
 		number, repo, owner, owner, repo, number, commits, reviews)
 }
 
+// forCommitResponse carries no pageInfo for the PR connection: the query does
+// not select one, and shurcooL's decoder rejects fields the struct lacks.
 func forCommitResponse(prNodes ...string) string {
-	return fmt.Sprintf(`{"data":{"repository":{"object":{"associatedPullRequests":%s}}}}`,
-		connectionJSON(prNodes, ""))
+	return fmt.Sprintf(`{"data":{"repository":{"object":{"associatedPullRequests":{"nodes":[%s]}}}}}`,
+		strings.Join(prNodes, ","))
 }
 
 func TestPREvidenceForCommitV2_FollowsCommitPagesPerPR(t *testing.T) {

--- a/internal/github/pr_pagination_test.go
+++ b/internal/github/pr_pagination_test.go
@@ -190,10 +190,18 @@ func TestPREvidenceByPRNumber_ErrorsWhenCursorDoesNotAdvance(t *testing.T) {
 // v2PRNodeJSON is one associatedPullRequests node. Unlike the by-number query
 // it carries the PR number and has no mergeCommit.
 func v2PRNodeJSON(number int, commits, reviews string) string {
-	return fmt.Sprintf(`{"number":%d,"title":"A PR","state":"MERGED","headRefName":"feature",`+
-		`"baseRefName":"main","url":"https://github.com/o/r/pull/%d",`+
+	return v2PRNodeInRepoJSON("test-org", "test-repo", number, commits, reviews)
+}
+
+// v2PRNodeInRepoJSON is an associatedPullRequests node belonging to owner/repo,
+// which need not be the configured repository.
+func v2PRNodeInRepoJSON(owner, repo string, number int, commits, reviews string) string {
+	return fmt.Sprintf(`{"number":%d,"repository":{"name":%q,"owner":{"login":%q}},`+
+		`"title":"A PR","state":"MERGED","headRefName":"feature",`+
+		`"baseRefName":"main","url":"https://github.com/%s/%s/pull/%d",`+
 		`"createdAt":"2026-03-01T11:00:00Z","mergedAt":"2026-03-01T14:00:00Z",`+
-		`"author":{"login":"ada"},"commits":%s,"reviews":%s}`, number, number, commits, reviews)
+		`"author":{"login":"ada"},"commits":%s,"reviews":%s}`,
+		number, repo, owner, owner, repo, number, commits, reviews)
 }
 
 func forCommitResponse(prNodes ...string) string {
@@ -256,4 +264,54 @@ func shasIn(evidence *types.PREvidence) []string {
 		shas = append(shas, c.SHA)
 	}
 	return shas
+}
+
+// A commit's associated PRs are not guaranteed to live in the configured repo.
+// The follow-up page query resolves pullRequest(number:) in a separate request,
+// so it must target the repo the node came from — otherwise it silently reads a
+// different PR's commits, or none.
+func TestPREvidenceForCommitV2_FollowUpTargetsTheNodesOwnRepo(t *testing.T) {
+	ts := newGraphQLTestServer(t,
+		forCommitResponse(v2PRNodeInRepoJSON("upstream-org", "upstream-repo", 7,
+			connectionJSON([]string{commitNodeJSON("sha1")}, "c1"),
+			connectionJSON(nil, ""))),
+		commitsPageResponse([]string{commitNodeJSON("sha2")}, ""),
+	)
+
+	prs, err := newPaginationConfig(ts).PREvidenceForCommitV2("merge-sha")
+	require.NoError(t, err)
+	require.Equal(t, []string{"sha1", "sha2"}, shasIn(prs[0]))
+	require.Contains(t, ts.bodies[1], `"owner":"upstream-org"`)
+	require.Contains(t, ts.bodies[1], `"repo":"upstream-repo"`)
+}
+
+// PREvidenceByPRNumber is given a number for the configured repo, so its
+// follow-up pages must keep using it.
+func TestPREvidenceByPRNumber_FollowUpUsesConfiguredRepo(t *testing.T) {
+	ts := newGraphQLTestServer(t,
+		byPRNumberResponse(
+			connectionJSON([]string{commitNodeJSON("sha1")}, "c1"),
+			connectionJSON(nil, "")),
+		commitsPageResponse([]string{commitNodeJSON("sha2")}, ""),
+	)
+
+	_, err := newPaginationConfig(ts).PREvidenceByPRNumber(1)
+	require.NoError(t, err)
+	require.Contains(t, ts.bodies[1], `"owner":"test-org"`)
+	require.Contains(t, ts.bodies[1], `"repo":"test-repo"`)
+}
+
+// A node's PR can live in a repo the token cannot read. That query fails
+// permanently, so retrying it only delays the failure by the full ladder.
+func TestPREvidenceForCommitV2_DoesNotRetryCrossRepoFollowUp(t *testing.T) {
+	ts := newGraphQLTestServer(t,
+		forCommitResponse(v2PRNodeInRepoJSON("upstream-org", "upstream-repo", 7,
+			connectionJSON([]string{commitNodeJSON("sha1")}, "c1"),
+			connectionJSON(nil, ""))),
+		"500",
+	)
+
+	_, err := newPaginationConfig(ts).PREvidenceForCommitV2("merge-sha")
+	require.Error(t, err)
+	require.Len(t, ts.bodies, 2, "a cross-repo follow-up must not be retried")
 }

--- a/internal/github/pr_pagination_test.go
+++ b/internal/github/pr_pagination_test.go
@@ -317,3 +317,32 @@ func TestPREvidenceForCommitV2_DoesNotRetryCrossRepoFollowUp(t *testing.T) {
 	require.Error(t, err)
 	require.Len(t, ts.bodies, 2, "a cross-repo follow-up must not be retried")
 }
+
+// A stuck cursor is a hard failure now, so the message is the whole
+// user-facing surface of the change — it has to say which PR gave up.
+func TestPREvidenceForCommitV2_DrainErrorNamesThePullRequest(t *testing.T) {
+	ts := newGraphQLTestServer(t,
+		forCommitResponse(v2PRNodeInRepoJSON("upstream-org", "upstream-repo", 42,
+			connectionJSON([]string{commitNodeJSON("sha1")}, "stuck"),
+			connectionJSON(nil, ""))),
+		commitsPageResponse([]string{commitNodeJSON("sha2")}, "stuck"),
+	)
+
+	_, err := newPaginationConfig(ts).PREvidenceForCommitV2("merge-sha")
+	require.ErrorContains(t, err, "upstream-org/upstream-repo#42")
+	require.ErrorContains(t, err, "commits")
+	require.ErrorContains(t, err, "did not advance", "the cause must survive the wrap")
+}
+
+func TestPREvidenceByPRNumber_ApprovalDrainErrorNamesThePullRequest(t *testing.T) {
+	ts := newGraphQLTestServer(t,
+		byPRNumberResponse(
+			connectionJSON([]string{commitNodeJSON("sha1")}, ""),
+			connectionJSON([]string{reviewNodeJSON("ada")}, "stuck")),
+		reviewsPageResponse([]string{reviewNodeJSON("grace")}, "stuck"),
+	)
+
+	_, err := newPaginationConfig(ts).PREvidenceByPRNumber(7)
+	require.ErrorContains(t, err, "test-org/test-repo#7")
+	require.ErrorContains(t, err, "approvals")
+}

--- a/internal/github/rest_pagination_test.go
+++ b/internal/github/rest_pagination_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -92,4 +93,89 @@ func TestPullRequestsForCommit_ReturnsErrorFromSecondPage(t *testing.T) {
 
 	_, err := newRestConfig(ts.URL).PullRequestsForCommit("abc123")
 	require.Error(t, err)
+}
+
+func TestGetPullRequestApprovers_DeduplicatesRepeatApprovals(t *testing.T) {
+	// A reviewer can approve, request changes, then approve again. These
+	// entries carry no timestamp, so the repeat is noise.
+	ts := newRestTestServer(t, "/api/v3/repos/test-org/test-repo/pulls/5/reviews",
+		`[{"state":"APPROVED","user":{"login":"ada"}},{"state":"CHANGES_REQUESTED","user":{"login":"ada"}}]`,
+		`[{"state":"APPROVED","user":{"login":"ada"}},{"state":"APPROVED","user":{"login":"grace"}}]`,
+	)
+
+	approvers, err := newRestConfig(ts.URL).GetPullRequestApprovers(5)
+	require.NoError(t, err)
+	require.Equal(t, []string{"ada", "grace"}, approvers)
+}
+
+func TestGetPullRequestApprovers_ErrorsWhenNextPageDoesNotAdvance(t *testing.T) {
+	// Without the guard a server pinning NextPage re-reads the same page until
+	// the cap fires, accumulating duplicate work rather than failing.
+	calls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Link", `<https://example.invalid/x?page=1>; rel="next"`)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `[{"state":"APPROVED","user":{"login":"ada"}}]`)
+	}))
+	defer ts.Close()
+
+	_, err := newRestConfig(ts.URL).GetPullRequestApprovers(5)
+	require.ErrorContains(t, err, "did not advance")
+	require.Equal(t, 1, calls)
+}
+
+// alwaysMorePages advertises a next page forever, so only the cap stops it.
+func alwaysMorePages(t *testing.T, body string) (*httptest.Server, *int) {
+	t.Helper()
+	calls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Link", fmt.Sprintf(`<https://example.invalid/x?page=%d>; rel="next"`, calls+1))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, body)
+	}))
+	t.Cleanup(ts.Close)
+	return ts, &calls
+}
+
+func TestListPullRequestsForCommit_ErrorsPastMaxPages(t *testing.T) {
+	ts, calls := alwaysMorePages(t, `[{"number":1}]`)
+	config := newRestConfig(ts.URL)
+	client, err := NewGithubClientFromToken(context.Background(), config.Token, config.BaseURL, false)
+	require.NoError(t, err)
+
+	got, err := config.listPullRequestsForCommit(context.Background(), client, "abc123", 2)
+	require.ErrorContains(t, err, "2 pages")
+	require.Nil(t, got, "no partial result on an error path")
+	require.Equal(t, 2, *calls)
+}
+
+func TestListApprovers_ErrorsPastMaxPages(t *testing.T) {
+	ts, calls := alwaysMorePages(t, `[{"state":"APPROVED","user":{"login":"ada"}}]`)
+	config := newRestConfig(ts.URL)
+	client, err := NewGithubClientFromToken(context.Background(), config.Token, config.BaseURL, false)
+	require.NoError(t, err)
+
+	got, err := config.listApprovers(context.Background(), client, 5, 2)
+	require.ErrorContains(t, err, "2 pages")
+	require.Nil(t, got, "no partial result on an error path")
+	require.Equal(t, 2, *calls)
+}
+
+// Mirror of TestGetPullRequestApprovers_ErrorsWhenNextPageDoesNotAdvance for
+// the identical guard in the PRs-for-commit loop.
+func TestPullRequestsForCommit_ErrorsWhenNextPageDoesNotAdvance(t *testing.T) {
+	calls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Link", `<https://example.invalid/x?page=1>; rel="next"`)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `[{"number":1}]`)
+	}))
+	defer ts.Close()
+
+	_, err := newRestConfig(ts.URL).PullRequestsForCommit("abc123")
+	require.ErrorContains(t, err, "did not advance")
+	require.Equal(t, 1, calls)
 }

--- a/internal/github/rest_pagination_test.go
+++ b/internal/github/rest_pagination_test.go
@@ -1,0 +1,95 @@
+package github
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// restTestServer serves canned REST pages and records the query string of each
+// request, so tests can assert per_page and page were sent.
+type restTestServer struct {
+	*httptest.Server
+	queries []string
+}
+
+// newRestTestServer replies to path with pages in order, setting the Link
+// header that go-github reads to derive NextPage.
+func newRestTestServer(t *testing.T, path string, pages ...string) *restTestServer {
+	t.Helper()
+	s := &restTestServer{}
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != path {
+			t.Errorf("unexpected path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		s.queries = append(s.queries, r.URL.RawQuery)
+		i := len(s.queries) - 1
+		if i >= len(pages) {
+			t.Errorf("unexpected request %d", len(s.queries))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if i < len(pages)-1 {
+			w.Header().Set("Link", fmt.Sprintf(`<%s%s?page=%d>; rel="next"`, s.URL, path, i+2))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, pages[i])
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+func newRestConfig(url string) *GithubConfig {
+	return &GithubConfig{Token: "fake-token", BaseURL: url, Org: "test-org", Repository: "test-repo"}
+}
+
+func TestPullRequestsForCommit_FollowsLinkHeader(t *testing.T) {
+	ts := newRestTestServer(t, "/api/v3/repos/test-org/test-repo/commits/abc123/pulls",
+		`[{"number":1},{"number":2}]`,
+		`[{"number":3}]`,
+	)
+
+	prs, err := newRestConfig(ts.URL).PullRequestsForCommit("abc123")
+	require.NoError(t, err)
+	require.Len(t, prs, 3)
+	require.Equal(t, 3, prs[2].GetNumber())
+	require.Contains(t, ts.queries[0], "per_page=100")
+	require.Contains(t, ts.queries[1], "page=2")
+}
+
+func TestGetPullRequestApprovers_FindsApproverOnSecondPage(t *testing.T) {
+	// The APPROVED filter runs after fetching, so an approval on page 2 was
+	// dropped entirely before pagination (#1082).
+	ts := newRestTestServer(t, "/api/v3/repos/test-org/test-repo/pulls/5/reviews",
+		`[{"state":"COMMENTED","user":{"login":"bob"}}]`,
+		`[{"state":"APPROVED","user":{"login":"ada"}}]`,
+	)
+
+	approvers, err := newRestConfig(ts.URL).GetPullRequestApprovers(5)
+	require.NoError(t, err)
+	require.Equal(t, []string{"ada"}, approvers)
+	require.Contains(t, ts.queries[0], "per_page=100")
+}
+
+func TestPullRequestsForCommit_ReturnsErrorFromSecondPage(t *testing.T) {
+	calls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.Header().Set("Link", `<http://example.invalid/next?page=2>; rel="next"`)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `[{"number":1}]`)
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	_, err := newRestConfig(ts.URL).PullRequestsForCommit("abc123")
+	require.Error(t, err)
+}

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -148,7 +148,7 @@ func (c *GitlabConfig) MergeRequestsForCommit(commit string) ([]*gitlab.BasicMer
 		return mrs, err
 	}
 
-	mrs, _, err = client.Commits.ListMergeRequestsByCommit(c.ProjectID(), commit)
+	mrs, err = c.listMergeRequestsForCommit(client, commit, defaultMaxPages)
 	if err != nil {
 		return mrs, fmt.Errorf("failed to list merge requests for commit %s: %v", commit, err)
 	}

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -13,6 +13,9 @@ type GitlabConfig struct {
 	BaseURL    string
 	Org        string
 	Repository string
+	// MaxPages bounds pagination loops; zero means defaultMaxPages. Set it in
+	// tests to keep the stuck-cursor cases cheap.
+	MaxPages int
 }
 
 // GetClientOptFns creates a list of ClientOptionFunc
@@ -187,11 +190,12 @@ func (c *GitlabConfig) GetMergeRequestCommits(mr *gitlab.BasicMergeRequest) ([]t
 	if err != nil {
 		return commits, err
 	}
-	glCommits, _, err := client.MergeRequests.GetMergeRequestCommits(c.ProjectID(), mr.IID,
-		&gitlab.GetMergeRequestCommitsOptions{})
+	glCommits, err := c.listMergeRequestCommits(client, mr.IID, c.maxPages())
 	if err != nil {
 		return commits, err
 	}
+	// One signature lookup per commit: pagination multiplies this, but GitLab
+	// has no batch signature endpoint.
 	for _, commit := range glCommits {
 		mappedCommit := commitFromGitlabCommit(commit, mr.SourceBranch)
 		verified, signatureState, err := resolveGitlabSignature(

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -150,7 +150,7 @@ func (c *GitlabConfig) MergeRequestsForCommit(commit string) ([]*gitlab.BasicMer
 
 	mrs, err = c.listMergeRequestsForCommit(client, commit, defaultMaxPages)
 	if err != nil {
-		return mrs, fmt.Errorf("failed to list merge requests for commit %s: %v", commit, err)
+		return mrs, fmt.Errorf("failed to list merge requests for commit %s: %w", commit, err)
 	}
 	return mrs, nil
 }

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -13,9 +13,6 @@ type GitlabConfig struct {
 	BaseURL    string
 	Org        string
 	Repository string
-	// MaxPages bounds pagination loops; zero means defaultMaxPages. Set it in
-	// tests to keep the stuck-cursor cases cheap.
-	MaxPages int
 }
 
 // GetClientOptFns creates a list of ClientOptionFunc
@@ -190,7 +187,7 @@ func (c *GitlabConfig) GetMergeRequestCommits(mr *gitlab.BasicMergeRequest) ([]t
 	if err != nil {
 		return commits, err
 	}
-	glCommits, err := c.listMergeRequestCommits(client, mr.IID, c.maxPages())
+	glCommits, err := c.listMergeRequestCommits(client, mr.IID, defaultMaxPages)
 	if err != nil {
 		return commits, err
 	}

--- a/internal/gitlab/pagination.go
+++ b/internal/gitlab/pagination.go
@@ -1,0 +1,50 @@
+package gitlab
+
+import (
+	"fmt"
+
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+)
+
+const (
+	// defaultMaxPages bounds pagination when a caller does not set MaxPages.
+	defaultMaxPages = 100
+	// listPageSize is GitLab's maximum. The zero-valued options used before
+	// sent no per_page, so GitLab's default of 20 applied (#1082).
+	listPageSize = 100
+)
+
+// maxPages resolves the configured page cap, falling back to the default.
+func (c *GitlabConfig) maxPages() int {
+	if c.MaxPages > 0 {
+		return c.MaxPages
+	}
+	return defaultMaxPages
+}
+
+// listMergeRequestCommits returns every commit on an MR. GitLab's default page
+// size is 20, which silently truncated the commit list on larger MRs (#1082).
+// A cap or a non-advancing page errors rather than returning early: quietly
+// stopping is the bug being fixed.
+func (c *GitlabConfig) listMergeRequestCommits(client *gitlab.Client, mrIID int64, maxPages int) ([]*gitlab.Commit, error) {
+	all := []*gitlab.Commit{}
+	opts := &gitlab.GetMergeRequestCommitsOptions{
+		ListOptions: gitlab.ListOptions{PerPage: listPageSize, Page: 1},
+	}
+	for pages := 0; pages < maxPages; pages++ {
+		glCommits, resp, err := client.MergeRequests.GetMergeRequestCommits(c.ProjectID(), mrIID, opts)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, glCommits...)
+		if resp == nil || resp.NextPage == 0 {
+			return all, nil
+		}
+		if resp.NextPage <= opts.Page {
+			return nil, fmt.Errorf("next page %d did not advance past page %d for merge request %d",
+				resp.NextPage, opts.Page, mrIID)
+		}
+		opts.Page = resp.NextPage
+	}
+	return nil, fmt.Errorf("aborting after %d pages of commits for merge request %d", maxPages, mrIID)
+}

--- a/internal/gitlab/pagination.go
+++ b/internal/gitlab/pagination.go
@@ -2,6 +2,9 @@ package gitlab
 
 import (
 	"fmt"
+	"strconv"
+
+	retryablehttp "github.com/hashicorp/go-retryablehttp"
 
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 )
@@ -30,7 +33,7 @@ func (c *GitlabConfig) listMergeRequestCommits(client *gitlab.Client, mrIID int6
 			return nil, err
 		}
 		all = append(all, glCommits...)
-		if resp == nil || resp.NextPage == 0 {
+		if resp.NextPage == 0 {
 			return all, nil
 		}
 		if resp.NextPage <= opts.Page {
@@ -40,4 +43,42 @@ func (c *GitlabConfig) listMergeRequestCommits(client *gitlab.Client, mrIID int6
 		opts.Page = resp.NextPage
 	}
 	return nil, fmt.Errorf("aborting after %d pages of commits for merge request %d", maxPages, mrIID)
+}
+
+// withPage sets the offset-pagination query params. ListMergeRequestsByCommit
+// takes no list options struct, so they go straight onto the request.
+func withPage(page, perPage int64) gitlab.RequestOptionFunc {
+	return func(req *retryablehttp.Request) error {
+		q := req.URL.Query()
+		q.Set("page", strconv.FormatInt(page, 10))
+		q.Set("per_page", strconv.FormatInt(perPage, 10))
+		req.URL.RawQuery = q.Encode()
+		return nil
+	}
+}
+
+// listMergeRequestsForCommit returns every MR associated with a commit. Sending
+// no pagination params left this at GitLab's default of 20, the same truncation
+// as listMergeRequestCommits above and in the same PREvidenceForCommitV2 path
+// (#1082).
+func (c *GitlabConfig) listMergeRequestsForCommit(client *gitlab.Client, commit string, maxPages int) ([]*gitlab.BasicMergeRequest, error) {
+	all := []*gitlab.BasicMergeRequest{}
+	page := int64(1)
+	for pages := 0; pages < maxPages; pages++ {
+		mrs, resp, err := client.Commits.ListMergeRequestsByCommit(c.ProjectID(), commit,
+			withPage(page, listPageSize))
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, mrs...)
+		if resp.NextPage == 0 {
+			return all, nil
+		}
+		if resp.NextPage <= page {
+			return nil, fmt.Errorf("next page %d did not advance past page %d for commit %s",
+				resp.NextPage, page, commit)
+		}
+		page = resp.NextPage
+	}
+	return nil, fmt.Errorf("aborting after %d pages of merge requests for commit %s", maxPages, commit)
 }

--- a/internal/gitlab/pagination.go
+++ b/internal/gitlab/pagination.go
@@ -7,20 +7,13 @@ import (
 )
 
 const (
-	// defaultMaxPages bounds pagination when a caller does not set MaxPages.
+	// defaultMaxPages bounds every pagination loop. It guards against an API
+	// that keeps reporting more results; it is not a tunable limit.
 	defaultMaxPages = 100
 	// listPageSize is GitLab's maximum. The zero-valued options used before
 	// sent no per_page, so GitLab's default of 20 applied (#1082).
 	listPageSize = 100
 )
-
-// maxPages resolves the configured page cap, falling back to the default.
-func (c *GitlabConfig) maxPages() int {
-	if c.MaxPages > 0 {
-		return c.MaxPages
-	}
-	return defaultMaxPages
-}
 
 // listMergeRequestCommits returns every commit on an MR. GitLab's default page
 // size is 20, which silently truncated the commit list on larger MRs (#1082).

--- a/internal/gitlab/pagination_test.go
+++ b/internal/gitlab/pagination_test.go
@@ -122,3 +122,110 @@ func TestListMergeRequestCommits_ErrorsPastMaxPages(t *testing.T) {
 	require.ErrorContains(t, err, "2 pages")
 	require.Equal(t, 2, calls)
 }
+
+// mrListServer serves paged MRs-for-commit, setting X-Next-Page as GitLab does.
+// alwaysAdvance keeps advertising a next page, so only the cap stops it.
+func mrListServer(t *testing.T, alwaysAdvance bool, pages ...[]int64) (*httptest.Server, *int) {
+	t.Helper()
+	calls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		if alwaysAdvance {
+			w.Header().Set("X-Next-Page", strconv.Itoa(calls+1))
+			_, _ = fmt.Fprint(w, mrsJSON(pages[0]))
+			return
+		}
+		i := calls - 1
+		if i >= len(pages) {
+			t.Errorf("unexpected request %d", calls)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if i < len(pages)-1 {
+			w.Header().Set("X-Next-Page", strconv.Itoa(i+2))
+		}
+		_, _ = fmt.Fprint(w, mrsJSON(pages[i]))
+	}))
+	t.Cleanup(ts.Close)
+	return ts, &calls
+}
+
+func mrsJSON(iids []int64) string {
+	items := []string{}
+	for _, iid := range iids {
+		items = append(items, fmt.Sprintf(`{"iid":%d,"source_branch":"feature","web_url":"https://gitlab.com/o/r/-/merge_requests/%d"}`, iid, iid))
+	}
+	return "[" + strings.Join(items, ",") + "]"
+}
+
+func iidsOf(mrs []*gitlab.BasicMergeRequest) []int64 {
+	iids := []int64{}
+	for _, mr := range mrs {
+		iids = append(iids, mr.IID)
+	}
+	return iids
+}
+
+func TestMergeRequestsForCommit_FollowsNextPage(t *testing.T) {
+	ts, calls := mrListServer(t, false, []int64{1, 2}, []int64{3})
+
+	mrs, err := newPaginationConfig(ts.URL).MergeRequestsForCommit("abc123")
+	require.NoError(t, err)
+	require.Equal(t, []int64{1, 2, 3}, iidsOf(mrs))
+	require.Equal(t, 2, *calls)
+}
+
+func TestMergeRequestsForCommit_SingleRequestWhenNoNextPage(t *testing.T) {
+	ts, calls := mrListServer(t, false, []int64{1})
+
+	mrs, err := newPaginationConfig(ts.URL).MergeRequestsForCommit("abc123")
+	require.NoError(t, err)
+	require.Len(t, mrs, 1)
+	require.Equal(t, 1, *calls)
+}
+
+func TestListMergeRequestsForCommit_ErrorsPastMaxPages(t *testing.T) {
+	ts, calls := mrListServer(t, true, []int64{1})
+	config := newPaginationConfig(ts.URL)
+	client, err := config.NewGitlabClientFromToken()
+	require.NoError(t, err)
+
+	got, err := config.listMergeRequestsForCommit(client, "abc123", 2)
+	require.ErrorContains(t, err, "2 pages")
+	require.Nil(t, got)
+	require.Equal(t, 2, *calls)
+}
+
+func TestListMergeRequestsForCommit_SendsPageParams(t *testing.T) {
+	queries := []string{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queries = append(queries, r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, mrsJSON([]int64{1}))
+	}))
+	defer ts.Close()
+
+	_, err := newPaginationConfig(ts.URL).MergeRequestsForCommit("abc123")
+	require.NoError(t, err)
+	require.Len(t, queries, 1)
+	require.Contains(t, queries[0], "per_page=100")
+	require.Contains(t, queries[0], "page=1")
+}
+
+func TestListMergeRequestsForCommit_ErrorsWhenNextPageDoesNotAdvance(t *testing.T) {
+	calls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Next-Page", "1")
+		_, _ = fmt.Fprint(w, mrsJSON([]int64{1}))
+	}))
+	defer ts.Close()
+
+	_, err := newPaginationConfig(ts.URL).MergeRequestsForCommit("abc123")
+	require.ErrorContains(t, err, "did not advance")
+	// page starts at 1, so "next is 1" is already non-advancing: it fails on
+	// the first response rather than burning maxPages round trips.
+	require.Equal(t, 1, calls)
+}

--- a/internal/gitlab/pagination_test.go
+++ b/internal/gitlab/pagination_test.go
@@ -1,0 +1,124 @@
+package gitlab
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+)
+
+// mrCommitsServer serves paged MR commits and 404s every signature lookup,
+// which resolveGitlabSignature treats as an unsigned commit.
+type mrCommitsServer struct {
+	*httptest.Server
+	queries []string
+}
+
+// newMRCommitsServer replies with one page of commit SHAs per entry in pages,
+// setting X-Next-Page the way GitLab does. nextPageOverride, when non-empty,
+// is sent as X-Next-Page on every page to simulate a misbehaving server.
+func newMRCommitsServer(t *testing.T, nextPageOverride string, pages ...[]string) *mrCommitsServer {
+	t.Helper()
+	s := &mrCommitsServer{}
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/signature") {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = fmt.Fprint(w, `{"message":"404 Not Found"}`)
+			return
+		}
+		s.queries = append(s.queries, r.URL.RawQuery)
+		i := len(s.queries) - 1
+		if nextPageOverride != "" {
+			w.Header().Set("X-Next-Page", nextPageOverride)
+			_, _ = fmt.Fprint(w, commitsJSON(pages[0]))
+			return
+		}
+		if i >= len(pages) {
+			t.Errorf("unexpected request %d", len(s.queries))
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if i < len(pages)-1 {
+			w.Header().Set("X-Next-Page", strconv.Itoa(i+2))
+		}
+		_, _ = fmt.Fprint(w, commitsJSON(pages[i]))
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+func commitsJSON(shas []string) string {
+	items := []string{}
+	for _, sha := range shas {
+		items = append(items, fmt.Sprintf(`{"id":%q,"message":"msg","author_name":"Ada",`+
+			`"author_email":"ada@example.com","created_at":"2026-03-01T12:00:00Z",`+
+			`"authored_date":"2026-03-01T12:00:00Z","web_url":"https://gitlab.com/o/r/-/commit/%s"}`, sha, sha))
+	}
+	return "[" + strings.Join(items, ",") + "]"
+}
+
+func newPaginationConfig(url string) *GitlabConfig {
+	return &GitlabConfig{Token: "fake-token", BaseURL: url, Org: "test-org", Repository: "test-repo"}
+}
+
+func mrWithIID(iid int64) *gitlab.BasicMergeRequest {
+	return &gitlab.BasicMergeRequest{IID: iid, SourceBranch: "feature"}
+}
+
+func TestGetMergeRequestCommits_FollowsNextPage(t *testing.T) {
+	ts := newMRCommitsServer(t, "", []string{"sha1", "sha2"}, []string{"sha3"})
+	commits, err := newPaginationConfig(ts.URL).GetMergeRequestCommits(mrWithIID(1))
+	require.NoError(t, err)
+
+	shas := []string{}
+	for _, c := range commits {
+		shas = append(shas, c.SHA)
+	}
+	require.Equal(t, []string{"sha1", "sha2", "sha3"}, shas)
+	require.Len(t, ts.queries, 2)
+	require.Contains(t, ts.queries[0], "per_page=100")
+	require.Contains(t, ts.queries[1], "page=2")
+	require.Nil(t, commits[0].Verified, "a 404 signature means unsigned, not an error")
+}
+
+func TestGetMergeRequestCommits_SingleRequestWhenNoNextPage(t *testing.T) {
+	ts := newMRCommitsServer(t, "", []string{"sha1"})
+
+	commits, err := newPaginationConfig(ts.URL).GetMergeRequestCommits(mrWithIID(1))
+	require.NoError(t, err)
+	require.Len(t, commits, 1)
+	require.Len(t, ts.queries, 1)
+}
+
+func TestGetMergeRequestCommits_ErrorsWhenNextPageDoesNotAdvance(t *testing.T) {
+	ts := newMRCommitsServer(t, "1", []string{"sha1"})
+
+	_, err := newPaginationConfig(ts.URL).GetMergeRequestCommits(mrWithIID(1))
+	require.ErrorContains(t, err, "did not advance")
+}
+
+func TestListMergeRequestCommits_ErrorsPastMaxPages(t *testing.T) {
+	// A server that always advances would page forever without the cap.
+	calls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Next-Page", strconv.Itoa(calls+1))
+		_, _ = fmt.Fprint(w, commitsJSON([]string{"sha"}))
+	}))
+	defer ts.Close()
+
+	config := newPaginationConfig(ts.URL)
+	client, err := config.NewGitlabClientFromToken()
+	require.NoError(t, err)
+
+	_, err = config.listMergeRequestCommits(client, 1, 2)
+	require.ErrorContains(t, err, "2 pages")
+	require.Equal(t, 2, calls)
+}

--- a/internal/gitlab/pagination_test.go
+++ b/internal/gitlab/pagination_test.go
@@ -1,6 +1,7 @@
 package gitlab
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -225,6 +226,9 @@ func TestListMergeRequestsForCommit_ErrorsWhenNextPageDoesNotAdvance(t *testing.
 
 	_, err := newPaginationConfig(ts.URL).MergeRequestsForCommit("abc123")
 	require.ErrorContains(t, err, "did not advance")
+	// Unwrap, not ErrorContains: the message survives %v too, so only the
+	// chain distinguishes a wrapped cause from an interpolated one.
+	require.ErrorContains(t, errors.Unwrap(err), "did not advance", "the cause must stay unwrappable")
 	// page starts at 1, so "next is 1" is already non-advancing: it fails on
 	// the first response rather than burning maxPages round trips.
 	require.Equal(t, 1, calls)


### PR DESCRIPTION


`kosli attest pullrequest` recorded only the first page of a pull request's
commits and approvers, silently: the payload stayed valid and the attestation
looked complete while under-reporting what actually shipped. GitHub capped at
100 commits and 100 approved reviews (the GraphQL queries selected `pageInfo`
but never read it), GitLab at 20 commits (zero-valued list options, so no
`per_page` was sent), Azure at one page (the `x-ms-continuationtoken` was
ignored), and the legacy GitHub REST path at 30 — worst there, since
`ListReviews` returns every review event and the `APPROVED` filter ran *after*
the truncation, so a PR with 30+ comments could drop a real approver.

This PR adds pagination all four, one commit per provider concern, with a test per provider
that reproduces the truncation first. A stuck cursor or a page cap now errors
rather than stopping early, since returning early quietly is the bug being
fixed. No signatures or exported API change.

Behavioural changes:

- Attestations for large PRs now carry more commits and approvers, so payloads
  grow and GitLab in particular gets slower (its per-commit GPG signature
  lookup is an N+1 that pagination multiplies).
- Duplicate approvers are dropped on the REST path. A reviewer can approve more
  than once and those entries carry no timestamp, so a repeat added nothing; the
  30-item truncation used to mask it.
- **One case now fails where it previously succeeded.** A commit's
  `associatedPullRequests` can include a PR in a repo the token cannot read. If
  such a PR has more than 100 commits, the follow-up page query targets that
  repo and GitHub answers with `errors[]`, so the attestation fails instead of
  silently recording a truncated commit list. That is the intended trade — an
  incomplete compliance record that looks complete is the failure mode this PR
  removes — but it is a real availability change, not just "more commits". The
  retry ladder is skipped for those queries, since a permission failure will
  never succeed on retry.

Fixes #1082

### Checklist

- [x] **Docs** are autogenerated from CLI help — make sure the help text reflects your changes
- [x] **Helm chart** (`charts/k8s-reporter/`) updated, if needed. Note: these changes live in a **separate PR**
- [x] **Terraform provider** and related changes ([terraform-provider-kosli](https://github.com/kosli-dev/terraform-provider-kosli), [terraform-aws-evidence-reporter](https://github.com/kosli-dev/terraform-aws-evidence-reporter), [terraform-aws-kosli-reporter](https://github.com/kosli-dev/terraform-aws-kosli-reporter)) updated, if needed
