### PR TITLE
fix(fingerprint): prevent .kosli_ignore from excluding itself

### DIFF
--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -102,7 +102,10 @@ The service principal needs to have the following permissions:
 	`
 	kosliIgnoreDesc = `To specify paths in a directory artifact that should always be excluded from the SHA256 calculation, you can add a ^.kosli_ignore^ file to the root of the artifact.
 Each line should specify a relative path or path glob to be ignored. You can include comments in this file, using ^#^.
-The ^.kosli_ignore^ file is always treated as part of the artifact: its own entries cannot exclude it, so the exclusion list cannot be changed without changing the fingerprint. Paths the list already matches stay excluded whatever is later added there, so keep its entries as narrow as possible. Excluding the file with ^--exclude^ keeps it out of the fingerprint but still applies the paths it lists, which lets a writable directory change the list again; to drop the file from the fingerprint safely, move its entries to ^--exclude^ and delete it.`
+The ^.kosli_ignore^ file is always treated as part of the artifact: its own entries cannot exclude it, so the exclusion list cannot be changed without changing the fingerprint.
+Paths the list already matches stay excluded whatever is later added there, so keep its entries as narrow as possible.
+Excluding the file with ^--exclude^ keeps it out of the fingerprint but still applies the paths it lists, which lets a writable directory change the list again.
+To drop the file from the fingerprint safely, move its entries to ^--exclude^ and delete it.`
 
 	// single source of truth for the env type lists shown in flag help texts;
 	// the server is the authority on which types are actually accepted

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -102,7 +102,7 @@ The service principal needs to have the following permissions:
 	`
 	kosliIgnoreDesc = `To specify paths in a directory artifact that should always be excluded from the SHA256 calculation, you can add a ^.kosli_ignore^ file to the root of the artifact.
 Each line should specify a relative path or path glob to be ignored. You can include comments in this file, using ^#^.
-The ^.kosli_ignore^ will be treated as part of the artifact like any other file, unless it is explicitly ignored itself.`
+The ^.kosli_ignore^ file is always treated as part of the artifact: its own entries cannot exclude it, so a directory cannot hide files that have been added to it. Excluding the file with ^--exclude^ keeps it out of the fingerprint but still applies the paths it lists, which lets a writable directory hide files again; to drop the file from the fingerprint safely, move its entries to ^--exclude^ and delete it.`
 
 	// single source of truth for the env type lists shown in flag help texts;
 	// the server is the authority on which types are actually accepted

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -102,7 +102,7 @@ The service principal needs to have the following permissions:
 	`
 	kosliIgnoreDesc = `To specify paths in a directory artifact that should always be excluded from the SHA256 calculation, you can add a ^.kosli_ignore^ file to the root of the artifact.
 Each line should specify a relative path or path glob to be ignored. You can include comments in this file, using ^#^.
-The ^.kosli_ignore^ file is always treated as part of the artifact: its own entries cannot exclude it, so a directory cannot hide files that have been added to it. Excluding the file with ^--exclude^ keeps it out of the fingerprint but still applies the paths it lists, which lets a writable directory hide files again; to drop the file from the fingerprint safely, move its entries to ^--exclude^ and delete it.`
+The ^.kosli_ignore^ file is always treated as part of the artifact: its own entries cannot exclude it, so the exclusion list cannot be changed without changing the fingerprint. Paths the list already matches stay excluded whatever is later added there, so keep its entries as narrow as possible. Excluding the file with ^--exclude^ keeps it out of the fingerprint but still applies the paths it lists, which lets a writable directory change the list again; to drop the file from the fingerprint safely, move its entries to ^--exclude^ and delete it.`
 
 	// single source of truth for the env type lists shown in flag help texts;
 	// the server is the authority on which types are actually accepted

--- a/cmd/kosli/root.go
+++ b/cmd/kosli/root.go
@@ -107,6 +107,14 @@ Paths the list already matches stay excluded whatever is later added there, so k
 Excluding the file with ^--exclude^ keeps it out of the fingerprint but still applies the paths it lists, which lets a writable directory change the list again.
 To drop the file from the fingerprint safely, move its entries to ^--exclude^ and delete it.`
 
+	// snapshot s3 and snapshot azure-apps fingerprint a directory but have no
+	// --exclude that feeds it: s3's filters bucket paths at download time, and
+	// azure-apps registers none.
+	kosliIgnoreDescNoExclude = `To specify paths in a directory artifact that should always be excluded from the SHA256 calculation, you can add a ^.kosli_ignore^ file to the root of the artifact.
+Each line should specify a relative path or path glob to be ignored. You can include comments in this file, using ^#^.
+The ^.kosli_ignore^ file is always treated as part of the artifact: its own entries cannot exclude it, so the exclusion list cannot be changed without changing the fingerprint.
+Paths the list already matches stay excluded whatever is later added there, so keep its entries as narrow as possible.`
+
 	// single source of truth for the env type lists shown in flag help texts;
 	// the server is the authority on which types are actually accepted
 	validEnvTypesList = "K8S, ECS, S3, lambda, server, docker, azure-apps, cloud-run, logical"

--- a/cmd/kosli/snapshotAzureApps.go
+++ b/cmd/kosli/snapshotAzureApps.go
@@ -31,7 +31,7 @@ from any other registry is read without credentials, which works for a public im
 one; report those apps with ^--digests-source logs^ instead.
 
 ^--dry-run^ suppresses only the request to Kosli. Azure discovery and registry lookups still run.
-` + kosliIgnoreDesc + azureAuthDesc
+` + kosliIgnoreDescNoExclude + azureAuthDesc
 
 const snapshotAzureAppsExample = `
 # Use Azure Container Registry to get the digests for artifacts in a snapshot

--- a/cmd/kosli/snapshotS3.go
+++ b/cmd/kosli/snapshotS3.go
@@ -16,7 +16,7 @@ const snapshotS3LongDesc = snapshotS3ShortDesc + awsAuthDesc + `
 You can report the entire bucket content, or filter some of the content using ^--include^ / ^--exclude^ (literal prefix match) or ^--include-regex^ / ^--exclude-regex^ (Go regular expressions matched against the full object key).
 In all cases, the content is reported as one artifact. If you wish to report separate files/dirs within the same bucket as separate artifacts, you need to run the command twice.
 
-` + kosliIgnoreDesc
+` + kosliIgnoreDescNoExclude
 
 const snapshotS3Example = `
 # report the contents of an entire AWS S3 bucket (AWS auth provided in env variables):

--- a/cmd/kosli/testdata/output/docs/mintlify/artifact.md
+++ b/cmd/kosli/testdata/output/docs/mintlify/artifact.md
@@ -45,7 +45,7 @@ is set), registry credentials are resolved as follows:
 
 To specify paths in a directory artifact that should always be excluded from the SHA256 calculation, you can add a `.kosli_ignore` file to the root of the artifact.
 Each line should specify a relative path or path glob to be ignored. You can include comments in this file, using `#`.
-The `.kosli_ignore` will be treated as part of the artifact like any other file, unless it is explicitly ignored itself.
+The `.kosli_ignore` file is always treated as part of the artifact: its own entries cannot exclude it, so a directory cannot hide files that have been added to it. Excluding the file with `--exclude` keeps it out of the fingerprint but still applies the paths it lists, which lets a writable directory hide files again; to drop the file from the fingerprint safely, move its entries to `--exclude` and delete it.
 
 ## Flags
 | Flag | Type | Description |

--- a/cmd/kosli/testdata/output/docs/mintlify/artifact.md
+++ b/cmd/kosli/testdata/output/docs/mintlify/artifact.md
@@ -45,7 +45,7 @@ is set), registry credentials are resolved as follows:
 
 To specify paths in a directory artifact that should always be excluded from the SHA256 calculation, you can add a `.kosli_ignore` file to the root of the artifact.
 Each line should specify a relative path or path glob to be ignored. You can include comments in this file, using `#`.
-The `.kosli_ignore` file is always treated as part of the artifact: its own entries cannot exclude it, so a directory cannot hide files that have been added to it. Excluding the file with `--exclude` keeps it out of the fingerprint but still applies the paths it lists, which lets a writable directory hide files again; to drop the file from the fingerprint safely, move its entries to `--exclude` and delete it.
+The `.kosli_ignore` file is always treated as part of the artifact: its own entries cannot exclude it, so the exclusion list cannot be changed without changing the fingerprint. Paths the list already matches stay excluded whatever is later added there, so keep its entries as narrow as possible. Excluding the file with `--exclude` keeps it out of the fingerprint but still applies the paths it lists, which lets a writable directory change the list again; to drop the file from the fingerprint safely, move its entries to `--exclude` and delete it.
 
 ## Flags
 | Flag | Type | Description |

--- a/cmd/kosli/testdata/output/docs/mintlify/artifact.md
+++ b/cmd/kosli/testdata/output/docs/mintlify/artifact.md
@@ -45,7 +45,10 @@ is set), registry credentials are resolved as follows:
 
 To specify paths in a directory artifact that should always be excluded from the SHA256 calculation, you can add a `.kosli_ignore` file to the root of the artifact.
 Each line should specify a relative path or path glob to be ignored. You can include comments in this file, using `#`.
-The `.kosli_ignore` file is always treated as part of the artifact: its own entries cannot exclude it, so the exclusion list cannot be changed without changing the fingerprint. Paths the list already matches stay excluded whatever is later added there, so keep its entries as narrow as possible. Excluding the file with `--exclude` keeps it out of the fingerprint but still applies the paths it lists, which lets a writable directory change the list again; to drop the file from the fingerprint safely, move its entries to `--exclude` and delete it.
+The `.kosli_ignore` file is always treated as part of the artifact: its own entries cannot exclude it, so the exclusion list cannot be changed without changing the fingerprint.
+Paths the list already matches stay excluded whatever is later added there, so keep its entries as narrow as possible.
+Excluding the file with `--exclude` keeps it out of the fingerprint but still applies the paths it lists, which lets a writable directory change the list again.
+To drop the file from the fingerprint safely, move its entries to `--exclude` and delete it.
 
 ## Flags
 | Flag | Type | Description |

--- a/cmd/kosli/testdata/output/docs/mintlify/snyk.md
+++ b/cmd/kosli/testdata/output/docs/mintlify/snyk.md
@@ -26,7 +26,7 @@ The attestation can be bound to an *artifact* in two ways:
 
 To specify paths in a directory artifact that should always be excluded from the SHA256 calculation, you can add a `.kosli_ignore` file to the root of the artifact.
 Each line should specify a relative path or path glob to be ignored. You can include comments in this file, using `#`.
-The `.kosli_ignore` will be treated as part of the artifact like any other file, unless it is explicitly ignored itself.
+The `.kosli_ignore` file is always treated as part of the artifact: its own entries cannot exclude it, so a directory cannot hide files that have been added to it. Excluding the file with `--exclude` keeps it out of the fingerprint but still applies the paths it lists, which lets a writable directory hide files again; to drop the file from the fingerprint safely, move its entries to `--exclude` and delete it.
 
 You can optionally associate the attestation to a git commit using `--commit` (requires access to a git repo).
 You can optionally redact some of the git commit data sent to Kosli using `--redact-commit-info`.

--- a/cmd/kosli/testdata/output/docs/mintlify/snyk.md
+++ b/cmd/kosli/testdata/output/docs/mintlify/snyk.md
@@ -26,7 +26,7 @@ The attestation can be bound to an *artifact* in two ways:
 
 To specify paths in a directory artifact that should always be excluded from the SHA256 calculation, you can add a `.kosli_ignore` file to the root of the artifact.
 Each line should specify a relative path or path glob to be ignored. You can include comments in this file, using `#`.
-The `.kosli_ignore` file is always treated as part of the artifact: its own entries cannot exclude it, so a directory cannot hide files that have been added to it. Excluding the file with `--exclude` keeps it out of the fingerprint but still applies the paths it lists, which lets a writable directory hide files again; to drop the file from the fingerprint safely, move its entries to `--exclude` and delete it.
+The `.kosli_ignore` file is always treated as part of the artifact: its own entries cannot exclude it, so the exclusion list cannot be changed without changing the fingerprint. Paths the list already matches stay excluded whatever is later added there, so keep its entries as narrow as possible. Excluding the file with `--exclude` keeps it out of the fingerprint but still applies the paths it lists, which lets a writable directory change the list again; to drop the file from the fingerprint safely, move its entries to `--exclude` and delete it.
 
 You can optionally associate the attestation to a git commit using `--commit` (requires access to a git repo).
 You can optionally redact some of the git commit data sent to Kosli using `--redact-commit-info`.

--- a/cmd/kosli/testdata/output/docs/mintlify/snyk.md
+++ b/cmd/kosli/testdata/output/docs/mintlify/snyk.md
@@ -26,7 +26,10 @@ The attestation can be bound to an *artifact* in two ways:
 
 To specify paths in a directory artifact that should always be excluded from the SHA256 calculation, you can add a `.kosli_ignore` file to the root of the artifact.
 Each line should specify a relative path or path glob to be ignored. You can include comments in this file, using `#`.
-The `.kosli_ignore` file is always treated as part of the artifact: its own entries cannot exclude it, so the exclusion list cannot be changed without changing the fingerprint. Paths the list already matches stay excluded whatever is later added there, so keep its entries as narrow as possible. Excluding the file with `--exclude` keeps it out of the fingerprint but still applies the paths it lists, which lets a writable directory change the list again; to drop the file from the fingerprint safely, move its entries to `--exclude` and delete it.
+The `.kosli_ignore` file is always treated as part of the artifact: its own entries cannot exclude it, so the exclusion list cannot be changed without changing the fingerprint.
+Paths the list already matches stay excluded whatever is later added there, so keep its entries as narrow as possible.
+Excluding the file with `--exclude` keeps it out of the fingerprint but still applies the paths it lists, which lets a writable directory change the list again.
+To drop the file from the fingerprint safely, move its entries to `--exclude` and delete it.
 
 You can optionally associate the attestation to a git commit using `--commit` (requires access to a git repo).
 You can optionally redact some of the git commit data sent to Kosli using `--redact-commit-info`.

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -99,7 +99,7 @@ func DirSha256(dirPath string, excludePaths []string, logger *logger.Logger) (st
 		return "", err
 	}
 	if len(ignoredPaths) > 0 {
-		logger.Debug("  -> ignore file used %s -- excluding paths: %s", ignoreFilePath, ignoredPaths)
+		logger.Debug("  -> ignore file used %s -- excluding paths: %s", ignoreFileInTree, ignoredPaths)
 		// Warn only once the file is known to carry rules. An empty or comment-only
 		// one that a flag excludes weakens nothing, and the message's subject is the
 		// paths it lists.
@@ -270,6 +270,14 @@ func ignoreFilePathInTree(dirPath string) (string, error) {
 		if folded == "" && strings.EqualFold(entry.Name(), ignoreFileName) {
 			folded = filepath.Join(dirPath, entry.Name())
 		}
+	}
+	if folded == "" {
+		// The Lstat above resolved, so the file whose rules will be read exists. Not
+		// finding it in the listing means the two reads disagree, and answering "none"
+		// would leave nothing protected while its entries are still applied. Refuse
+		// instead: a rename between the two calls is winnable by an attacker with
+		// write access to the tree, which is the adversary this protects against.
+		return "", fmt.Errorf("%s exists in %s but was not found in its directory listing", ignoreFileName, dirPath)
 	}
 	return folded, nil
 }

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -32,6 +32,9 @@ var (
 		"has it been pushed to or pulled from a registry?")
 )
 
+// ignoreFileName is the exclusion list a directory artifact may carry at its root.
+const ignoreFileName = ".kosli_ignore"
+
 // DirSha256 returns sha256 digest of a directory
 func DirSha256(dirPath string, excludePaths []string, logger *logger.Logger) (string, error) {
 	logger.Debug("calculating fingerprint for path [%s] -- excluding paths: %s", dirPath, excludePaths)
@@ -66,7 +69,29 @@ func DirSha256(dirPath string, excludePaths []string, logger *logger.Logger) (st
 			logger.Warn("failed to close digests file: %v", err)
 		}
 	}()
-	ignoreFilePath := filepath.Join(dirPath, ".kosli_ignore")
+	// The ignore file must stay in the fingerprint whatever the tree asks for, or a
+	// directory could add files and keep the approved fingerprint by listing them
+	// (kosli-dev/server#6785). It is protected at the point the walk decides what to
+	// skip, using the path the walk itself emits, so no reasoning about how a
+	// pattern happens to be spelled or normalised can get between the two.
+	protectedPath := ignoreFilePathInTree(dirPath)
+
+	pathsToExclude, err := resolveExcludePaths(dirPath, excludePaths)
+	if err != nil {
+		return "", err
+	}
+
+	// An operator flag may still exclude it, which is the migration path off the
+	// old behaviour. That keeps the file out of the fingerprint while the entries it
+	// carries are still applied, so the tree decides what is measured again.
+	if protectedPath != "" && utils.Contains(pathsToExclude, protectedPath) {
+		logger.Warn("%s is excluded by a flag, so the paths it lists are still applied while the file itself is not fingerprinted. "+
+			"A file added to the directory and listed in %s stays invisible. "+
+			"Move the entries to --exclude and delete the file to get the same fingerprint without that.", protectedPath, ignoreFileName)
+		protectedPath = ""
+	}
+
+	ignoreFilePath := filepath.Join(dirPath, ignoreFileName)
 	ignoredPaths, err := excludePathsFromFile(ignoreFilePath)
 	if err != nil {
 		return "", err
@@ -74,8 +99,13 @@ func DirSha256(dirPath string, excludePaths []string, logger *logger.Logger) (st
 	if len(ignoredPaths) > 0 {
 		logger.Debug("  -> ignore file used %s -- excluding paths: %s", ignoreFilePath, ignoredPaths)
 	}
-	excludePaths = append(excludePaths, ignoredPaths...)
-	err = calculateDirContentSha256(digestsFile, dirPath, tmpDir, excludePaths, logger)
+	resolvedIgnoredPaths, err := resolveExcludePaths(dirPath, ignoredPaths)
+	if err != nil {
+		return "", err
+	}
+	pathsToExclude = append(pathsToExclude, resolvedIgnoredPaths...)
+
+	err = calculateDirContentSha256(digestsFile, dirPath, tmpDir, pathsToExclude, protectedPath, logger)
 	if err != nil {
 		return "", err
 	}
@@ -193,17 +223,56 @@ func Sha256Fingerprint(parsed godigest.Digest) (string, error) {
 	return parsed.Encoded(), nil
 }
 
-// calculateDirContentSha256 calculates a sha256 digest for a directory content
-func calculateDirContentSha256(digestsFile *os.File, dirPath, tmpDir string, excludePaths []string, logger *logger.Logger) error {
+// ignoreFilePathInTree returns the tree's ignore file as filepath.WalkDir will
+// emit it, or "" when the tree has no ignore file.
+//
+// The name comes from the directory listing rather than from ignoreFileName
+// because a case-insensitive filesystem (macOS, Windows) stores whatever name was
+// written, a ".KOSLI_IGNORE", while opening it under any case. The walk emits the
+// stored name, so this is the exact string the walk will compare, which is what
+// makes protecting the file independent of how an exclusion pattern is spelled.
+func ignoreFilePathInTree(dirPath string) string {
+	info, err := os.Lstat(filepath.Join(dirPath, ignoreFileName))
+	if err != nil {
+		return ""
+	}
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		return ""
+	}
+	// Folding the name covers every filesystem in practice. The identity pass is a
+	// fallback so that a folding rule Go does not implement cannot leave a file the
+	// filesystem does treat as the ignore file unprotected.
+	for _, entry := range entries {
+		if strings.EqualFold(entry.Name(), ignoreFileName) {
+			return filepath.Join(dirPath, entry.Name())
+		}
+	}
+	for _, entry := range entries {
+		path := filepath.Join(dirPath, entry.Name())
+		if other, err := os.Lstat(path); err == nil && os.SameFile(info, other) {
+			return path
+		}
+	}
+	return ""
+}
+
+// resolveExcludePaths expands exclusion patterns, relative to dirPath, into the
+// paths they actually match.
+func resolveExcludePaths(dirPath string, excludePaths []string) ([]string, error) {
 	pathsToExclude := []string{}
 	for _, p := range excludePaths {
 		found, err := filepathx.Glob(filepath.Join(dirPath, p))
 		if err != nil {
-			return err
+			return nil, err
 		}
 		pathsToExclude = append(pathsToExclude, found...)
 	}
+	return pathsToExclude, nil
+}
 
+// calculateDirContentSha256 calculates a sha256 digest for a directory content
+func calculateDirContentSha256(digestsFile *os.File, dirPath, tmpDir string, pathsToExclude []string, protectedPath string, logger *logger.Logger) error {
 	return filepath.WalkDir(dirPath, func(path string, info fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -215,7 +284,7 @@ func calculateDirContentSha256(digestsFile *os.File, dirPath, tmpDir string, exc
 			return nil
 		}
 
-		if utils.Contains(pathsToExclude, path) {
+		if path != protectedPath && utils.Contains(pathsToExclude, path) {
 			if info.IsDir() {
 				logger.Debug("skipping dir %s (and its contents) as it matches excluded paths", path)
 				return fs.SkipDir

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -98,6 +98,15 @@ func DirSha256(dirPath string, excludePaths []string, logger *logger.Logger) (st
 	if err != nil {
 		return "", err
 	}
+	// Locating the file and reading its rules are two reads of the same path, so
+	// they can disagree: a rename between them leaves nothing protected while the
+	// rules are still applied, which is a self-excluding entry working again. That
+	// race is winnable by an attacker with write access to the tree, the adversary
+	// this protects against, so refuse rather than fingerprint unprotected.
+	if ignoreFileInTree == "" && len(ignoredPaths) > 0 {
+		return "", fmt.Errorf("%s was not in the listing of %s but its rules were read, "+
+			"so refusing to fingerprint with the exclusion list unprotected", ignoreFileName, dirPath)
+	}
 	if len(ignoredPaths) > 0 {
 		logger.Debug("  -> ignore file used %s -- excluding paths: %s", ignoreFileInTree, ignoredPaths)
 		// Warn only once the file is known to carry rules. An empty or comment-only
@@ -264,20 +273,18 @@ func ignoreFilePathInTree(dirPath string) (string, error) {
 	}
 	folded := ""
 	for _, entry := range entries {
+		// Only a file can carry rules, and protectedPath means "the file whose rules
+		// are read". A directory of this name yields no rules, so leaving it
+		// unprotected keeps it excludable like any other directory.
+		if entry.IsDir() {
+			continue
+		}
 		if entry.Name() == ignoreFileName {
 			return filepath.Join(dirPath, entry.Name()), nil
 		}
 		if folded == "" && strings.EqualFold(entry.Name(), ignoreFileName) {
 			folded = filepath.Join(dirPath, entry.Name())
 		}
-	}
-	if folded == "" {
-		// The Lstat above resolved, so the file whose rules will be read exists. Not
-		// finding it in the listing means the two reads disagree, and answering "none"
-		// would leave nothing protected while its entries are still applied. Refuse
-		// instead: a rename between the two calls is winnable by an attacker with
-		// write access to the tree, which is the adversary this protects against.
-		return "", fmt.Errorf("%s exists in %s but was not found in its directory listing", ignoreFileName, dirPath)
 	}
 	return folded, nil
 }

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -291,13 +291,16 @@ func calculateDirContentSha256(digestsFile *os.File, dirPath, tmpDir string, pat
 			return nil
 		}
 
-		if path != protectedPath && utils.Contains(pathsToExclude, path) {
-			if info.IsDir() {
+		if utils.Contains(pathsToExclude, path) {
+			if path == protectedPath {
+				logger.Debug("keeping %s although an exclusion matches it: an exclusion list cannot exclude itself", path)
+			} else if info.IsDir() {
 				logger.Debug("skipping dir %s (and its contents) as it matches excluded paths", path)
 				return fs.SkipDir
+			} else {
+				logger.Debug("skipping %s as it matches excluded paths", path)
+				return nil
 			}
-			logger.Debug("skipping %s as it matches excluded paths", path)
-			return nil
 		}
 
 		// If it's a symlink, resolve the target

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -74,7 +74,10 @@ func DirSha256(dirPath string, excludePaths []string, logger *logger.Logger) (st
 	// (kosli-dev/server#6785). It is protected at the point the walk decides what to
 	// skip, using the path the walk itself emits, so no reasoning about how a
 	// pattern happens to be spelled or normalised can get between the two.
-	ignoreFileInTree := ignoreFilePathInTree(dirPath)
+	ignoreFileInTree, err := ignoreFilePathInTree(dirPath)
+	if err != nil {
+		return "", err
+	}
 	protectedPath := ignoreFileInTree
 
 	pathsToExclude, err := resolveExcludePaths(dirPath, excludePaths)
@@ -244,24 +247,31 @@ func Sha256Fingerprint(parsed godigest.Digest) (string, error) {
 // hold both spellings as two distinct files, and protecting the one that folds
 // first would leave the file whose entries are actually applied free to exclude
 // itself. Other spellings are ordinary files there, excludable like any other.
-func ignoreFilePathInTree(dirPath string) string {
+func ignoreFilePathInTree(dirPath string) (string, error) {
+	// Errors are returned rather than swallowed as "no ignore file". The rules are
+	// read separately by excludePathsFromFile, so answering "" on a failed read
+	// would let the two disagree: nothing protected while the file's entries are
+	// still applied, which is a self-excluding entry working again.
 	if _, err := os.Lstat(filepath.Join(dirPath, ignoreFileName)); err != nil {
-		return ""
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", nil
+		}
+		return "", err
 	}
 	entries, err := os.ReadDir(dirPath)
 	if err != nil {
-		return ""
+		return "", err
 	}
 	folded := ""
 	for _, entry := range entries {
 		if entry.Name() == ignoreFileName {
-			return filepath.Join(dirPath, entry.Name())
+			return filepath.Join(dirPath, entry.Name()), nil
 		}
 		if folded == "" && strings.EqualFold(entry.Name(), ignoreFileName) {
 			folded = filepath.Join(dirPath, entry.Name())
 		}
 	}
-	return folded
+	return folded, nil
 }
 
 // resolveExcludePaths expands exclusion patterns, relative to dirPath, into the
@@ -293,7 +303,8 @@ func calculateDirContentSha256(digestsFile *os.File, dirPath, tmpDir string, pat
 
 		if utils.Contains(pathsToExclude, path) {
 			if path == protectedPath {
-				logger.Debug("keeping %s although an exclusion matches it: an exclusion list cannot exclude itself", path)
+				logger.Debug("keeping %s although an exclusion matches it: an exclusion list cannot exclude itself. "+
+					"Move its entries to --exclude and delete the file to recover the previous fingerprint.", path)
 			} else if info.IsDir() {
 				logger.Debug("skipping dir %s (and its contents) as it matches excluded paths", path)
 				return fs.SkipDir

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -253,7 +253,7 @@ func ignoreFilePathInTree(dirPath string) (string, error) {
 	folded := ""
 	for _, entry := range entries {
 		// A directory of this name carries no rules; a symlink to one is matched by
-		// dirent type as a link, so it is not caught here and yields an empty list.
+		// dirent type as a link, so it is not caught here and fails the read instead.
 		if entry.IsDir() {
 			continue
 		}
@@ -535,6 +535,11 @@ func excludePathsFromFile(path string) ([]string, error) {
 			if len(line) > 0 {
 				excludes = append(excludes, line)
 			}
+		}
+		// A stopped scan yields the entries read so far, so an unchecked error means
+		// fingerprinting against a rule set the file does not hold.
+		if err := scanner.Err(); err != nil {
+			return nil, fmt.Errorf("failed to read %s: %w", path, err)
 		}
 		return excludes, nil
 	} else if errors.Is(err, fs.ErrNotExist) {

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -74,7 +74,8 @@ func DirSha256(dirPath string, excludePaths []string, logger *logger.Logger) (st
 	// (kosli-dev/server#6785). It is protected at the point the walk decides what to
 	// skip, using the path the walk itself emits, so no reasoning about how a
 	// pattern happens to be spelled or normalised can get between the two.
-	protectedPath := ignoreFilePathInTree(dirPath)
+	ignoreFileInTree := ignoreFilePathInTree(dirPath)
+	protectedPath := ignoreFileInTree
 
 	pathsToExclude, err := resolveExcludePaths(dirPath, excludePaths)
 	if err != nil {
@@ -84,10 +85,8 @@ func DirSha256(dirPath string, excludePaths []string, logger *logger.Logger) (st
 	// An operator flag may still exclude it, which is the migration path off the
 	// old behaviour. That keeps the file out of the fingerprint while the entries it
 	// carries are still applied, so the tree decides what is measured again.
-	if protectedPath != "" && utils.Contains(pathsToExclude, protectedPath) {
-		logger.Warn("%s is excluded by a flag, so the paths it lists are still applied while the file itself is not fingerprinted. "+
-			"A file added to the directory and listed in %s stays invisible. "+
-			"Move the entries to --exclude and delete the file to get the same fingerprint without that.", protectedPath, ignoreFileName)
+	flagExcludesIgnoreFile := ignoreFileInTree != "" && utils.Contains(pathsToExclude, ignoreFileInTree)
+	if flagExcludesIgnoreFile {
 		protectedPath = ""
 	}
 
@@ -98,6 +97,14 @@ func DirSha256(dirPath string, excludePaths []string, logger *logger.Logger) (st
 	}
 	if len(ignoredPaths) > 0 {
 		logger.Debug("  -> ignore file used %s -- excluding paths: %s", ignoreFilePath, ignoredPaths)
+		// Warn only once the file is known to carry rules. An empty or comment-only
+		// one that a flag excludes weakens nothing, and the message's subject is the
+		// paths it lists.
+		if flagExcludesIgnoreFile {
+			logger.Warn("%s is excluded by a flag, so the paths it lists are still applied while the file itself is not fingerprinted. "+
+				"A file added to the directory and listed in %s stays invisible. "+
+				"Move the entries to --exclude and delete the file to get the same fingerprint without that.", ignoreFileInTree, ignoreFileName)
+		}
 	}
 	resolvedIgnoredPaths, err := resolveExcludePaths(dirPath, ignoredPaths)
 	if err != nil {

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -255,16 +255,25 @@ func Sha256Fingerprint(parsed godigest.Digest) (string, error) {
 // stored name, so this is the exact string the walk will compare, which is what
 // makes protecting the file independent of how an exclusion pattern is spelled.
 //
-// An exact match wins over a folded one because excludePathsFromFile reads the
-// rules from ignoreFileName byte-exact. On a case-sensitive filesystem a tree can
-// hold both spellings as two distinct files, and protecting the one that folds
-// first would leave the file whose entries are actually applied free to exclude
-// itself. Other spellings are ordinary files there, excludable like any other.
+// An exact match wins over a folded one to keep the meaning of the ignore file
+// stable, not for safety: since the caller reads the rules from whatever this
+// returns, either answer would protect the file it read. On a case-sensitive
+// filesystem a tree can hold both spellings as two distinct files, and every
+// release before this one read the rules from ignoreFileName byte-exact, so
+// returning the one that folds first would hand rule authority to a previously
+// inert ".KOSLI_IGNORE" and change the fingerprint with it. Other spellings are
+// ordinary files there, excludable like any other.
+//
+// Skipping directories interacts with that: where ignoreFileName is a directory
+// and another spelling is a file, the file is returned and its rules apply, where
+// before they were not read at all. Contrived, and the alternative is to protect a
+// path that can carry no rules.
 func ignoreFilePathInTree(dirPath string) (string, error) {
-	// Errors are returned rather than swallowed as "no ignore file". The rules are
-	// read separately by excludePathsFromFile, so answering "" on a failed read
-	// would let the two disagree: nothing protected while the file's entries are
-	// still applied, which is a self-excluding entry working again.
+	// Errors are returned rather than swallowed as "no ignore file", because "" is
+	// also the answer for a tree that has none, and the caller reads the rules from
+	// whatever this returns. A failed read must not be indistinguishable from an
+	// absent file: that would fingerprint a tree whose exclusion list was never
+	// established.
 	if _, err := os.Lstat(filepath.Join(dirPath, ignoreFileName)); err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return "", nil

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -82,11 +82,13 @@ func DirSha256(dirPath string, excludePaths []string, logger *logger.Logger) (st
 		return "", err
 	}
 
-	// A flag exclusion drops the file from the digest while its entries still apply,
-	// so the tree decides what is measured.
-	flagExcludesIgnoreFile := ignoreFileInTree != "" && utils.Contains(pathsToExclude, ignoreFileInTree)
-	if flagExcludesIgnoreFile {
+	// A flag exclusion drops the list's content from the digest, so the tree may
+	// supply any content on a later run whatever it holds now.
+	if ignoreFileInTree != "" && utils.Contains(pathsToExclude, ignoreFileInTree) {
 		protectedPath = ""
+		logger.Warn("%s is excluded by a flag, so its rules are applied while its content is not fingerprinted: "+
+			"the directory can change the list at any time, and files it comes to list stay invisible. "+
+			"Move the entries to --exclude and delete the file to get the same fingerprint without that.", ignoreFileInTree)
 	}
 
 	// Reading the located path makes the file protected, the file read and the file
@@ -101,12 +103,6 @@ func DirSha256(dirPath string, excludePaths []string, logger *logger.Logger) (st
 	}
 	if len(ignoredPaths) > 0 {
 		logger.Debug("  -> ignore file used %s -- excluding paths: %s", ignoreFileInTree, ignoredPaths)
-		// An empty or comment-only file that a flag excludes weakens nothing.
-		if flagExcludesIgnoreFile {
-			logger.Warn("%s is excluded by a flag, so the paths it lists are still applied while the file itself is not fingerprinted. "+
-				"A file added to the directory and listed in %s stays invisible. "+
-				"Move the entries to --exclude and delete the file to get the same fingerprint without that.", ignoreFileInTree, ignoreFileName)
-		}
 	}
 	resolvedIgnoredPaths, err := resolveExcludePaths(dirPath, ignoredPaths)
 	if err != nil {

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -252,7 +252,8 @@ func ignoreFilePathInTree(dirPath string) (string, error) {
 	}
 	folded := ""
 	for _, entry := range entries {
-		// A directory of this name carries no rules.
+		// A directory of this name carries no rules; a symlink to one is matched by
+		// dirent type as a link, so it is not caught here and yields an empty list.
 		if entry.IsDir() {
 			continue
 		}

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -69,11 +69,8 @@ func DirSha256(dirPath string, excludePaths []string, logger *logger.Logger) (st
 			logger.Warn("failed to close digests file: %v", err)
 		}
 	}()
-	// The ignore file must stay in the fingerprint whatever the tree asks for, or a
-	// directory could add files and keep the approved fingerprint by listing them
-	// (kosli-dev/server#6785). It is protected at the point the walk decides what to
-	// skip, using the path the walk itself emits, so no reasoning about how a
-	// pattern happens to be spelled or normalised can get between the two.
+	// An exclusion list cannot exclude itself, or a tree could add files and keep the
+	// approved fingerprint by listing them.
 	ignoreFileInTree, err := ignoreFilePathInTree(dirPath)
 	if err != nil {
 		return "", err
@@ -85,25 +82,16 @@ func DirSha256(dirPath string, excludePaths []string, logger *logger.Logger) (st
 		return "", err
 	}
 
-	// An operator flag may still exclude it, which is the migration path off the
-	// old behaviour. That keeps the file out of the fingerprint while the entries it
-	// carries are still applied, so the tree decides what is measured again.
+	// A flag exclusion drops the file from the digest while its entries still apply,
+	// so the tree decides what is measured.
 	flagExcludesIgnoreFile := ignoreFileInTree != "" && utils.Contains(pathsToExclude, ignoreFileInTree)
 	if flagExcludesIgnoreFile {
 		protectedPath = ""
 	}
 
-	// The rules are read from the path that was located, not from one rebuilt out
-	// of ignoreFileName. Rebuilding it made "the file protected" and "the file whose
-	// rules are applied" two independently resolved names, and a rename between the
-	// two reads could make them disagree: rules applied with the wrong file, or no
-	// file, protected. Reading the located path makes them the same string, and the
-	// walk emits that same string by the same construction.
-	//
-	// One race is left and is not closable here: the rules are read before the file
-	// is hashed, so a tree that rewrites it in between has its old rules applied to
-	// newly hashed content. Closing that means hashing the bytes that were read,
-	// which is a larger change than this.
+	// Reading the located path makes the file protected, the file read and the file
+	// hashed one string. The rules are read before the file is hashed, so a tree that
+	// rewrites it in between has these rules applied to different content.
 	ignoredPaths := []string{}
 	if ignoreFileInTree != "" {
 		ignoredPaths, err = excludePathsFromFile(ignoreFileInTree)
@@ -113,9 +101,7 @@ func DirSha256(dirPath string, excludePaths []string, logger *logger.Logger) (st
 	}
 	if len(ignoredPaths) > 0 {
 		logger.Debug("  -> ignore file used %s -- excluding paths: %s", ignoreFileInTree, ignoredPaths)
-		// Warn only once the file is known to carry rules. An empty or comment-only
-		// one that a flag excludes weakens nothing, and the message's subject is the
-		// paths it lists.
+		// An empty or comment-only file that a flag excludes weakens nothing.
 		if flagExcludesIgnoreFile {
 			logger.Warn("%s is excluded by a flag, so the paths it lists are still applied while the file itself is not fingerprinted. "+
 				"A file added to the directory and listed in %s stays invisible. "+
@@ -246,34 +232,18 @@ func Sha256Fingerprint(parsed godigest.Digest) (string, error) {
 	return parsed.Encoded(), nil
 }
 
-// ignoreFilePathInTree returns the tree's ignore file as filepath.WalkDir will
-// emit it, or "" when the tree has no ignore file.
+// ignoreFilePathInTree returns the tree's ignore file as filepath.WalkDir emits
+// it, or "" when there is none.
 //
-// The name comes from the directory listing rather than from ignoreFileName
-// because a case-insensitive filesystem (macOS, Windows) stores whatever name was
-// written, a ".KOSLI_IGNORE", while opening it under any case. The walk emits the
-// stored name, so this is the exact string the walk will compare, which is what
-// makes protecting the file independent of how an exclusion pattern is spelled.
+// The name comes from the directory listing because a case-insensitive filesystem
+// stores one spelling and opens any of them. Snapshotting S3 or Azure unzips the
+// tree onto the machine running the CLI, so that filesystem is the operator's.
 //
-// An exact match wins over a folded one to keep the meaning of the ignore file
-// stable, not for safety: since the caller reads the rules from whatever this
-// returns, either answer would protect the file it read. On a case-sensitive
-// filesystem a tree can hold both spellings as two distinct files, and every
-// release before this one read the rules from ignoreFileName byte-exact, so
-// returning the one that folds first would hand rule authority to a previously
-// inert ".KOSLI_IGNORE" and change the fingerprint with it. Other spellings are
-// ordinary files there, excludable like any other.
-//
-// Skipping directories interacts with that: where ignoreFileName is a directory
-// and another spelling is a file, the file is returned and its rules apply, where
-// before they were not read at all. Contrived, and the alternative is to protect a
-// path that can carry no rules.
+// An exact match wins over a folded one so that ignoreFileName owns the rules
+// where a case-sensitive filesystem holds both spellings as distinct files.
 func ignoreFilePathInTree(dirPath string) (string, error) {
-	// Errors are returned rather than swallowed as "no ignore file", because "" is
-	// also the answer for a tree that has none, and the caller reads the rules from
-	// whatever this returns. A failed read must not be indistinguishable from an
-	// absent file: that would fingerprint a tree whose exclusion list was never
-	// established.
+	// "" is also the answer for a tree with no ignore file, so a swallowed error
+	// would silently mean "no exclusions".
 	if _, err := os.Lstat(filepath.Join(dirPath, ignoreFileName)); err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return "", nil
@@ -286,9 +256,7 @@ func ignoreFilePathInTree(dirPath string) (string, error) {
 	}
 	folded := ""
 	for _, entry := range entries {
-		// Only a file can carry rules, and protectedPath means "the file whose rules
-		// are read". A directory of this name yields no rules, so leaving it
-		// unprotected keeps it excludable like any other directory.
+		// A directory of this name carries no rules.
 		if entry.IsDir() {
 			continue
 		}

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -231,30 +231,30 @@ func Sha256Fingerprint(parsed godigest.Digest) (string, error) {
 // written, a ".KOSLI_IGNORE", while opening it under any case. The walk emits the
 // stored name, so this is the exact string the walk will compare, which is what
 // makes protecting the file independent of how an exclusion pattern is spelled.
+//
+// An exact match wins over a folded one because excludePathsFromFile reads the
+// rules from ignoreFileName byte-exact. On a case-sensitive filesystem a tree can
+// hold both spellings as two distinct files, and protecting the one that folds
+// first would leave the file whose entries are actually applied free to exclude
+// itself. Other spellings are ordinary files there, excludable like any other.
 func ignoreFilePathInTree(dirPath string) string {
-	info, err := os.Lstat(filepath.Join(dirPath, ignoreFileName))
-	if err != nil {
+	if _, err := os.Lstat(filepath.Join(dirPath, ignoreFileName)); err != nil {
 		return ""
 	}
 	entries, err := os.ReadDir(dirPath)
 	if err != nil {
 		return ""
 	}
-	// Folding the name covers every filesystem in practice. The identity pass is a
-	// fallback so that a folding rule Go does not implement cannot leave a file the
-	// filesystem does treat as the ignore file unprotected.
+	folded := ""
 	for _, entry := range entries {
-		if strings.EqualFold(entry.Name(), ignoreFileName) {
+		if entry.Name() == ignoreFileName {
 			return filepath.Join(dirPath, entry.Name())
 		}
-	}
-	for _, entry := range entries {
-		path := filepath.Join(dirPath, entry.Name())
-		if other, err := os.Lstat(path); err == nil && os.SameFile(info, other) {
-			return path
+		if folded == "" && strings.EqualFold(entry.Name(), ignoreFileName) {
+			folded = filepath.Join(dirPath, entry.Name())
 		}
 	}
-	return ""
+	return folded
 }
 
 // resolveExcludePaths expands exclusion patterns, relative to dirPath, into the

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -252,16 +252,24 @@ func ignoreFilePathInTree(dirPath string) (string, error) {
 	}
 	folded := ""
 	for _, entry := range entries {
-		// A directory of this name carries no rules; a symlink to one is matched by
-		// dirent type as a link, so it is not caught here and fails the read instead.
+		if !strings.EqualFold(entry.Name(), ignoreFileName) {
+			continue
+		}
+		// Only a file can carry rules. The dirent type is not enough on its own: it
+		// reports a symlink to a directory as a link, and following that would fail
+		// the read where a plain directory of this name is skipped.
+		path := filepath.Join(dirPath, entry.Name())
 		if entry.IsDir() {
 			continue
 		}
-		if entry.Name() == ignoreFileName {
-			return filepath.Join(dirPath, entry.Name()), nil
+		if resolved, err := os.Stat(path); err == nil && resolved.IsDir() {
+			continue
 		}
-		if folded == "" && strings.EqualFold(entry.Name(), ignoreFileName) {
-			folded = filepath.Join(dirPath, entry.Name())
+		if entry.Name() == ignoreFileName {
+			return path, nil
+		}
+		if folded == "" {
+			folded = path
 		}
 	}
 	return folded, nil

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -93,19 +93,23 @@ func DirSha256(dirPath string, excludePaths []string, logger *logger.Logger) (st
 		protectedPath = ""
 	}
 
-	ignoreFilePath := filepath.Join(dirPath, ignoreFileName)
-	ignoredPaths, err := excludePathsFromFile(ignoreFilePath)
-	if err != nil {
-		return "", err
-	}
-	// Locating the file and reading its rules are two reads of the same path, so
-	// they can disagree: a rename between them leaves nothing protected while the
-	// rules are still applied, which is a self-excluding entry working again. That
-	// race is winnable by an attacker with write access to the tree, the adversary
-	// this protects against, so refuse rather than fingerprint unprotected.
-	if ignoreFileInTree == "" && len(ignoredPaths) > 0 {
-		return "", fmt.Errorf("%s was not in the listing of %s but its rules were read, "+
-			"so refusing to fingerprint with the exclusion list unprotected", ignoreFileName, dirPath)
+	// The rules are read from the path that was located, not from one rebuilt out
+	// of ignoreFileName. Rebuilding it made "the file protected" and "the file whose
+	// rules are applied" two independently resolved names, and a rename between the
+	// two reads could make them disagree: rules applied with the wrong file, or no
+	// file, protected. Reading the located path makes them the same string, and the
+	// walk emits that same string by the same construction.
+	//
+	// One race is left and is not closable here: the rules are read before the file
+	// is hashed, so a tree that rewrites it in between has its old rules applied to
+	// newly hashed content. Closing that means hashing the bytes that were read,
+	// which is a larger change than this.
+	ignoredPaths := []string{}
+	if ignoreFileInTree != "" {
+		ignoredPaths, err = excludePathsFromFile(ignoreFileInTree)
+		if err != nil {
+			return "", err
+		}
 	}
 	if len(ignoredPaths) > 0 {
 		logger.Debug("  -> ignore file used %s -- excluding paths: %s", ignoreFileInTree, ignoredPaths)

--- a/internal/digest/digest_test.go
+++ b/internal/digest/digest_test.go
@@ -527,6 +527,235 @@ func (suite *DigestTestSuite) TestDirSha256() {
 	}
 }
 
+// TestDirSha256IgnoreFileCannotHideItself covers #6785: .kosli_ignore is read from
+// the tree being measured, so if its entries could exclude it, a writable tree
+// could add files and keep the fingerprint of the approved one. These are
+// differential rather than golden tests - what matters is that the trees differ.
+func (suite *DigestTestSuite) TestDirSha256IgnoreFileCannotHideItself() {
+	baseline := map[string]string{
+		"app/index.js":    "console.log(1)",
+		"app/lib/util.js": "exports.x = 1",
+	}
+	for i, t := range []struct {
+		name         string
+		ignore       string
+		excludePaths []string
+		wantEqual    bool
+	}{
+		{
+			name:   "a self-excluding ignore file cannot hide an added file",
+			ignore: ".kosli_ignore\napp/backdoor.js",
+		},
+		{
+			name:   "a glob matching the ignore file cannot hide it",
+			ignore: "*ignore*\napp/backdoor.js",
+		},
+		{
+			name:   "a dotted glob matching the ignore file cannot hide it",
+			ignore: ".kosli*\napp/backdoor.js",
+		},
+		{
+			// filepathx concatenates the pieces of a ** pattern, so this resolves to
+			// "dir//.kosli_ignore" rather than the path the walk emits.
+			name:   "a ** glob matching the ignore file cannot hide it",
+			ignore: "**/.kosli_ignore\napp/backdoor.js",
+		},
+		{
+			name:   "a bare ** cannot hide the ignore file",
+			ignore: "**\napp/backdoor.js",
+		},
+		{
+			// Excluding the ignore file by flag restores the pre-fix fingerprint and,
+			// with it, the pre-fix bypass: the entries still come from the tree, so an
+			// added file listed there is still hidden. Pinned because it is the
+			// migration path, not because it is safe.
+			name:         "--exclude of the ignore file keeps applying the entries it lists",
+			ignore:       "app/backdoor.js",
+			excludePaths: []string{".kosli_ignore"},
+			wantEqual:    true,
+		},
+	} {
+		suite.Run(t.name, func() {
+			approved := suite.createDirWithFiles(fmt.Sprintf("approved%d", i), baseline)
+			deployed := suite.createDirWithFiles(fmt.Sprintf("deployed%d", i), baseline)
+			suite.createFileWithContent(filepath.Join(deployed, "app/backdoor.js"), "BACKDOOR")
+			suite.createFileWithContent(filepath.Join(deployed, ".kosli_ignore"), t.ignore)
+
+			approvedSha, err := DirSha256(approved, t.excludePaths, logger.NewStandardLogger())
+			require.NoError(suite.T(), err)
+			deployedSha, err := DirSha256(deployed, t.excludePaths, logger.NewStandardLogger())
+			require.NoError(suite.T(), err)
+
+			if t.wantEqual {
+				assert.Equal(suite.T(), approvedSha, deployedSha)
+			} else {
+				assert.NotEqual(suite.T(), approvedSha, deployedSha,
+					"the added file is invisible to the fingerprint")
+			}
+		})
+	}
+}
+
+// TestIgnoreFilePathInTree pins that the protected path is the name the tree
+// actually stores, since that is the string filepath.WalkDir will emit and
+// therefore the one the walk's exclusion check compares.
+func (suite *DigestTestSuite) TestIgnoreFilePathInTree() {
+	for i, t := range []struct {
+		name       string
+		ignoreName string
+	}{
+		{name: "the usual lower-case name", ignoreName: ".kosli_ignore"},
+		{name: "an upper-case name on a case-insensitive filesystem", ignoreName: ".KOSLI_IGNORE"},
+		{name: "a mixed-case name on a case-insensitive filesystem", ignoreName: ".Kosli_Ignore"},
+	} {
+		suite.Run(t.name, func() {
+			// The directory name must not embed ignoreName: on a case-insensitive
+			// filesystem the three cases would be one directory, and each subtest
+			// would find the previous one's ignore file.
+			dir := suite.createDirWithFiles(fmt.Sprintf("tree%d", i), map[string]string{"app.js": "app"})
+			suite.createFileWithContent(filepath.Join(dir, t.ignoreName), "logs")
+
+			if _, err := os.Stat(filepath.Join(dir, ".kosli_ignore")); err != nil {
+				suite.T().Skipf("filesystem is case-sensitive, so %s is not the ignore file", t.ignoreName)
+			}
+
+			assert.Equal(suite.T(), filepath.Join(dir, t.ignoreName), ignoreFilePathInTree(dir))
+		})
+	}
+}
+
+// TestIgnoreFilePathInTreeWithoutIgnoreFile pins that a tree with no ignore file
+// protects nothing, rather than a path that does not exist.
+func (suite *DigestTestSuite) TestIgnoreFilePathInTreeWithoutIgnoreFile() {
+	dir := suite.createDirWithFiles("no-ignore", map[string]string{"app.js": "app"})
+	assert.Equal(suite.T(), "", ignoreFilePathInTree(dir))
+}
+
+// TestDirSha256IgnoreFileAliasesStayExcludable pins the scope of the refusal: only
+// the path the walk produces for the ignore file is protected. A hard link or
+// symlink to it is a distinct walk entry, so excluding that entry is legitimate and
+// still allowed - it removes the alias from the digest and leaves the ignore file
+// in it, which is why refusing it would buy nothing.
+func (suite *DigestTestSuite) TestDirSha256IgnoreFileAliasesStayExcludable() {
+	baseline := map[string]string{"app/index.js": "console.log(1)"}
+	for i, t := range []struct {
+		name string
+		link func(ignorePath, aliasPath string) error
+	}{
+		{name: "a hard link of the ignore file can be excluded", link: os.Link},
+		{
+			name: "a symlink to the ignore file can be excluded",
+			link: func(ignorePath, aliasPath string) error { return os.Symlink(ignorePath, aliasPath) },
+		},
+	} {
+		suite.Run(t.name, func() {
+			withAlias := suite.createDirWithFiles(fmt.Sprintf("with-alias%d", i), baseline)
+			suite.createFileWithContent(filepath.Join(withAlias, ".kosli_ignore"), "alias")
+			require.NoError(suite.T(), t.link(
+				filepath.Join(withAlias, ".kosli_ignore"),
+				filepath.Join(withAlias, "alias"),
+			))
+
+			noAlias := suite.createDirWithFiles(fmt.Sprintf("no-alias%d", i), baseline)
+			suite.createFileWithContent(filepath.Join(noAlias, ".kosli_ignore"), "alias")
+
+			withAliasSha, err := DirSha256(withAlias, nil, logger.NewStandardLogger())
+			require.NoError(suite.T(), err)
+			noAliasSha, err := DirSha256(noAlias, nil, logger.NewStandardLogger())
+			require.NoError(suite.T(), err)
+
+			assert.Equal(suite.T(), noAliasSha, withAliasSha,
+				"the alias is excluded, leaving the same digest as a tree without it")
+		})
+	}
+}
+
+// TestDirSha256NestedIgnoreFileIsExcludable pins that the refusal is scoped to the
+// root ignore file. Only that one is read as an exclusion list, so a .kosli_ignore
+// belonging to a vendored subproject is an ordinary file the root list may exclude.
+func (suite *DigestTestSuite) TestDirSha256NestedIgnoreFileIsExcludable() {
+	baseline := map[string]string{
+		"app.js":          "app",
+		"vendor/lib/v.js": "v",
+		".kosli_ignore":   "vendor/**/.kosli_ignore",
+	}
+	withNested := suite.createDirWithFiles("with-nested", baseline)
+	suite.createFileWithContent(filepath.Join(withNested, "vendor/lib/.kosli_ignore"), "nested-rules")
+	withoutNested := suite.createDirWithFiles("without-nested", baseline)
+
+	withNestedSha, err := DirSha256(withNested, nil, logger.NewStandardLogger())
+	require.NoError(suite.T(), err)
+	withoutNestedSha, err := DirSha256(withoutNested, nil, logger.NewStandardLogger())
+	require.NoError(suite.T(), err)
+
+	assert.Equal(suite.T(), withoutNestedSha, withNestedSha,
+		"a nested .kosli_ignore is an ordinary file and the root list may exclude it")
+}
+
+// TestDirSha256IgnoreFileCannotHideItselfCaseInsensitiveFS covers the same #6785
+// primitive on a case-insensitive filesystem (macOS, Windows), where the ignore
+// file can be named in one case and refer to itself in another. Snapshotting S3
+// and Azure unzips the deployed tree into a temp dir on the machine running the
+// CLI, so the filesystem that matters is the operator's, not the deployment's.
+func (suite *DigestTestSuite) TestDirSha256IgnoreFileCannotHideItselfCaseInsensitiveFS() {
+	for i, t := range []struct {
+		name       string
+		ignoreName string
+		ignore     string
+	}{
+		{
+			name:       "an upper-case ignore file naming itself cannot hide an added file",
+			ignoreName: ".KOSLI_IGNORE",
+			ignore:     ".KOSLI_IGNORE\napp/backdoor.js",
+		},
+		{
+			name:       "a mixed-case ignore file naming itself cannot hide an added file",
+			ignoreName: ".Kosli_Ignore",
+			ignore:     ".Kosli_Ignore\napp/backdoor.js",
+		},
+		{
+			name:       "an upper-case glob cannot hide an upper-case ignore file",
+			ignoreName: ".KOSLI_IGNORE",
+			ignore:     ".KOSLI*\napp/backdoor.js",
+		},
+	} {
+		suite.Run(t.name, func() {
+			baseline := map[string]string{
+				"app/index.js":    "console.log(1)",
+				"app/lib/util.js": "exports.x = 1",
+			}
+			approved := suite.createDirWithFiles(fmt.Sprintf("approved%d", i), baseline)
+			deployed := suite.createDirWithFiles(fmt.Sprintf("deployed%d", i), baseline)
+			suite.createFileWithContent(filepath.Join(deployed, "app/backdoor.js"), "BACKDOOR")
+			suite.createFileWithContent(filepath.Join(deployed, t.ignoreName), t.ignore)
+
+			if _, err := os.Stat(filepath.Join(deployed, ".kosli_ignore")); err != nil {
+				suite.T().Skipf("filesystem is case-sensitive, so %s is not read as an ignore file", t.ignoreName)
+			}
+
+			approvedSha, err := DirSha256(approved, nil, logger.NewStandardLogger())
+			require.NoError(suite.T(), err)
+			deployedSha, err := DirSha256(deployed, nil, logger.NewStandardLogger())
+			require.NoError(suite.T(), err)
+
+			assert.NotEqual(suite.T(), approvedSha, deployedSha,
+				"the added file is invisible to the fingerprint")
+		})
+	}
+}
+
+// createDirWithFiles creates a directory under the suite's tmpDir from a map of
+// relative path to content, and returns its absolute path.
+func (suite *DigestTestSuite) createDirWithFiles(name string, files map[string]string) string {
+	dirPath := filepath.Join(suite.tmpDir, name)
+	err := os.MkdirAll(dirPath, 0777)
+	require.NoErrorf(suite.T(), err, "error creating test dir %s", dirPath)
+	for path, content := range files {
+		suite.createFileWithContent(filepath.Join(dirPath, path), content)
+	}
+	return dirPath
+}
+
 func (suite *DigestTestSuite) createNestedDir(path string, files []fileEntry, dirs []dirEntry) {
 	for _, f := range files {
 		filePath := filepath.Join(path, f.name)

--- a/internal/digest/digest_test.go
+++ b/internal/digest/digest_test.go
@@ -530,10 +530,7 @@ func (suite *DigestTestSuite) TestDirSha256() {
 	}
 }
 
-// TestDirSha256IgnoreFileCannotHideItself covers #6785: .kosli_ignore is read from
-// the tree being measured, so if its entries could exclude it, a writable tree
-// could add files and keep the fingerprint of the approved one. These are
-// differential rather than golden tests - what matters is that the trees differ.
+// Differential rather than golden: what matters is that the two trees differ.
 func (suite *DigestTestSuite) TestDirSha256IgnoreFileCannotHideItself() {
 	baseline := map[string]string{
 		"app/index.js":    "console.log(1)",
@@ -559,25 +556,20 @@ func (suite *DigestTestSuite) TestDirSha256IgnoreFileCannotHideItself() {
 		},
 		{
 			// filepathx concatenates the pieces of a ** pattern, so this resolves to
-			// "dir//.kosli_ignore" rather than the path the walk emits.
+			// "dir//.kosli_ignore", which the walk never emits.
 			name:   "a ** glob matching the ignore file cannot hide it",
 			ignore: "**/.kosli_ignore\napp/backdoor.js",
 		},
 		{
-			// Bare ** resolves to every path in the tree, so the deployed digest
-			// differs from the baseline whether or not the ignore file is protected.
-			// This case documents that the protection is indifferent to pattern
-			// shape; it does not pin it. The two globs above do, and so does the
-			// literal case - strip the protection and those three land exactly on the
-			// approved digest.
+			// Bare ** excludes every path, so this differs from the baseline whether
+			// or not the ignore file is protected. It documents; the three cases above
+			// pin.
 			name:   "a bare ** cannot hide the ignore file",
 			ignore: "**\napp/backdoor.js",
 		},
 		{
-			// Excluding the ignore file by flag restores the pre-fix fingerprint and,
-			// with it, the pre-fix bypass: the entries still come from the tree, so an
-			// added file listed there is still hidden. Pinned because it is the
-			// migration path, not because it is safe.
+			// The entries still come from the tree, so a file listed there is hidden.
+			// Pinned as the migration path, not as a safety property.
 			name:         "--exclude of the ignore file keeps applying the entries it lists",
 			ignore:       "app/backdoor.js",
 			excludePaths: []string{".kosli_ignore"},
@@ -605,17 +597,11 @@ func (suite *DigestTestSuite) TestDirSha256IgnoreFileCannotHideItself() {
 	}
 }
 
-// TestIgnoreFilePathInTreeFailsClosedOnAnUnreadableDir pins that a failed
-// directory read is an error rather than "no ignore file". Answering "" would
-// leave nothing protected while excludePathsFromFile still applied the file's
-// entries, which is a self-excluding entry working again. DirSha256 as a whole is
-// already safe against a persistent failure, since WalkDir reads the same
-// directory and surfaces the error, so this is only reachable transiently - which
-// is why it is pinned here rather than through a fingerprint.
+// Pinned at the function because DirSha256 cannot reach it: WalkDir reads the same
+// directory and surfaces a persistent failure itself.
 func (suite *DigestTestSuite) TestIgnoreFilePathInTreeFailsClosedOnAnUnreadableDir() {
 	dir := suite.createDirWithFiles("unreadable", map[string]string{".kosli_ignore": ".kosli_ignore"})
-	// Write and search but not read: Lstat still resolves the ignore file while
-	// ReadDir fails.
+	// Write and search but not read: Lstat resolves while ReadDir fails.
 	require.NoError(suite.T(), os.Chmod(dir, 0300))
 	defer func() { _ = os.Chmod(dir, 0700) }()
 
@@ -628,10 +614,6 @@ func (suite *DigestTestSuite) TestIgnoreFilePathInTreeFailsClosedOnAnUnreadableD
 	assert.Equal(suite.T(), "", path)
 }
 
-// TestDirSha256LogsWhenTheIgnoreFileIsKept pins the only explanation available for
-// the common upgrade case. A tree whose .kosli_ignore excludes itself fingerprints
-// differently after this change, and the flag route warns while the tree route has
-// nothing but this debug line.
 func (suite *DigestTestSuite) TestDirSha256LogsWhenTheIgnoreFileIsKept() {
 	dir := suite.createDirWithFiles("kept", map[string]string{"app/index.js": "console.log(1)"})
 	suite.createFileWithContent(filepath.Join(dir, ".kosli_ignore"), ".kosli_ignore")
@@ -643,12 +625,8 @@ func (suite *DigestTestSuite) TestDirSha256LogsWhenTheIgnoreFileIsKept() {
 	assert.Contains(suite.T(), out.String(), "an exclusion list cannot exclude itself")
 }
 
-// TestDirSha256WarnsOnlyWhenAFlagExclusionWeakensTheFingerprint holds the warning
-// itself, not just its effect on the digest. It is the only thing that tells an
-// operator they are in the weakened mode, it has been wrong twice - firing where
-// the exclusion was a no-op, and on a spelling the walk never matches - and it is
-// correct now only because it asks utils.Contains the same question the walk asks.
-// The silent legs are the ones that pin that.
+// The silent legs carry this test: the warning must speak only when the exclusion
+// reaches the walk.
 func (suite *DigestTestSuite) TestDirSha256WarnsOnlyWhenAFlagExclusionWeakensTheFingerprint() {
 	const warning = "is excluded by a flag"
 	for i, t := range []struct {
@@ -674,13 +652,9 @@ func (suite *DigestTestSuite) TestDirSha256WarnsOnlyWhenAFlagExclusionWeakensThe
 			excludePaths: []string{".kosli_ignore"},
 		},
 		{
-			// The property is that the warning is silent because nothing is excluded,
-			// not because of how this particular pattern fails to resolve. filepathx
-			// concatenates the pieces of a ** pattern, so this becomes
-			// "dir//.kosli_ignore", which the walk's byte-exact comparison never
-			// matches, making the flag a silent no-op - a separate pre-existing wart.
-			// If that is ever fixed, this case starts excluding the file and belongs
-			// in the wantWarning: true group.
+			// Silent because nothing is excluded at all: filepathx resolves this to
+			// "dir//.kosli_ignore", which the walk never emits. Give ** patterns a
+			// path the walk emits and this case moves to wantWarning: true.
 			name:         "a ** spelling that never excludes anything stays silent",
 			ignore:       "logs",
 			excludePaths: []string{"**/.kosli_ignore"},
@@ -716,9 +690,6 @@ func (suite *DigestTestSuite) TestDirSha256WarnsOnlyWhenAFlagExclusionWeakensThe
 	}
 }
 
-// TestIgnoreFilePathInTree pins that the protected path is the name the tree
-// actually stores, since that is the string filepath.WalkDir will emit and
-// therefore the one the walk's exclusion check compares.
 func (suite *DigestTestSuite) TestIgnoreFilePathInTree() {
 	for i, t := range []struct {
 		name       string
@@ -730,8 +701,7 @@ func (suite *DigestTestSuite) TestIgnoreFilePathInTree() {
 	} {
 		suite.Run(t.name, func() {
 			// The directory name must not embed ignoreName: on a case-insensitive
-			// filesystem the three cases would be one directory, and each subtest
-			// would find the previous one's ignore file.
+			// filesystem the three cases would collapse into one directory.
 			dir := suite.createDirWithFiles(fmt.Sprintf("tree%d", i), map[string]string{"app.js": "app"})
 			suite.createFileWithContent(filepath.Join(dir, t.ignoreName), "logs")
 
@@ -746,13 +716,7 @@ func (suite *DigestTestSuite) TestIgnoreFilePathInTree() {
 	}
 }
 
-// TestIgnoreFilePathInTreeWithBothSpellings pins which file the tree's rules are
-// taken from. On a case-sensitive filesystem - which the CI runner is - a tree can
-// hold both spellings as two distinct files, and every release before this one read
-// the rules from ".kosli_ignore" byte-exact. Returning the spelling that folds
-// first would hand rule authority to a previously inert ".KOSLI_IGNORE" and change
-// the fingerprint with it. Since the located path is now also the path whose rules
-// are read, this is the only test that fails under a folded-first mutation.
+// The only test that fails under a folded-first mutation.
 func (suite *DigestTestSuite) TestIgnoreFilePathInTreeWithBothSpellings() {
 	dir := suite.createDirWithFiles("both", map[string]string{"app.js": "app"})
 	suite.createFileWithContent(filepath.Join(dir, ".KOSLI_IGNORE"), "")
@@ -764,15 +728,8 @@ func (suite *DigestTestSuite) TestIgnoreFilePathInTreeWithBothSpellings() {
 	assert.Equal(suite.T(), filepath.Join(dir, ".kosli_ignore"), got)
 }
 
-// TestDirSha256IgnoreFileCannotHideItselfBesideACaseVariant exercises the same tree
-// end to end: a decoy ".KOSLI_IGNORE" committed from a case-insensitive machine
-// must not shield the real ignore file from being fingerprinted.
-//
-// It documents rather than pins. Once the rules are read from the located path, a
-// folded-first mutation locates the empty decoy, so no rules are read and the
-// deployed tree differs from the baseline anyway - verified on a case-sensitive
-// APFS volume, where this passes under that mutation and only the unit test above
-// fails. It pinned the rule before that change.
+// Documents rather than pins: a folded-first mutation locates the empty decoy, so
+// no rules are read and the trees differ regardless.
 func (suite *DigestTestSuite) TestDirSha256IgnoreFileCannotHideItselfBesideACaseVariant() {
 	baseline := map[string]string{"app/index.js": "console.log(1)"}
 	approved := suite.createDirWithFiles("approved-decoy", baseline)
@@ -794,8 +751,6 @@ func (suite *DigestTestSuite) TestDirSha256IgnoreFileCannotHideItselfBesideACase
 		"the added file is invisible to the fingerprint")
 }
 
-// requireCaseSensitiveDir skips the test unless dir holds ".KOSLI_IGNORE" and
-// ".kosli_ignore" as two distinct files.
 func (suite *DigestTestSuite) requireCaseSensitiveDir(dir string) {
 	entries, err := os.ReadDir(dir)
 	require.NoError(suite.T(), err)
@@ -810,9 +765,6 @@ func (suite *DigestTestSuite) requireCaseSensitiveDir(dir string) {
 	}
 }
 
-// TestIgnoreFilePathInTreeIgnoresADirectory pins that protectedPath means "the
-// file whose rules are read". A directory of that name carries no rules, so
-// protecting it would only stop it being excluded like any other directory.
 func (suite *DigestTestSuite) TestIgnoreFilePathInTreeIgnoresADirectory() {
 	dir := suite.createDirWithFiles("dir-named-ignore", map[string]string{"app.js": "app"})
 	require.NoError(suite.T(), os.Mkdir(filepath.Join(dir, ".kosli_ignore"), 0777))
@@ -822,7 +774,6 @@ func (suite *DigestTestSuite) TestIgnoreFilePathInTreeIgnoresADirectory() {
 	require.NoError(suite.T(), err)
 	assert.Equal(suite.T(), "", path)
 
-	// And it stays excludable: the digest matches a tree without it.
 	withDir, err := DirSha256(dir, []string{".kosli_ignore"}, logger.NewStandardLogger())
 	require.NoError(suite.T(), err)
 	withoutDir, err := DirSha256(
@@ -832,8 +783,6 @@ func (suite *DigestTestSuite) TestIgnoreFilePathInTreeIgnoresADirectory() {
 	assert.Equal(suite.T(), withoutDir, withDir)
 }
 
-// TestIgnoreFilePathInTreeWithoutIgnoreFile pins that a tree with no ignore file
-// protects nothing, rather than a path that does not exist.
 func (suite *DigestTestSuite) TestIgnoreFilePathInTreeWithoutIgnoreFile() {
 	dir := suite.createDirWithFiles("no-ignore", map[string]string{"app.js": "app"})
 	got, err := ignoreFilePathInTree(dir)
@@ -841,11 +790,8 @@ func (suite *DigestTestSuite) TestIgnoreFilePathInTreeWithoutIgnoreFile() {
 	assert.Equal(suite.T(), "", got)
 }
 
-// TestDirSha256IgnoreFileAliasesStayExcludable pins the scope of the refusal: only
-// the path the walk produces for the ignore file is protected. A hard link or
-// symlink to it is a distinct walk entry, so excluding that entry is legitimate and
-// still allowed - it removes the alias from the digest and leaves the ignore file
-// in it, which is why refusing it would buy nothing.
+// An alias is a distinct walk entry, so excluding it leaves the ignore file in the
+// digest.
 func (suite *DigestTestSuite) TestDirSha256IgnoreFileAliasesStayExcludable() {
 	baseline := map[string]string{"app/index.js": "console.log(1)"}
 	for i, t := range []struct {
@@ -880,9 +826,7 @@ func (suite *DigestTestSuite) TestDirSha256IgnoreFileAliasesStayExcludable() {
 	}
 }
 
-// TestDirSha256NestedIgnoreFileIsExcludable pins that the refusal is scoped to the
-// root ignore file. Only that one is read as an exclusion list, so a .kosli_ignore
-// belonging to a vendored subproject is an ordinary file the root list may exclude.
+// Only the root ignore file is read as an exclusion list.
 func (suite *DigestTestSuite) TestDirSha256NestedIgnoreFileIsExcludable() {
 	baseline := map[string]string{
 		"app.js":          "app",
@@ -902,11 +846,8 @@ func (suite *DigestTestSuite) TestDirSha256NestedIgnoreFileIsExcludable() {
 		"a nested .kosli_ignore is an ordinary file and the root list may exclude it")
 }
 
-// TestDirSha256IgnoreFileCannotHideItselfCaseInsensitiveFS covers the same #6785
-// primitive on a case-insensitive filesystem (macOS, Windows), where the ignore
-// file can be named in one case and refer to itself in another. Snapshotting S3
-// and Azure unzips the deployed tree into a temp dir on the machine running the
-// CLI, so the filesystem that matters is the operator's, not the deployment's.
+// A case-insensitive filesystem lets the ignore file be named in one case and refer
+// to itself in another.
 func (suite *DigestTestSuite) TestDirSha256IgnoreFileCannotHideItselfCaseInsensitiveFS() {
 	for i, t := range []struct {
 		name       string
@@ -954,8 +895,6 @@ func (suite *DigestTestSuite) TestDirSha256IgnoreFileCannotHideItselfCaseInsensi
 	}
 }
 
-// createDirWithFiles creates a directory under the suite's tmpDir from a map of
-// relative path to content, and returns its absolute path.
 func (suite *DigestTestSuite) createDirWithFiles(name string, files map[string]string) string {
 	dirPath := filepath.Join(suite.tmpDir, name)
 	err := os.MkdirAll(dirPath, 0777)

--- a/internal/digest/digest_test.go
+++ b/internal/digest/digest_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kosli-dev/cli/internal/docker"
@@ -621,6 +622,60 @@ func (suite *DigestTestSuite) TestIgnoreFilePathInTree() {
 
 			assert.Equal(suite.T(), filepath.Join(dir, t.ignoreName), ignoreFilePathInTree(dir))
 		})
+	}
+}
+
+// TestIgnoreFilePathInTreeWithBothSpellings pins that the file whose rules are
+// read is the file protected. excludePathsFromFile opens ignoreFileName
+// byte-exact, so on a case-sensitive filesystem - which the CI runner is - a tree
+// holding both spellings must protect the exact one. Protecting the spelling that
+// folds first would leave the rules file free to exclude itself again.
+func (suite *DigestTestSuite) TestIgnoreFilePathInTreeWithBothSpellings() {
+	dir := suite.createDirWithFiles("both", map[string]string{"app.js": "app"})
+	suite.createFileWithContent(filepath.Join(dir, ".KOSLI_IGNORE"), "")
+	suite.createFileWithContent(filepath.Join(dir, ".kosli_ignore"), "logs")
+	suite.requireCaseSensitiveDir(dir)
+
+	assert.Equal(suite.T(), filepath.Join(dir, ".kosli_ignore"), ignoreFilePathInTree(dir))
+}
+
+// TestDirSha256IgnoreFileCannotHideItselfBesideACaseVariant is the fingerprint-level
+// form of the same thing. A decoy ".KOSLI_IGNORE" committed from a case-insensitive
+// machine must not shield the real ignore file from being fingerprinted.
+func (suite *DigestTestSuite) TestDirSha256IgnoreFileCannotHideItselfBesideACaseVariant() {
+	baseline := map[string]string{"app/index.js": "console.log(1)"}
+	approved := suite.createDirWithFiles("approved-decoy", baseline)
+	suite.createFileWithContent(filepath.Join(approved, ".KOSLI_IGNORE"), "")
+	suite.createFileWithContent(filepath.Join(approved, ".kosli_ignore"), ".kosli_ignore")
+	suite.requireCaseSensitiveDir(approved)
+
+	deployed := suite.createDirWithFiles("deployed-decoy", baseline)
+	suite.createFileWithContent(filepath.Join(deployed, ".KOSLI_IGNORE"), "")
+	suite.createFileWithContent(filepath.Join(deployed, ".kosli_ignore"), ".kosli_ignore\napp/backdoor.js")
+	suite.createFileWithContent(filepath.Join(deployed, "app/backdoor.js"), "BACKDOOR")
+
+	approvedSha, err := DirSha256(approved, nil, logger.NewStandardLogger())
+	require.NoError(suite.T(), err)
+	deployedSha, err := DirSha256(deployed, nil, logger.NewStandardLogger())
+	require.NoError(suite.T(), err)
+
+	assert.NotEqual(suite.T(), approvedSha, deployedSha,
+		"the added file is invisible to the fingerprint")
+}
+
+// requireCaseSensitiveDir skips the test unless dir holds ".KOSLI_IGNORE" and
+// ".kosli_ignore" as two distinct files.
+func (suite *DigestTestSuite) requireCaseSensitiveDir(dir string) {
+	entries, err := os.ReadDir(dir)
+	require.NoError(suite.T(), err)
+	found := 0
+	for _, entry := range entries {
+		if strings.EqualFold(entry.Name(), ".kosli_ignore") {
+			found++
+		}
+	}
+	if found < 2 {
+		suite.T().Skip("filesystem is case-insensitive, so the two spellings are one file")
 	}
 }
 

--- a/internal/digest/digest_test.go
+++ b/internal/digest/digest_test.go
@@ -1,7 +1,9 @@
 package digest
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -592,6 +594,74 @@ func (suite *DigestTestSuite) TestDirSha256IgnoreFileCannotHideItself() {
 			} else {
 				assert.NotEqual(suite.T(), approvedSha, deployedSha,
 					"the added file is invisible to the fingerprint")
+			}
+		})
+	}
+}
+
+// TestDirSha256WarnsOnlyWhenAFlagExclusionWeakensTheFingerprint holds the warning
+// itself, not just its effect on the digest. It is the only thing that tells an
+// operator they are in the weakened mode, it has been wrong twice - firing where
+// the exclusion was a no-op, and on a spelling the walk never matches - and it is
+// correct now only because it asks utils.Contains the same question the walk asks.
+// The silent legs are the ones that pin that.
+func (suite *DigestTestSuite) TestDirSha256WarnsOnlyWhenAFlagExclusionWeakensTheFingerprint() {
+	const warning = "is excluded by a flag"
+	for i, t := range []struct {
+		name         string
+		ignore       string
+		excludePaths []string
+		wantWarning  bool
+	}{
+		{
+			name:         "excluding an ignore file that carries rules",
+			ignore:       "logs",
+			excludePaths: []string{".kosli_ignore"},
+			wantWarning:  true,
+		},
+		{
+			name:         "excluding an empty ignore file weakens nothing",
+			ignore:       "",
+			excludePaths: []string{".kosli_ignore"},
+		},
+		{
+			name:         "excluding a comment-only ignore file weakens nothing",
+			ignore:       "# nothing to see here",
+			excludePaths: []string{".kosli_ignore"},
+		},
+		{
+			// filepathx resolves this to "dir//.kosli_ignore", which the walk's
+			// byte-exact comparison never matches, so nothing is excluded.
+			name:         "a ** spelling that never excludes anything stays silent",
+			ignore:       "logs",
+			excludePaths: []string{"**/.kosli_ignore"},
+			wantWarning:  false,
+		},
+		{
+			name:   "no flag exclusion at all",
+			ignore: "logs",
+		},
+		{
+			name:         "excluding an unrelated path",
+			ignore:       "logs",
+			excludePaths: []string{"app"},
+		},
+	} {
+		suite.Run(t.name, func() {
+			dir := suite.createDirWithFiles(fmt.Sprintf("warn%d", i), map[string]string{
+				"app/index.js": "console.log(1)",
+				"logs/a.log":   "noise",
+			})
+			suite.createFileWithContent(filepath.Join(dir, ".kosli_ignore"), t.ignore)
+
+			var warnings bytes.Buffer
+			_, err := DirSha256(dir, t.excludePaths, logger.NewLogger(io.Discard, &warnings, false))
+			require.NoError(suite.T(), err)
+
+			if t.wantWarning {
+				assert.Contains(suite.T(), warnings.String(), warning)
+			} else {
+				assert.NotContains(suite.T(), warnings.String(), warning)
 			}
 		})
 	}

--- a/internal/digest/digest_test.go
+++ b/internal/digest/digest_test.go
@@ -1,6 +1,7 @@
 package digest
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -1260,6 +1261,17 @@ func (suite *DigestTestSuite) TestExtractImageDigestFromRepoDigest() {
 			}
 		})
 	}
+}
+
+// A stopped scan must not pass off the entries read so far as the file's rules.
+func (suite *DigestTestSuite) TestExcludePathsFromFileErrorsOnAStoppedScan() {
+	dir := suite.createDirWithFiles("stopped-scan", map[string]string{})
+	path := filepath.Join(dir, ".kosli_ignore")
+	suite.createFileWithContent(path, "#"+strings.Repeat("z", bufio.MaxScanTokenSize)+"\nlogs\n")
+
+	paths, err := excludePathsFromFile(path)
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), paths)
 }
 
 func (suite *DigestTestSuite) TestGetExcludePathsFromIgnoreFile() {

--- a/internal/digest/digest_test.go
+++ b/internal/digest/digest_test.go
@@ -786,6 +786,21 @@ func (suite *DigestTestSuite) TestIgnoreFilePathInTreeIgnoresADirectory() {
 	assert.Equal(suite.T(), withoutDir, withDir)
 }
 
+// Without the resolved-directory guard this reaches excludePathsFromFile and
+// aborts the fingerprint with EISDIR.
+func (suite *DigestTestSuite) TestIgnoreFilePathInTreeIgnoresASymlinkToADirectory() {
+	dir := suite.createDirWithFiles("symlink-named-ignore", map[string]string{"app.js": "app"})
+	require.NoError(suite.T(), os.Mkdir(filepath.Join(dir, "realdir"), 0777))
+	require.NoError(suite.T(), os.Symlink(filepath.Join(dir, "realdir"), filepath.Join(dir, ".kosli_ignore")))
+
+	path, err := ignoreFilePathInTree(dir)
+	require.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "", path)
+
+	_, err = DirSha256(dir, nil, logger.NewStandardLogger())
+	require.NoError(suite.T(), err)
+}
+
 func (suite *DigestTestSuite) TestIgnoreFilePathInTreeWithoutIgnoreFile() {
 	dir := suite.createDirWithFiles("no-ignore", map[string]string{"app.js": "app"})
 	got, err := ignoreFilePathInTree(dir)

--- a/internal/digest/digest_test.go
+++ b/internal/digest/digest_test.go
@@ -630,8 +630,13 @@ func (suite *DigestTestSuite) TestDirSha256WarnsOnlyWhenAFlagExclusionWeakensThe
 			excludePaths: []string{".kosli_ignore"},
 		},
 		{
-			// filepathx resolves this to "dir//.kosli_ignore", which the walk's
-			// byte-exact comparison never matches, so nothing is excluded.
+			// The property is that the warning is silent because nothing is excluded,
+			// not because of how this particular pattern fails to resolve. filepathx
+			// concatenates the pieces of a ** pattern, so this becomes
+			// "dir//.kosli_ignore", which the walk's byte-exact comparison never
+			// matches, making the flag a silent no-op - a separate pre-existing wart.
+			// If that is ever fixed, this case starts excluding the file and belongs
+			// in the wantWarning: true group.
 			name:         "a ** spelling that never excludes anything stays silent",
 			ignore:       "logs",
 			excludePaths: []string{"**/.kosli_ignore"},

--- a/internal/digest/digest_test.go
+++ b/internal/digest/digest_test.go
@@ -564,6 +564,12 @@ func (suite *DigestTestSuite) TestDirSha256IgnoreFileCannotHideItself() {
 			ignore: "**/.kosli_ignore\napp/backdoor.js",
 		},
 		{
+			// Bare ** resolves to every path in the tree, so the deployed digest
+			// differs from the baseline whether or not the ignore file is protected.
+			// This case documents that the protection is indifferent to pattern
+			// shape; it does not pin it. The two globs above do, and so does the
+			// literal case - strip the protection and those three land exactly on the
+			// approved digest.
 			name:   "a bare ** cannot hide the ignore file",
 			ignore: "**\napp/backdoor.js",
 		},
@@ -597,6 +603,44 @@ func (suite *DigestTestSuite) TestDirSha256IgnoreFileCannotHideItself() {
 			}
 		})
 	}
+}
+
+// TestIgnoreFilePathInTreeFailsClosedOnAnUnreadableDir pins that a failed
+// directory read is an error rather than "no ignore file". Answering "" would
+// leave nothing protected while excludePathsFromFile still applied the file's
+// entries, which is a self-excluding entry working again. DirSha256 as a whole is
+// already safe against a persistent failure, since WalkDir reads the same
+// directory and surfaces the error, so this is only reachable transiently - which
+// is why it is pinned here rather than through a fingerprint.
+func (suite *DigestTestSuite) TestIgnoreFilePathInTreeFailsClosedOnAnUnreadableDir() {
+	dir := suite.createDirWithFiles("unreadable", map[string]string{".kosli_ignore": ".kosli_ignore"})
+	// Write and search but not read: Lstat still resolves the ignore file while
+	// ReadDir fails.
+	require.NoError(suite.T(), os.Chmod(dir, 0300))
+	defer func() { _ = os.Chmod(dir, 0700) }()
+
+	if _, err := os.ReadDir(dir); err == nil {
+		suite.T().Skip("directory is readable regardless of mode, probably running as root")
+	}
+
+	path, err := ignoreFilePathInTree(dir)
+	assert.Error(suite.T(), err)
+	assert.Equal(suite.T(), "", path)
+}
+
+// TestDirSha256LogsWhenTheIgnoreFileIsKept pins the only explanation available for
+// the common upgrade case. A tree whose .kosli_ignore excludes itself fingerprints
+// differently after this change, and the flag route warns while the tree route has
+// nothing but this debug line.
+func (suite *DigestTestSuite) TestDirSha256LogsWhenTheIgnoreFileIsKept() {
+	dir := suite.createDirWithFiles("kept", map[string]string{"app/index.js": "console.log(1)"})
+	suite.createFileWithContent(filepath.Join(dir, ".kosli_ignore"), ".kosli_ignore")
+
+	var out bytes.Buffer
+	_, err := DirSha256(dir, nil, logger.NewLogger(io.Discard, &out, true))
+	require.NoError(suite.T(), err)
+
+	assert.Contains(suite.T(), out.String(), "an exclusion list cannot exclude itself")
 }
 
 // TestDirSha256WarnsOnlyWhenAFlagExclusionWeakensTheFingerprint holds the warning
@@ -695,7 +739,9 @@ func (suite *DigestTestSuite) TestIgnoreFilePathInTree() {
 				suite.T().Skipf("filesystem is case-sensitive, so %s is not the ignore file", t.ignoreName)
 			}
 
-			assert.Equal(suite.T(), filepath.Join(dir, t.ignoreName), ignoreFilePathInTree(dir))
+			got, err := ignoreFilePathInTree(dir)
+			require.NoError(suite.T(), err)
+			assert.Equal(suite.T(), filepath.Join(dir, t.ignoreName), got)
 		})
 	}
 }
@@ -711,7 +757,9 @@ func (suite *DigestTestSuite) TestIgnoreFilePathInTreeWithBothSpellings() {
 	suite.createFileWithContent(filepath.Join(dir, ".kosli_ignore"), "logs")
 	suite.requireCaseSensitiveDir(dir)
 
-	assert.Equal(suite.T(), filepath.Join(dir, ".kosli_ignore"), ignoreFilePathInTree(dir))
+	got, err := ignoreFilePathInTree(dir)
+	require.NoError(suite.T(), err)
+	assert.Equal(suite.T(), filepath.Join(dir, ".kosli_ignore"), got)
 }
 
 // TestDirSha256IgnoreFileCannotHideItselfBesideACaseVariant is the fingerprint-level
@@ -758,7 +806,9 @@ func (suite *DigestTestSuite) requireCaseSensitiveDir(dir string) {
 // protects nothing, rather than a path that does not exist.
 func (suite *DigestTestSuite) TestIgnoreFilePathInTreeWithoutIgnoreFile() {
 	dir := suite.createDirWithFiles("no-ignore", map[string]string{"app.js": "app"})
-	assert.Equal(suite.T(), "", ignoreFilePathInTree(dir))
+	got, err := ignoreFilePathInTree(dir)
+	require.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "", got)
 }
 
 // TestDirSha256IgnoreFileAliasesStayExcludable pins the scope of the refusal: only

--- a/internal/digest/digest_test.go
+++ b/internal/digest/digest_test.go
@@ -746,11 +746,13 @@ func (suite *DigestTestSuite) TestIgnoreFilePathInTree() {
 	}
 }
 
-// TestIgnoreFilePathInTreeWithBothSpellings pins that the file whose rules are
-// read is the file protected. excludePathsFromFile opens ignoreFileName
-// byte-exact, so on a case-sensitive filesystem - which the CI runner is - a tree
-// holding both spellings must protect the exact one. Protecting the spelling that
-// folds first would leave the rules file free to exclude itself again.
+// TestIgnoreFilePathInTreeWithBothSpellings pins which file the tree's rules are
+// taken from. On a case-sensitive filesystem - which the CI runner is - a tree can
+// hold both spellings as two distinct files, and every release before this one read
+// the rules from ".kosli_ignore" byte-exact. Returning the spelling that folds
+// first would hand rule authority to a previously inert ".KOSLI_IGNORE" and change
+// the fingerprint with it. Since the located path is now also the path whose rules
+// are read, this is the only test that fails under a folded-first mutation.
 func (suite *DigestTestSuite) TestIgnoreFilePathInTreeWithBothSpellings() {
 	dir := suite.createDirWithFiles("both", map[string]string{"app.js": "app"})
 	suite.createFileWithContent(filepath.Join(dir, ".KOSLI_IGNORE"), "")
@@ -762,9 +764,15 @@ func (suite *DigestTestSuite) TestIgnoreFilePathInTreeWithBothSpellings() {
 	assert.Equal(suite.T(), filepath.Join(dir, ".kosli_ignore"), got)
 }
 
-// TestDirSha256IgnoreFileCannotHideItselfBesideACaseVariant is the fingerprint-level
-// form of the same thing. A decoy ".KOSLI_IGNORE" committed from a case-insensitive
-// machine must not shield the real ignore file from being fingerprinted.
+// TestDirSha256IgnoreFileCannotHideItselfBesideACaseVariant exercises the same tree
+// end to end: a decoy ".KOSLI_IGNORE" committed from a case-insensitive machine
+// must not shield the real ignore file from being fingerprinted.
+//
+// It documents rather than pins. Once the rules are read from the located path, a
+// folded-first mutation locates the empty decoy, so no rules are read and the
+// deployed tree differs from the baseline anyway - verified on a case-sensitive
+// APFS volume, where this passes under that mutation and only the unit test above
+// fails. It pinned the rule before that change.
 func (suite *DigestTestSuite) TestDirSha256IgnoreFileCannotHideItselfBesideACaseVariant() {
 	baseline := map[string]string{"app/index.js": "console.log(1)"}
 	approved := suite.createDirWithFiles("approved-decoy", baseline)

--- a/internal/digest/digest_test.go
+++ b/internal/digest/digest_test.go
@@ -642,14 +642,16 @@ func (suite *DigestTestSuite) TestDirSha256WarnsOnlyWhenAFlagExclusionWeakensThe
 			wantWarning:  true,
 		},
 		{
-			name:         "excluding an empty ignore file weakens nothing",
+			name:         "excluding an empty ignore file still weakens the fingerprint",
 			ignore:       "",
 			excludePaths: []string{".kosli_ignore"},
+			wantWarning:  true,
 		},
 		{
-			name:         "excluding a comment-only ignore file weakens nothing",
+			name:         "excluding a comment-only ignore file still weakens the fingerprint",
 			ignore:       "# nothing to see here",
 			excludePaths: []string{".kosli_ignore"},
+			wantWarning:  true,
 		},
 		{
 			// Silent because nothing is excluded at all: filepathx resolves this to

--- a/internal/digest/digest_test.go
+++ b/internal/digest/digest_test.go
@@ -802,6 +802,28 @@ func (suite *DigestTestSuite) requireCaseSensitiveDir(dir string) {
 	}
 }
 
+// TestIgnoreFilePathInTreeIgnoresADirectory pins that protectedPath means "the
+// file whose rules are read". A directory of that name carries no rules, so
+// protecting it would only stop it being excluded like any other directory.
+func (suite *DigestTestSuite) TestIgnoreFilePathInTreeIgnoresADirectory() {
+	dir := suite.createDirWithFiles("dir-named-ignore", map[string]string{"app.js": "app"})
+	require.NoError(suite.T(), os.Mkdir(filepath.Join(dir, ".kosli_ignore"), 0777))
+	suite.createFileWithContent(filepath.Join(dir, ".kosli_ignore", "inside.txt"), "secret")
+
+	path, err := ignoreFilePathInTree(dir)
+	require.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "", path)
+
+	// And it stays excludable: the digest matches a tree without it.
+	withDir, err := DirSha256(dir, []string{".kosli_ignore"}, logger.NewStandardLogger())
+	require.NoError(suite.T(), err)
+	withoutDir, err := DirSha256(
+		suite.createDirWithFiles("no-dir-named-ignore", map[string]string{"app.js": "app"}),
+		nil, logger.NewStandardLogger())
+	require.NoError(suite.T(), err)
+	assert.Equal(suite.T(), withoutDir, withDir)
+}
+
 // TestIgnoreFilePathInTreeWithoutIgnoreFile pins that a tree with no ignore file
 // protects nothing, rather than a path that does not exist.
 func (suite *DigestTestSuite) TestIgnoreFilePathInTreeWithoutIgnoreFile() {


### PR DESCRIPTION
Part of kosli-dev/server#6785. This reduces the vulnerability rather than closing it, so the ticket should stay open.

`DirSha256` read its `.kosli_ignore` exclusion list from inside the directory it was measuring, and that file could list itself, so the tree controlled its own measurement. It no longer can: the list is pinned to the approved build's.

## Why

Anyone with write access to a deployed directory artifact could add files to it and keep Kosli reporting the tree as byte-identical to the approved artifact, indefinitely. Where a required-provenance policy sits over a directory fingerprint, that is a silent compliance bypass. It reached every directory fingerprint; modify and delete were always caught.

## What changed

The walk is told which path to keep and never skips it, so the ignore file is always in the fingerprint. `filepath.WalkDir` emits its path exactly as the tree stores it, and that is the string the exclusion check compares, so no exclusion pattern is inspected at all. The stored name is read from the directory listing rather than built, since a case-insensitive filesystem stores one spelling and opens any — which reaches Linux targets too, because `snapshot s3` and `azure` unzip the tree locally.

None of the four `.kosli_ignore` files in kosli-dev repos self-excludes, so no observable tree changes fingerprint. Where one does, moving its entries to `--exclude` and deleting the file recovers the old value; excluding the file itself recovers it too but stays vulnerable, which `DirSha256` now warns about.

## What this does not close

The pinned list is one of *patterns*, resolved against the deployed tree, so a file added where the approved list already matches stays invisible. Verified against a kosli-dev demo's real ignore list (`logs/`, `*.log`, `*.html`): adding `logs/shell.php` or `payload.html` keeps the approved fingerprint exactly. Carrying the list in the attestation, the ticket's fuller fix, does not help — an approved list saying `logs` still excludes `logs`. Closing it needs a per-file manifest, which the artifact document does not store.

The unconstrained add is gone; what remains is the operator's declared blind spot. For a tree with no `.kosli_ignore`, the vulnerability is absent rather than reduced.

## Verification

`TestDirSha256IgnoreFileCannotHideItself` and `...CaseInsensitiveFS` pin the self-exclusion shapes against a clean baseline, which `digest_test.go` had no test for; five further tests pin the scope of the refusal and the operator-facing messages. Removing the protection fails 7 of them, and building the stored name rather than reading it fails 5.

Beyond the suite, 23 self-exclusion spellings were checked by hand, and the cases that skip on macOS were run on a case-sensitive APFS volume.

`test / Test` runs the full integration suite and has passed on this branch. Every pre-existing golden hash in `TestDirSha256` is unchanged, so a green run shows no fingerprint change for anyone unaffected.
