### PR TITLE
docs(security): state that the CLI has no bug bounty and point to the platform program

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ Please send all reports to security@kosli.com and include:
 
 Please report privately by email rather than opening a public issue or pull request, and give us reasonable time to ship a fix before disclosing publicly. This repository is public, so anything raised here is disclosed to everyone at the same moment it reaches us.
 
-## Bug bounty
+## Bug Bounty
 
 **There is no bug bounty for the Kosli CLI, and reports against it do not qualify for a payment.** The CLI is an open source client that runs in your environment rather than ours, so CLI findings sit outside the scope of our paid program.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ Please report privately by email rather than opening a public issue or pull requ
 
 ## Bug Bounty
 
-**There is no bug bounty for the Kosli CLI, and reports against it do not qualify for a payment.** The CLI is an open source client that runs in your environment rather than ours, so CLI findings sit outside the scope of our paid program.
+**There is no bug bounty for the Kosli CLI, and reports against it do not qualify for a payment.** 
 
 We do run a paid bug bounty for our production platform, **app.kosli.com** and its supporting APIs, and for **www.kosli.com**. The scope, testing guidelines, eligibility criteria and bounty rates are published here:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,5 +12,17 @@ Please send all reports to security@kosli.com and include:
 * Potential impact assessment
 * Any supporting evidence (screenshots, logs, PoC)
 
+Please report privately by email rather than opening a public issue or pull request, and give us reasonable time to ship a fix before disclosing publicly. This repository is public, so anything raised here is disclosed to everyone at the same moment it reaches us.
+
+## Bug bounty
+
+**There is no bug bounty for the Kosli CLI, and reports against it do not qualify for a payment.** The CLI is an open source client that runs in your environment rather than ours, so CLI findings sit outside the scope of our paid program.
+
+We do run a paid bug bounty for our production platform, **app.kosli.com** and its supporting APIs, and for **www.kosli.com**. The scope, testing guidelines, eligibility criteria and bounty rates are published here:
+
+https://www.kosli.com/vulnerability-disclosure
+
+CLI reports are still genuinely welcome, and we would rather hear about a problem than not. We will acknowledge your report, assess it, tell you our determination and reasoning, fix what needs fixing, and credit you in the release notes if you would like us to.
+
 ## Our Commitment
 Integrity is a core value at Kosli. We have a strong track record of working fairly and openly with security researchers, and we're committed to transparent communication throughout the disclosure process. We will acknowledge receipt, assess the finding, and respond with our determination. If we classify the vulnerability differently than reported, we'll explain our reasoning.


### PR DESCRIPTION
## What and why

`SECURITY.md` directs reporters to `security@kosli.com` and says nothing about scope or payment. The published policy at [www.kosli.com/vulnerability-disclosure](https://www.kosli.com/vulnerability-disclosure) names only `app.kosli.com`, its supporting APIs and `www.kosli.com` as in scope, and until now said nothing about the CLI either way.

So a researcher reading this file had a fair basis to expect CLI findings to be bounty-eligible, and nothing told them otherwise. That gap came up this week and had to be adjudicated by hand.

## Changes

- **States plainly that there is no bounty for the CLI** and that CLI reports do not qualify for payment, with the reason: the CLI runs in the user's environment rather than ours.
- **Points at the paid program** for the production platform and marketing site, and links to the policy for scope, testing guidelines, eligibility and rates.
- **Keeps CLI disclosure welcome.** The intent is to set expectations on payment, not to discourage reports. We still acknowledge, assess, explain our determination, fix, and credit.
- **Asks for private reports.** This repository is public, so a vulnerability raised as an issue or PR here is disclosed to everyone the moment it lands. That was not previously spelled out.

No code or behaviour changes.

## Companion PR

[kosli-dev/www.kosli.com#1967](https://github.com/kosli-dev/www.kosli.com/pull/1967) states the same position from the policy side and links back to this file. The two should land together so the documents agree at all times. That PR also adds grandfathering, so a scope change is never applied retroactively to a report already received.

🤖 Generated with [Claude Code](https://claude.com/claude-code)