### PR TITLE
fix: improve testing robustness

### DIFF
--- a/cmd/kosli/snapshotPaths_test.go
+++ b/cmd/kosli/snapshotPaths_test.go
@@ -37,9 +37,10 @@ func (suite *SnapshotPathsTestSuite) TestSnapshotPathsCmd() {
 			goldenRegex: "Error: failed to parse path spec file \\[testdata\\/paths-files\\/does-not-exist\\.yml\\] : Config File \"does-not-exist\" Not Found in \"\\[.*\\/cli\\/cmd\\/kosli\\/testdata\\/paths-files\\]\"\n",
 		},
 		{
-			wantError:   true,
-			name:        "fails when paths spec file is invalid (fails to unmarshal)",
-			cmd:         fmt.Sprintf(`snapshot paths --paths-file testdata/paths-files/invalid-pathsfile.yml %s %s`, suite.envName, suite.defaultKosliArguments),
+			wantError: true,
+			name:      "fails when paths spec file is invalid (fails to unmarshal)",
+			cmd:       fmt.Sprintf(`snapshot paths --paths-file testdata/paths-files/invalid-pathsfile.yml %s %s`, suite.envName, suite.defaultKosliArguments),
+			// the quoted decode-path name is '' at the root today, but varies across viper/mapstructure versions — match it loosely and pin everything else
 			goldenRegex: `\AError: failed to unmarshal path spec file \[testdata/paths-files/invalid-pathsfile\.yml\] : decoding failed due to the following error\(s\):\n\n'[^']*' has invalid keys: foo, versionnn\n\z`,
 		},
 		{

--- a/cmd/kosli/snapshotPaths_test.go
+++ b/cmd/kosli/snapshotPaths_test.go
@@ -31,16 +31,19 @@ func (suite *SnapshotPathsTestSuite) SetupSuite() {
 func (suite *SnapshotPathsTestSuite) TestSnapshotPathsCmd() {
 	tests := []cmdTestCase{
 		{
-			wantError:   true,
-			name:        "fails when paths spec file does not exist",
-			cmd:         fmt.Sprintf(`snapshot paths --paths-file testdata/paths-files/does-not-exist.yml %s %s`, suite.envName, suite.defaultKosliArguments),
-			goldenRegex: "Error: failed to parse path spec file \\[testdata\\/paths-files\\/does-not-exist\\.yml\\] : Config File \"does-not-exist\" Not Found in \"\\[.*\\/cli\\/cmd\\/kosli\\/testdata\\/paths-files\\]\"\n",
+			wantError: true,
+			name:      "fails when paths spec file does not exist",
+			cmd:       fmt.Sprintf(`snapshot paths --paths-file testdata/paths-files/does-not-exist.yml %s %s`, suite.envName, suite.defaultKosliArguments),
+			// Anchored at both ends; the only loose part is the absolute path
+			// prefix of the search dir, which varies by checkout location.
+			goldenRegex: `\AError: failed to parse path spec file \[testdata/paths-files/does-not-exist\.yml\] : Config File "does-not-exist" Not Found in "\[[^"\]]*/cli/cmd/kosli/testdata/paths-files\]"\n\z`,
 		},
 		{
 			wantError: true,
 			name:      "fails when paths spec file is invalid (fails to unmarshal)",
 			cmd:       fmt.Sprintf(`snapshot paths --paths-file testdata/paths-files/invalid-pathsfile.yml %s %s`, suite.envName, suite.defaultKosliArguments),
-			// the quoted decode-path name is '' at the root today, but varies across viper/mapstructure versions — match it loosely and pin everything else
+			// the quoted decode-path name is '' at the root today, but varies
+			// across viper/mapstructure versions — match it loosely and pin everything else
 			goldenRegex: `\AError: failed to unmarshal path spec file \[testdata/paths-files/invalid-pathsfile\.yml\] : decoding failed due to the following error\(s\):\n\n'[^']*' has invalid keys: foo, versionnn\n\z`,
 		},
 		{

--- a/cmd/kosli/snapshotPaths_test.go
+++ b/cmd/kosli/snapshotPaths_test.go
@@ -37,10 +37,10 @@ func (suite *SnapshotPathsTestSuite) TestSnapshotPathsCmd() {
 			goldenRegex: "Error: failed to parse path spec file \\[testdata\\/paths-files\\/does-not-exist\\.yml\\] : Config File \"does-not-exist\" Not Found in \"\\[.*\\/cli\\/cmd\\/kosli\\/testdata\\/paths-files\\]\"\n",
 		},
 		{
-			wantError: true,
-			name:      "fails when paths spec file is invalid (fails to unmarshal)",
-			cmd:       fmt.Sprintf(`snapshot paths --paths-file testdata/paths-files/invalid-pathsfile.yml %s %s`, suite.envName, suite.defaultKosliArguments),
-			golden:    "Error: failed to unmarshal path spec file [testdata/paths-files/invalid-pathsfile.yml] : decoding failed due to the following error(s):\n\n'' has invalid keys: foo, versionnn\n",
+			wantError:   true,
+			name:        "fails when paths spec file is invalid (fails to unmarshal)",
+			cmd:         fmt.Sprintf(`snapshot paths --paths-file testdata/paths-files/invalid-pathsfile.yml %s %s`, suite.envName, suite.defaultKosliArguments),
+			goldenRegex: `\AError: failed to unmarshal path spec file \[testdata/paths-files/invalid-pathsfile\.yml\] : decoding failed due to the following error\(s\):\n\n'[^']*' has invalid keys: foo, versionnn\n\z`,
 		},
 		{
 			wantError: true,

--- a/cmd/kosli/snapshotPaths_test.go
+++ b/cmd/kosli/snapshotPaths_test.go
@@ -42,8 +42,8 @@ func (suite *SnapshotPathsTestSuite) TestSnapshotPathsCmd() {
 			wantError: true,
 			name:      "fails when paths spec file is invalid (fails to unmarshal)",
 			cmd:       fmt.Sprintf(`snapshot paths --paths-file testdata/paths-files/invalid-pathsfile.yml %s %s`, suite.envName, suite.defaultKosliArguments),
-			// the quoted decode-path name is '' at the root today, but varies
-			// across viper/mapstructure versions — match it loosely and pin everything else
+			// Quoted decode-path name is '' at the root today, but varies across
+			// viper/mapstructure versions — match it loosely and pin everything else
 			goldenRegex: `\AError: failed to unmarshal path spec file \[testdata/paths-files/invalid-pathsfile\.yml\] : decoding failed due to the following error\(s\):\n\n'[^']*' has invalid keys: foo, versionnn\n\z`,
 		},
 		{


### PR DESCRIPTION
<!-- What does this PR change and why? Link any related issue. -->
Prepare for upcoming Viber dependency bump (https://github.com/kosli-dev/cli/pull/1154) and improve testing robustness.

### Checklist

- [x] **Docs** are autogenerated from CLI help — make sure the help text reflects your changes
- [x] **Helm chart** (`charts/k8s-reporter/`) updated, if needed. Note: these changes live in a **separate PR**
- [x] **Terraform provider** and related changes ([terraform-provider-kosli](https://github.com/kosli-dev/terraform-provider-kosli), [terraform-aws-evidence-reporter](https://github.com/kosli-dev/terraform-aws-evidence-reporter), [terraform-aws-kosli-reporter](https://github.com/kosli-dev/terraform-aws-kosli-reporter)) updated, if needed
