### PR TITLE
ci: upload Snyk Code SARIF to GitHub code scanning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,6 +90,11 @@ jobs:
       KOSLI_ORG: kosli-public
       checkout_ref: ${{ needs.pre-build.outputs.checkout_ref }}
       report_to_kosli: ${{ needs.pre-build.outputs.report_to_kosli }}
+      # Push events only. This workflow also runs on pull_request_target, where
+      # github.ref is the base branch while checkout_ref is the PR head, so an
+      # upload there would attribute PR findings to main. Tags never reach this
+      # workflow (see branches-ignore above); release.yml leaves this unset.
+      upload_sarif: ${{ github.event_name == 'push' }}
     secrets:
       github_access_token: ${{ secrets.KOSLI_GITHUB_TOKEN }}
       gitlab_access_token: ${{ secrets.KOSLI_GITLAB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,13 @@ on:
         required: false
         type: boolean
         default: true
+      upload_sarif:
+        # Upload the Snyk Code SARIF report to GitHub code scanning. Off by
+        # default: only a caller triggered by a push to a branch can attribute
+        # the results to the right ref, so the decision belongs at the call site.
+        required: false
+        type: boolean
+        default: false
       report_to_kosli:
         required: false
         type: string
@@ -221,12 +228,15 @@ jobs:
           snyk code test --sarif --policy-path=.snyk  --sarif-file-output=snyk-code.sarif --prune-repeated-subdependencies
 
     - name: Upload Snyk Code results to GitHub code scanning
-      # snyk exits non-zero when it finds issues, so upload on failure too.
-      # Branch pushes only: on pull_request_target (dependabot) github.ref is the
-      # base branch while the checkout is the PR head, so uploading there would
-      # attribute PR findings to main. Tag pushes (release.yml) are skipped - a
-      # release tag is not a useful code scanning baseline.
-      if: ${{ (success() || failure()) && github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/') }}
+      # snyk exits non-zero when it finds issues, so upload on failure too;
+      # hashFiles guards the case where snyk (or an earlier step) died before
+      # writing the report, so the real error stays the visible one.
+      # Soft-failure on purpose: the Kosli attestation below is the gate, while
+      # `docker` in main.yml and `goreleaser`/`binary-provenance` in release.yml
+      # all need this workflow - a SARIF size limit or a GitHub 5xx should not
+      # block a publish over ancillary reporting.
+      if: ${{ (success() || failure()) && inputs.upload_sarif && hashFiles('snyk-code.sarif') != '' }}
+      continue-on-error: true
       uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         sarif_file: snyk-code.sarif
@@ -274,7 +284,7 @@ jobs:
       env:
         SNYK_TOKEN: ${{ secrets.snyk_token }}
       run:
-          snyk test --sarif --policy-path=.snyk  --sarif-file-output=snyk-dependency.json --prune-repeated-subdependencies
+          snyk test --sarif --policy-path=.snyk  --sarif-file-output=snyk-dependency.sarif --prune-repeated-subdependencies
 
     - name: Report Snyk Test to Kosli
       if:  ${{ (success() || failure()) && inputs.report_to_kosli != 'none' }}
@@ -284,5 +294,5 @@ jobs:
            --name snyk-dependency-test
            --flow ${{ inputs.FLOW_NAME }}
            --trail ${{ inputs.TRAIL_NAME }}
-           --scan-results  snyk-dependency.json
+           --scan-results  snyk-dependency.sarif
            --org ${{ inputs.KOSLI_ORG }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,6 +193,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      security-events: write  # upload SARIF to GitHub code scanning
     steps:
 
     - name: Harden Runner
@@ -217,7 +218,19 @@ jobs:
       env:
         SNYK_TOKEN: ${{ secrets.snyk_token }}
       run:
-          snyk code test --sarif --policy-path=.snyk  --sarif-file-output=snyk-code.json --prune-repeated-subdependencies
+          snyk code test --sarif --policy-path=.snyk  --sarif-file-output=snyk-code.sarif --prune-repeated-subdependencies
+
+    - name: Upload Snyk Code results to GitHub code scanning
+      # snyk exits non-zero when it finds issues, so upload on failure too.
+      # Branch pushes only: on pull_request_target (dependabot) github.ref is the
+      # base branch while the checkout is the PR head, so uploading there would
+      # attribute PR findings to main. Tag pushes (release.yml) are skipped - a
+      # release tag is not a useful code scanning baseline.
+      if: ${{ (success() || failure()) && github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/') }}
+      uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+      with:
+        sarif_file: snyk-code.sarif
+        category: snyk-code
 
     - name: Report Snyk Code to Kosli
       if:  ${{ (success() || failure()) && inputs.report_to_kosli != 'none' }}
@@ -227,7 +240,7 @@ jobs:
            --name snyk-code-test
            --flow ${{ inputs.FLOW_NAME }}
            --trail ${{ inputs.TRAIL_NAME }}
-           --scan-results  snyk-code.json
+           --scan-results  snyk-code.sarif
            --org ${{ inputs.KOSLI_ORG }}
 
   snyk-dependency-test:


### PR DESCRIPTION
Snyk Code already produces a SARIF report, but it was only attested to Kosli — the findings never showed up under **Security → Code scanning**. This uploads the same report there too, so Snyk results get GitHub's alert triage, dismissal tracking and history alongside the Kosli attestation.

### Changes

- `security-events: write` on the `snyk-code-test` job. The repo's default `GITHUB_TOKEN` permission is `write`, so `main.yml` and `release.yml` already grant it — no call-site permission changes.
- SARIF output renamed `snyk-code.json` → `snyk-code.sarif` (and the sibling `snyk-dependency.json` → `.sarif`, so the two agree on extension for the same format). `upload-sarif` expects that extension; `kosli attest snyk` is unaffected — `internal/snyk/snyk.go:50` validates only the `$schema` field (Snyk's `oasis-tcs` URL is on its allowlist) and never looks at the filename. Nothing else in the repo referenced the old names.
- New `github/codeql-action/upload-sarif` step, SHA-pinned to v4.37.9, `category: snyk-code`, `continue-on-error: true`.
- New `upload_sarif` input on `test.yml`, default `false`.

### Who uploads, and why it is an input

```yaml
if: ${{ (success() || failure()) && inputs.upload_sarif && hashFiles('snyk-code.sarif') != '' }}
continue-on-error: true
```

- `success() || failure()` mirrors the existing Kosli attest step, since `snyk code test` exits non-zero when it finds issues.
- `hashFiles(...)` guards the case where snyk (or an earlier step) died *before* writing the report — otherwise `upload-sarif` aborts with `Path does not exist` and buries the real error.
- `inputs.upload_sarif` keeps `test.yml` agnostic about how its three callers are wired, matching how `run_snyk` / `report_to_kosli` / `checkout_ref` already work. `main.yml` passes `${{ github.event_name == 'push' }}`; `release.yml` and `daily-cli-tests.yml` leave it at the default.

The reason only push events upload: `main.yml` also runs on `pull_request_target` (the dependabot path), where `github.ref` is the *base* branch while `checkout_ref` is the PR head SHA — an upload there would file PR findings against `main`'s baseline. Keeping that decision at the call site puts it next to the `on:` block it depends on, and a future caller defaults to not uploading rather than uploading under a mis-attributed ref.

`continue-on-error` because `docker` needs `test` in `main.yml`, and `goreleaser` / `binary-provenance` chain off it in `release.yml`. The SARIF [10 MB / 25 000-result limits](https://docs.github.com/en/code-security/code-scanning/troubleshooting-sarif-uploads/results-exceed-limit) and API 5xx are outside this repo's control, and ancillary reporting should not block a publish — the Kosli attestation remains the gate. A failed upload still shows as failed-but-ignored in the run UI.

Net effect: `main` gets the baseline, feature branches get their own alerts, dependabot PRs still attest to Kosli but do not upload.

### Worth knowing

- The Security tab will show Snyk's view *minus* the `.snyk` `exclude: global` entries (`internal/azure/azure_apps.go`, `cmd/kosli/root.go`, and the two test fixtures), so a green tab is not the same as full coverage of the tree.
- No upload for `snyk-dependency-test` — Dependabot already covers dependency CVEs.
- This PR's own run will not upload: it arrives as `pull_request_target`, which `pre-build` skips for non-dependabot actors. The first upload, and the baseline, land on the merge push to `main`.

### Checklist

- [x] **Docs** are autogenerated from CLI help — n/a, CI-only change
- [x] **Helm chart** (`charts/k8s-reporter/`) updated, if needed — n/a
- [x] **Terraform provider** and related changes updated, if needed — n/a
